### PR TITLE
docs: align tutorial step labels and clarify account refresh

### DIFF
--- a/docs/src/rust-client/create_deploy_tutorial.md
+++ b/docs/src/rust-client/create_deploy_tutorial.md
@@ -153,9 +153,9 @@ Add this snippet to the end of your file in the `main()` function:
 
 ```rust ignore
 //------------------------------------------------------------
-// STEP 1: Create a basic wallet for Alice
+// STEP 3: Create a basic wallet for Alice
 //------------------------------------------------------------
-println!("\n[STEP 1] Creating a new account for Alice");
+println!("\n[STEP 3] Creating a new account for Alice");
 
 // Account seed
 let mut init_seed = [0_u8; 32];
@@ -193,9 +193,9 @@ Add this snippet to the end of your file in the `main()` function:
 
 ```rust ignore
 //------------------------------------------------------------
-// STEP 2: Deploy a fungible faucet
+// STEP 4: Deploy a fungible faucet
 //------------------------------------------------------------
-println!("\n[STEP 2] Deploying a new fungible faucet.");
+println!("\n[STEP 4] Deploying a new fungible faucet.");
 
 // Faucet seed
 let mut init_seed = [0u8; 32];
@@ -292,9 +292,9 @@ async fn main() -> Result<(), ClientError> {
     println!("Latest block: {}", sync_summary.block_num);
 
     //------------------------------------------------------------
-    // STEP 1: Create a basic wallet for Alice
+    // STEP 3: Create a basic wallet for Alice
     //------------------------------------------------------------
-    println!("\n[STEP 1] Creating a new account for Alice");
+    println!("\n[STEP 3] Creating a new account for Alice");
 
     // Account seed
     let mut init_seed = [0_u8; 32];
@@ -321,9 +321,9 @@ async fn main() -> Result<(), ClientError> {
     println!("Alice's account ID: {:?}", alice_account_id_bech32);
 
     //------------------------------------------------------------
-    // STEP 2: Deploy a fungible faucet
+    // STEP 4: Deploy a fungible faucet
     //------------------------------------------------------------
-    println!("\n[STEP 2] Deploying a new fungible faucet.");
+    println!("\n[STEP 4] Deploying a new fungible faucet.");
 
     // Faucet seed
     let mut init_seed = [0u8; 32];
@@ -375,10 +375,10 @@ The output will look like this:
 ```text
 Latest block: 17771
 
-[STEP 1] Creating a new account for Alice
+[STEP 3] Creating a new account for Alice
 Alice's account ID: "0x3cb3e596d14ad410000017901eaa7b"
 
-[STEP 2] Deploying a new fungible faucet.
+[STEP 4] Deploying a new fungible faucet.
 Faucet account ID: "0x6ad1894ac233e4200000088311bb6b"
 ```
 

--- a/docs/src/rust-client/mint_consume_create_tutorial.md
+++ b/docs/src/rust-client/mint_consume_create_tutorial.md
@@ -129,6 +129,12 @@ loop {
 }
 ```
 
+If you want to verify Alice's updated balance after the consume transaction, first call
+`client.sync_state().await?` and then fetch a fresh account snapshot with
+`client.get_account(alice_account.id()).await?`. The original `alice_account` variable was
+created earlier in the tutorial, so it does not update in place when later transactions change the
+wallet state.
+
 ## Step 4: Sending tokens to other accounts
 
 After consuming the notes, Alice has tokens in her wallet. Now, she wants to send tokens to her friends. She has two options: create a separate transaction for each transfer or batch multiple transfers into a single transaction.


### PR DESCRIPTION
## Summary
- align the create/deploy tutorial's inline `STEP` labels with the tutorial section numbering so Step 3 and Step 4 no longer read as Step 1 and Step 2 in the embedded code/output
- add an explicit note in the mint/consume tutorial that account state must be re-synced and re-fetched before checking updated balances

## Why
The current create/deploy tutorial mixes section numbers and inline step labels, which is confusing when reading the generated code and output. Separately, the mint/consume tutorial implies Alice's balance updates in place, but the in-memory `alice_account` snapshot does not refresh automatically after later transactions.

## Testing
- `git diff --check`
- did not run Rust/doc tests locally because this machine does not have `cargo` installed

Closes #93
Closes #114
