### PR TITLE
docs: fix outdated repository URLs across tutorials

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -9,4 +9,4 @@ Basic tutorials and examples of how to build applications on Miden.
 
 The goal is to make getting up to speed with building on Miden as quick and simple as possible.
 
-All of the following tutorials are accompanied by code examples in Rust and TypeScript, which can be found in the [Miden Tutorials](https://github.com/0xMiden/miden-tutorials) repository.
+All of the following tutorials are accompanied by code examples in Rust and TypeScript, which can be found in the [Miden Tutorials](https://github.com/0xMiden/tutorials) repository.

--- a/docs/src/miden-bank/01-account-components.md
+++ b/docs/src/miden-bank/01-account-components.md
@@ -500,7 +500,7 @@ impl BankStorage {
 5. **Trait methods** (declared in the `#[component] trait`) are callable by other contracts via generated bindings; private helpers live in a plain `impl` block
 
 :::tip View Complete Source
-See the complete bank account implementation in [contracts/bank-account/src/lib.rs](https://github.com/0xMiden/miden-tutorials/blob/main/examples/miden-bank/contracts/bank-account/src/lib.rs).
+See the complete bank account implementation in [contracts/bank-account/src/lib.rs](https://github.com/0xMiden/tutorials/blob/main/examples/miden-bank/contracts/bank-account/src/lib.rs).
 :::
 
 ## Next Steps

--- a/docs/src/miden-bank/02-constants-constraints.md
+++ b/docs/src/miden-bank/02-constants-constraints.md
@@ -506,7 +506,7 @@ impl BankStorage {
 5. **Failed assertions** mean no valid proof can be generated
 
 :::tip View Complete Source
-See the complete constraint implementation in [contracts/bank-account/src/lib.rs](https://github.com/0xMiden/miden-tutorials/blob/main/examples/miden-bank/contracts/bank-account/src/lib.rs).
+See the complete constraint implementation in [contracts/bank-account/src/lib.rs](https://github.com/0xMiden/tutorials/blob/main/examples/miden-bank/contracts/bank-account/src/lib.rs).
 :::
 
 ## Next Steps

--- a/docs/src/miden-bank/03-asset-management.md
+++ b/docs/src/miden-bank/03-asset-management.md
@@ -752,7 +752,7 @@ impl BankStorage {
 6. **CRITICAL: Always validate before subtraction** - Felt arithmetic wraps silently!
 
 :::tip View Complete Source
-See the complete deposit and withdraw implementations in [contracts/bank-account/src/lib.rs](https://github.com/0xMiden/miden-tutorials/blob/main/examples/miden-bank/contracts/bank-account/src/lib.rs).
+See the complete deposit and withdraw implementations in [contracts/bank-account/src/lib.rs](https://github.com/0xMiden/tutorials/blob/main/examples/miden-bank/contracts/bank-account/src/lib.rs).
 :::
 
 ## Next Steps

--- a/docs/src/miden-bank/04-note-scripts.md
+++ b/docs/src/miden-bank/04-note-scripts.md
@@ -567,8 +567,8 @@ impl DepositNote {
 :::tip View Complete Source
 See the complete note script implementations:
 
-- [Deposit Note](https://github.com/0xMiden/miden-tutorials/blob/main/examples/miden-bank/contracts/deposit-note/src/lib.rs)
-- [Withdraw Request Note](https://github.com/0xMiden/miden-tutorials/blob/main/examples/miden-bank/contracts/withdraw-request-note/src/lib.rs)
+- [Deposit Note](https://github.com/0xMiden/tutorials/blob/main/examples/miden-bank/contracts/deposit-note/src/lib.rs)
+- [Withdraw Request Note](https://github.com/0xMiden/tutorials/blob/main/examples/miden-bank/contracts/withdraw-request-note/src/lib.rs)
   :::
 
 ## Next Steps

--- a/docs/src/miden-bank/05-cross-component-calls.md
+++ b/docs/src/miden-bank/05-cross-component-calls.md
@@ -313,8 +313,8 @@ error: dependency 'bank-account' not found
 :::tip View Complete Source
 See the complete `miden-project.toml` configurations:
 
-- [Deposit Note miden-project.toml](https://github.com/0xMiden/miden-tutorials/blob/main/examples/miden-bank/contracts/deposit-note/miden-project.toml)
-- [Withdraw Request Note miden-project.toml](https://github.com/0xMiden/miden-tutorials/blob/main/examples/miden-bank/contracts/withdraw-request-note/miden-project.toml)
+- [Deposit Note miden-project.toml](https://github.com/0xMiden/tutorials/blob/main/examples/miden-bank/contracts/deposit-note/miden-project.toml)
+- [Withdraw Request Note miden-project.toml](https://github.com/0xMiden/tutorials/blob/main/examples/miden-bank/contracts/withdraw-request-note/miden-project.toml)
   :::
 
 ## Next Steps

--- a/docs/src/miden-bank/06-transaction-scripts.md
+++ b/docs/src/miden-bank/06-transaction-scripts.md
@@ -571,7 +571,7 @@ rustflags = ["--cfg", "miden"]
 6. **TransactionScript-kind package** - Unlike an executable, the compiled tx-script is extracted with `build_tx_script_from_package`
 
 :::tip View Complete Source
-See the complete transaction script implementation in [contracts/init-tx-script/src/lib.rs](https://github.com/0xMiden/miden-tutorials/blob/main/examples/miden-bank/contracts/init-tx-script/src/lib.rs).
+See the complete transaction script implementation in [contracts/init-tx-script/src/lib.rs](https://github.com/0xMiden/tutorials/blob/main/examples/miden-bank/contracts/init-tx-script/src/lib.rs).
 :::
 
 ## Next Steps

--- a/docs/src/miden-bank/07-output-notes.md
+++ b/docs/src/miden-bank/07-output-notes.md
@@ -822,7 +822,7 @@ impl WithdrawRequestNote {
 7. **Always validate before subtraction** to prevent underflow exploits
 
 :::tip View Complete Source
-See the complete implementation in the [examples/miden-bank](https://github.com/0xMiden/miden-tutorials/tree/main/examples/miden-bank) directory.
+See the complete implementation in the [examples/miden-bank](https://github.com/0xMiden/tutorials/tree/main/examples/miden-bank) directory.
 :::
 
 ## Next Steps

--- a/docs/src/miden-bank/08-complete-flows.md
+++ b/docs/src/miden-bank/08-complete-flows.md
@@ -302,9 +302,9 @@ Use these patterns to build:
 :::tip View Complete Source
 Explore the complete banking application:
 
-- [All Contracts](https://github.com/0xMiden/miden-tutorials/tree/main/examples/miden-bank/contracts)
-- [Integration Tests](https://github.com/0xMiden/miden-tutorials/tree/main/examples/miden-bank/integration/tests)
-- [Test Helpers](https://github.com/0xMiden/miden-tutorials/blob/main/examples/miden-bank/integration/src/helpers.rs)
+- [All Contracts](https://github.com/0xMiden/tutorials/tree/main/examples/miden-bank/contracts)
+- [Integration Tests](https://github.com/0xMiden/tutorials/tree/main/examples/miden-bank/integration/tests)
+- [Test Helpers](https://github.com/0xMiden/tutorials/blob/main/examples/miden-bank/integration/src/helpers.rs)
   :::
 
 Happy building on Miden! 🚀

--- a/docs/src/miden-bank/index.md
+++ b/docs/src/miden-bank/index.md
@@ -185,11 +185,11 @@ This tutorial covers the following Miden Rust compiler features:
 
 ## Source Code
 
-The complete source code for this tutorial is available in the [examples/miden-bank](https://github.com/0xMiden/miden-tutorials/tree/main/examples/miden-bank) directory of this repository:
+The complete source code for this tutorial is available in the [examples/miden-bank](https://github.com/0xMiden/tutorials/tree/main/examples/miden-bank) directory of this repository:
 
 ```bash title=">_ Terminal"
-git clone https://github.com/0xMiden/miden-tutorials.git
-cd miden-tutorials/examples/miden-bank
+git clone https://github.com/0xMiden/tutorials.git
+cd tutorials/examples/miden-bank
 ```
 
 ## Supplementary Guides
@@ -206,6 +206,6 @@ If you get stuck during this tutorial:
 
 - Check the [Miden Docs](https://docs.miden.xyz) for detailed technical references
 - Join the [Build On Miden](https://t.me/BuildOnMiden) Telegram community for support
-- Review the complete code in the [examples/miden-bank](https://github.com/0xMiden/miden-tutorials/tree/main/examples/miden-bank) directory
+- Review the complete code in the [examples/miden-bank](https://github.com/0xMiden/tutorials/tree/main/examples/miden-bank) directory
 
 Ready to build your first Miden banking application? Let's get started with [Part 0: Project Setup](./00-project-setup.md)!

--- a/docs/src/rust-client/counter_contract_tutorial.md
+++ b/docs/src/rust-client/counter_contract_tutorial.md
@@ -538,7 +538,7 @@ To increment the count of the counter contract all you need is to know the accou
 
 ### Running the example
 
-To run the full example, navigate to the `rust-client` directory in the [miden-tutorials](https://github.com/0xMiden/miden-tutorials/) repository and run this command:
+To run the full example, navigate to the `rust-client` directory in the [tutorials](https://github.com/0xMiden/tutorials/) repository and run this command:
 
 ```bash
 cd rust-client

--- a/docs/src/rust-client/create_deploy_tutorial.md
+++ b/docs/src/rust-client/create_deploy_tutorial.md
@@ -420,7 +420,7 @@ In the next section we will cover how to mint tokens from the faucet, consume no
 
 ### Running the example
 
-To run a full working example navigate to the `rust-client` directory in the [miden-tutorials](https://github.com/0xMiden/miden-tutorials/) repository and run this command:
+To run a full working example navigate to the `rust-client` directory in the [tutorials](https://github.com/0xMiden/tutorials/) repository and run this command:
 
 ```bash
 cd rust-client

--- a/docs/src/rust-client/creating_notes_in_masm_tutorial.md
+++ b/docs/src/rust-client/creating_notes_in_masm_tutorial.md
@@ -564,7 +564,7 @@ Transaction 0xa003d298db5e7de263a8b98930b6e75336c3cca7cd4a090c707edb6a7f061ad5 n
 
 ### Running the example
 
-To run the full example, navigate to the `rust-client` directory in the [miden-tutorials](https://github.com/0xMiden/miden-tutorials/) repository and run this command:
+To run the full example, navigate to the `rust-client` directory in the [tutorials](https://github.com/0xMiden/tutorials/) repository and run this command:
 
 ```bash
 cd rust-client

--- a/docs/src/rust-client/custom_note_how_to.md
+++ b/docs/src/rust-client/custom_note_how_to.md
@@ -443,7 +443,7 @@ By leveraging Miden’s privacy features, you can create customized logic for se
 
 ### Running the example
 
-To run the custom note example, navigate to the `rust-client` directory in the [miden-tutorials](https://github.com/0xMiden/miden-tutorials/) repository and run this command:
+To run the custom note example, navigate to the `rust-client` directory in the [tutorials](https://github.com/0xMiden/tutorials/) repository and run this command:
 
 ```bash
 cd rust-client

--- a/docs/src/rust-client/delegated_proving_tutorial.md
+++ b/docs/src/rust-client/delegated_proving_tutorial.md
@@ -200,7 +200,7 @@ Alice nonce has increased: 1
 
 ### Running the example
 
-To run a full working example navigate to the `rust-client` directory in the [miden-tutorials](https://github.com/0xMiden/miden-tutorials/) repository and run this command:
+To run a full working example navigate to the `rust-client` directory in the [tutorials](https://github.com/0xMiden/tutorials/) repository and run this command:
 
 ```bash
 cd rust-client

--- a/docs/src/rust-client/foreign_procedure_invocation_tutorial.md
+++ b/docs/src/rust-client/foreign_procedure_invocation_tutorial.md
@@ -598,7 +598,7 @@ The output will show the count reader contract being created, the counter contra
 
 ### Running the example
 
-To run the full example, navigate to the `rust-client` directory in the [miden-tutorials](https://github.com/0xMiden/miden-tutorials/) repository and run this command:
+To run the full example, navigate to the `rust-client` directory in the [tutorials](https://github.com/0xMiden/tutorials/) repository and run this command:
 
 ```bash
 cd rust-client

--- a/docs/src/rust-client/mappings_in_masm_how_to.md
+++ b/docs/src/rust-client/mappings_in_masm_how_to.md
@@ -312,7 +312,7 @@ async fn main() -> Result<(), ClientError> {
 
 ### Running the example
 
-To run the full example, navigate to the `rust-client` directory in the [miden-tutorials](https://github.com/0xMiden/miden-tutorials/) repository and run this command:
+To run the full example, navigate to the `rust-client` directory in the [tutorials](https://github.com/0xMiden/tutorials/) repository and run this command:
 
 ```bash
 cd rust-client

--- a/docs/src/rust-client/mint_consume_create_tutorial.md
+++ b/docs/src/rust-client/mint_consume_create_tutorial.md
@@ -595,7 +595,7 @@ and then Alice sent 5 separate 50-token notes to 5 different users.
 
 ### Running the example
 
-To run a full working example navigate to the `rust-client` directory in the [miden-tutorials](https://github.com/0xMiden/miden-tutorials/) repository and run this command:
+To run a full working example navigate to the `rust-client` directory in the [tutorials](https://github.com/0xMiden/tutorials/) repository and run this command:
 
 ```bash
 cd rust-client

--- a/docs/src/rust-client/oracle_tutorial.md
+++ b/docs/src/rust-client/oracle_tutorial.md
@@ -444,7 +444,7 @@ The `get_median` procedure leaves three values on the stack. Index `0` holds `is
 
 ### Running the tutorial
 
-To run this tutorial end-to-end, navigate to the `rust-client` directory in the [miden-tutorials](https://github.com/0xMiden/miden-tutorials/) repository and run:
+To run this tutorial end-to-end, navigate to the `rust-client` directory in the [tutorials](https://github.com/0xMiden/tutorials/) repository and run:
 
 ```bash
 cd rust-client

--- a/docs/src/rust-client/public_account_interaction_tutorial.md
+++ b/docs/src/rust-client/public_account_interaction_tutorial.md
@@ -436,7 +436,7 @@ counter contract storage: Ok(RpoDigest([0, 0, 0, 2]))
 
 ### Running the example
 
-To run the full example, navigate to the `rust-client` directory in the [miden-tutorials](https://github.com/0xMiden/miden-tutorials/) repository and run this command:
+To run the full example, navigate to the `rust-client` directory in the [tutorials](https://github.com/0xMiden/tutorials/) repository and run this command:
 
 ```bash
 cd rust-client

--- a/docs/src/rust-client/unauthenticated_note_how_to.md
+++ b/docs/src/rust-client/unauthenticated_note_how_to.md
@@ -474,7 +474,7 @@ By following this guide, you should now have a clear understanding of how to bui
 
 ### Running the example
 
-To run the unauthenticated note transfer example, navigate to the `rust-client` directory in the [miden-tutorials](https://github.com/0xMiden/miden-tutorials/) repository and run this command:
+To run the unauthenticated note transfer example, navigate to the `rust-client` directory in the [tutorials](https://github.com/0xMiden/tutorials/) repository and run this command:
 
 ```bash
 cd rust-client

--- a/docs/src/web-client/counter_contract_tutorial.md
+++ b/docs/src/web-client/counter_contract_tutorial.md
@@ -424,7 +424,7 @@ end
 
 ### Running the example
 
-To run a full working example navigate to the `web-client` directory in the [miden-tutorials](https://github.com/0xMiden/miden-tutorials/) repository and run the web application example:
+To run a full working example navigate to the `web-client` directory in the [tutorials](https://github.com/0xMiden/tutorials/) repository and run the web application example:
 
 ```bash
 cd web-client

--- a/docs/src/web-client/creating_multiple_notes_tutorial.md
+++ b/docs/src/web-client/creating_multiple_notes_tutorial.md
@@ -483,7 +483,7 @@ export async function multiSendWithDelegatedProver(): Promise<void> {
 
 ### Running the example
 
-To run a full working example navigate to the `web-client` directory in the [miden-tutorials](https://github.com/0xMiden/miden-tutorials/) repository and run the web application example:
+To run a full working example navigate to the `web-client` directory in the [tutorials](https://github.com/0xMiden/tutorials/) repository and run the web application example:
 
 ```bash
 cd web-client

--- a/docs/src/web-client/foreign_procedure_invocation_tutorial.md
+++ b/docs/src/web-client/foreign_procedure_invocation_tutorial.md
@@ -570,7 +570,7 @@ The key steps were:
 
 ### Running the example
 
-To run a full working example navigate to the `web-client` directory in the [miden-tutorials](https://github.com/0xMiden/miden-tutorials/) repository and run the web application example:
+To run a full working example navigate to the `web-client` directory in the [tutorials](https://github.com/0xMiden/tutorials/) repository and run the web application example:
 
 ```bash
 cd web-client

--- a/docs/src/web-client/react_wallet_tutorial.md
+++ b/docs/src/web-client/react_wallet_tutorial.md
@@ -633,13 +633,20 @@ function Wallet({ accountId }: { accountId: string }) {
 
 ## Running the Example
 
-To run a full working example, navigate to the `packages/react-sdk/examples/wallet` directory in the [miden-client](https://github.com/0xMiden/miden-client/) repository:
+To run a full working example, navigate to the `packages/react-sdk/examples/wallet` directory in the [web-sdk](https://github.com/0xMiden/web-sdk/) repository:
 
 ```bash
-git clone https://github.com/0xMiden/miden-client.git
-cd miden-client/packages/react-sdk/examples/wallet
-yarn install
-yarn dev
+git clone https://github.com/0xMiden/web-sdk.git
+cd web-sdk
+
+# Install the workspace and build the React SDK.
+pnpm install
+pnpm --filter @miden-sdk/react run build
+
+# The example lives outside the pnpm workspace, so it needs its own install.
+cd packages/react-sdk/examples/wallet
+pnpm install --ignore-workspace
+pnpm dev
 ```
 
 ### Resetting the MidenClientDB
@@ -934,5 +941,5 @@ The `SignerContextValue` interface requires:
 Now that you've built a React wallet, explore these related topics:
 
 - [Creating Multiple Notes in a Single Transaction](./creating_multiple_notes_tutorial.md) - Learn about batch operations
-- [Miden React SDK Reference](https://github.com/0xMiden/miden-client/tree/main/packages/react-sdk) - Full API documentation
+- [Miden React SDK Reference](https://github.com/0xMiden/web-sdk/tree/main/packages/react-sdk) - Full API documentation
 - [Miden Documentation](https://docs.miden.io/) - Core Miden concepts

--- a/docs/src/web-client/unauthenticated_note_how_to.md
+++ b/docs/src/web-client/unauthenticated_note_how_to.md
@@ -449,7 +449,7 @@ The Miden webclient stores account and note data in the browser. If you get erro
 
 ### Running the Full Example
 
-To run a full working example navigate to the `web-client` directory in the [miden-tutorials](https://github.com/0xMiden/miden-tutorials/) repository and run the web application example:
+To run a full working example navigate to the `web-client` directory in the [tutorials](https://github.com/0xMiden/tutorials/) repository and run the web application example:
 
 ```bash
 cd web-client


### PR DESCRIPTION
### What

Two GitHub repositories referenced throughout the tutorials have moved, and the docs still point at their old locations:

| Referenced in docs | Actual location today |
| --- | --- |
| `0xMiden/miden-tutorials` | `0xMiden/tutorials` (this repo) |
| `0xMiden/miden-client` -> `packages/react-sdk` | `0xMiden/web-sdk` -> `packages/react-sdk` |

The first is a rename, so those links still resolve through GitHub's redirect - but they read as a different repository, which is confusing in pages that say "this repository", and they break the copy-paste `git clone` + `cd` snippet in the Miden Bank index.

The second is genuinely broken. `0xMiden/miden-client` now redirects to `0xMiden/rust-sdk`, which has no `packages/` directory on `main`, so `https://github.com/0xMiden/miden-client/tree/main/packages/react-sdk` 404s and the React wallet tutorial's clone-and-run instructions cannot work. The React SDK and its `examples/wallet` app live in `0xMiden/web-sdk`.

### Changes

- Replaced 33 `github.com/0xMiden/miden-tutorials` links with `github.com/0xMiden/tutorials` across 24 tutorial pages, and updated the link text `[miden-tutorials]` -> `[tutorials]` where the repo name was the label.
- Fixed the clone snippet in `docs/src/miden-bank/index.md` so the `cd` matches the directory `git clone` actually creates.
- Repointed the React wallet tutorial's **Running the Example** section at `0xMiden/web-sdk`, and replaced the `yarn install` / `yarn dev` commands with the pnpm workflow documented in that example's own README (the workspace build step plus `pnpm install --ignore-workspace`, since the example sits outside the pnpm workspace).
- Repointed the **Miden React SDK Reference** link in the same page at `0xMiden/web-sdk`.

### Verification

- Every `blob/main/...` and `tree/main/...` path linked into this repo was checked against the repo tree - all 11 resolve.
- `packages/react-sdk/examples/wallet` confirmed present in `0xMiden/web-sdk@main` and absent from `0xMiden/rust-sdk@main`.
- `prettier@3.8.4 --check "**/*.md"` passes (same version the Format Markdown workflow pins).
- Markdown-only change; no Rust code fences touched, so `cargo test --doc` is unaffected.

### Note on overlap

#203 also touches the **Miden React SDK Reference** line, repointing it at `https://docs.miden.xyz/builder/tools/clients/react-sdk/` instead. Both fixes are valid - if you'd rather take #203's version of that one line, I'm happy to drop that hunk. The **Running the Example** block is not covered by #203 or #213.
