### PR TITLE
docs: propagate unwrap-to-? migration into tutorial snippets

### DIFF
--- a/docs/src/rust-client/custom_note_how_to.md
+++ b/docs/src/rust-client/custom_note_how_to.md
@@ -326,9 +326,7 @@ async fn main() -> Result<(), ClientError> {
 
     if let Some((note_record, _)) = consumable_notes.first() {
         let note: Note = note_record.clone().try_into()?;
-        let consume_request = TransactionRequestBuilder::new()
-            .build_consume_notes(vec![note])
-            .unwrap();
+        let consume_request = TransactionRequestBuilder::new().build_consume_notes(vec![note])?;
 
         let tx_id = client
             .submit_new_transaction(alice_account.id(), consume_request)

--- a/docs/src/rust-client/mint_consume_create_tutorial.md
+++ b/docs/src/rust-client/mint_consume_create_tutorial.md
@@ -107,9 +107,8 @@ loop {
 
     if notes.len() == 5 {
         println!("Found 5 consumable notes for Alice. Consuming them now...");
-        let transaction_request = TransactionRequestBuilder::new()
-            .build_consume_notes(notes)
-            .unwrap();
+        let transaction_request =
+            TransactionRequestBuilder::new().build_consume_notes(notes)?;
 
         let tx_id = client
             .submit_new_transaction(alice_account.id(), transaction_request)

--- a/docs/src/rust-client/unauthenticated_note_how_to.md
+++ b/docs/src/rust-client/unauthenticated_note_how_to.md
@@ -255,9 +255,8 @@ async fn main() -> Result<(), ClientError> {
 
     if let Some((note_record, _)) = consumable_notes.first() {
         let note: Note = note_record.clone().try_into()?;
-        let transaction_request = TransactionRequestBuilder::new()
-            .build_consume_notes(vec![note])
-            .unwrap();
+        let transaction_request =
+            TransactionRequestBuilder::new().build_consume_notes(vec![note])?;
 
         let consume_tx_id = client
             .submit_new_transaction(alice.id(), transaction_request)


### PR DESCRIPTION
`rust-client/src/bin/` uses the `?` operator on `build_consume_notes`, but
three tutorial snippets still call `.unwrap()`. The migration reached the
large `no_run` listings, which CI compiles, but not the smaller
`rust ignore` snippets, which are never compiled and so drifted silently.

Three call sites, each now matching its source exactly:

- `mint_consume_create_tutorial.md` vs `create_mint_consume_send.rs`
- `custom_note_how_to.md` vs `hash_preimage_note.rs`
- `unauthenticated_note_how_to.md` vs `unauthenticated_note_transfer.rs`

The first one also resolves a contradiction inside its own file, which
already used `?` in the final full listing further down.

Line wrapping differs between the three because the sources differ:
`consume_request` fits on one line, `transaction_request` does not. Each
snippet reproduces its own source rather than normalizing them.

Scope is limited to these three `build_consume_notes` call sites. No
repo-wide `.unwrap()` sweep was done, and other `.unwrap()` calls that
match their sources are untouched.

Docs-only change. `cargo test --doc` in `docs/` passes (17 passed, 0 failed).
Ran `prettier --write` per CONTRIBUTING.md.