### PR TITLE
docs: correct P2ID note count and loop range in mint tutorial

### DIFF
--- a/docs/src/rust-client/mint_consume_create_tutorial.md
+++ b/docs/src/rust-client/mint_consume_create_tutorial.md
@@ -143,7 +143,7 @@ For the sake of the example, the first four P2ID transfers are handled in a sing
 
 To output multiple notes in a single transaction we need to create a list of our expected output notes. The expected output notes are the notes that we expect to create in our transaction request.
 
-In the snippet below, we create an empty vector to store five P2ID output notes, loop over five iterations `(using 0..=4)` to create five unique dummy account IDs, build a P2ID note for each one, and push each note onto the vector. Finally, we build a transaction request using `.own_output_notes()`—passing in all five notes—and submit it to the node.
+In the snippet below, we create an empty vector to store four P2ID output notes, loop over four iterations `(using 1..=4)` to create four unique dummy account IDs, build a P2ID note for each one, and push each note onto the vector. Finally, we build a transaction request using `.own_output_notes()`—passing in all four notes—and submit it to the node.
 
 Add this snippet to the end of your file in the `main()` function:
 


### PR DESCRIPTION
The paragraph introducing the multi-note output snippet describes five notes
over `0..=4`, but the code creates four notes over `1..=4`.

Three sources in the repo already agree on four:

- `rust-client/src/bin/create_mint_consume_send.rs` prints
  `Submitted a transaction with 4 P2ID notes`
- the code fence further down this same file uses `1..=4`
- line 140 of this same file already says "the first four P2ID transfers are
  handled in a single transaction, and the fifth transfer is a standard P2ID
  transfer"

So the paragraph contradicted both the code below it and the prose six lines
above it. This aligns the wording with all three.

Text-only change, no code touched. `cargo test --doc` in `docs/` passes
(17 passed, 0 failed). Ran `prettier --write` per CONTRIBUTING.md; the line
was already conformant.