### PR TITLE
fix: use CodeBuilder for oracle script linking

### DIFF
--- a/docs/src/rust-client/oracle_tutorial.md
+++ b/docs/src/rust-client/oracle_tutorial.md
@@ -57,9 +57,7 @@ use miden_client::{
         component::AccountComponentMetadata, AccountBuilder, AccountComponent, AccountId,
         AccountType, StorageMapKey, StorageSlot, StorageSlotName,
     },
-    assembly::{
-        CodeBuilder, DefaultSourceManager, Module, ModuleKind, Path as AssemblyPath,
-    },
+    assembly::CodeBuilder,
     auth::NoAuth,
     builder::ClientBuilder,
     keystore::FilesystemKeyStore,
@@ -67,12 +65,12 @@ use miden_client::{
         domain::account::AccountStorageRequirements,
         Endpoint, GrpcClient,
     },
-    transaction::{ForeignAccount, TransactionKernel, TransactionRequestBuilder},
+    transaction::{ForeignAccount, TransactionRequestBuilder},
     Client, ClientError, Felt, Word, ZERO,
 };
 use miden_client_sqlite_store::ClientBuilderSqliteExt;
 use rand::RngCore;
-use std::{fs, path::Path, sync::Arc};
+use std::sync::Arc;
 
 /// Import the oracle + its publishers and return the ForeignAccount list
 /// Due to Pragma's decentralized oracle architecture, we need to get the
@@ -149,21 +147,6 @@ pub async fn get_oracle_foreign_accounts(
     Ok(foreign_accounts)
 }
 
-fn create_library(
-    library_path: &str,
-    source_code: &str,
-) -> Result<Arc<miden_client::assembly::Library>, Box<dyn std::error::Error>> {
-    let source_manager = Arc::new(DefaultSourceManager::default());
-    let assembler = TransactionKernel::assembler_with_source_manager(source_manager.clone());
-    let module = Module::parser(ModuleKind::Library).parse_str(
-        AssemblyPath::new(library_path),
-        source_code,
-        source_manager,
-    )?;
-    let library = assembler.assemble_library([module])?;
-    Ok(library)
-}
-
 #[tokio::main]
 async fn main() -> Result<(), ClientError> {
     // -------------------------------------------------------------------------
@@ -218,13 +201,14 @@ async fn main() -> Result<(), ClientError> {
     // -------------------------------------------------------------------------
     // Create Oracle Reader contract
     // -------------------------------------------------------------------------
-    let contract_code =
-        fs::read_to_string(Path::new("../masm/accounts/oracle_reader.masm")).unwrap();
+    // Compile-time inclusion keeps the example independent of the directory
+    // from which the binary is launched.
+    let contract_code = include_str!("../masm/accounts/oracle_reader.masm");
 
     let contract_slot_name =
         StorageSlotName::new("miden::tutorials::oracle_reader").expect("valid slot name");
     let contract_component_code = CodeBuilder::new()
-        .compile_component_code("external_contract::oracle_reader", &contract_code)
+        .compile_component_code("external_contract::oracle_reader", contract_code)
         .unwrap();
     let contract_component = AccountComponent::new(
         contract_component_code,
@@ -254,18 +238,13 @@ async fn main() -> Result<(), ClientError> {
     // -------------------------------------------------------------------------
     // Build the script that calls our `get_price` procedure
     // -------------------------------------------------------------------------
-    let script_path = Path::new("../masm/scripts/oracle_reader_script.masm");
-    let script_code = fs::read_to_string(script_path).unwrap();
-
-    let library_path = "external_contract::oracle_reader";
-    let account_component_lib =
-        create_library(library_path, &contract_code).unwrap();
+    let script_code = include_str!("../masm/scripts/oracle_reader_script.masm");
 
     let tx_script = client
         .code_builder()
-        .with_dynamically_linked_library(&account_component_lib)
+        .with_linked_module("external_contract::oracle_reader", contract_code)
         .unwrap()
-        .compile_tx_script(&script_code)
+        .compile_tx_script(script_code)
         .unwrap();
 
     let tx_increment_request = TransactionRequestBuilder::new()

--- a/rust-client/src/bin/oracle_data_query.rs
+++ b/rust-client/src/bin/oracle_data_query.rs
@@ -3,9 +3,7 @@ use miden_client::{
         component::AccountComponentMetadata, AccountBuilder, AccountComponent, AccountId,
         AccountType, StorageMapKey, StorageSlot, StorageSlotName,
     },
-    assembly::{
-        CodeBuilder, DefaultSourceManager, Module, ModuleKind, Path as AssemblyPath,
-    },
+    assembly::CodeBuilder,
     auth::NoAuth,
     builder::ClientBuilder,
     keystore::FilesystemKeyStore,
@@ -13,7 +11,7 @@ use miden_client::{
         domain::account::AccountStorageRequirements,
         Endpoint, GrpcClient,
     },
-    transaction::{ForeignAccount, TransactionKernel, TransactionRequestBuilder},
+    transaction::{ForeignAccount, TransactionRequestBuilder},
     Client, ClientError, Felt, Word, ZERO,
 };
 use miden_client_sqlite_store::ClientBuilderSqliteExt;
@@ -93,21 +91,6 @@ pub async fn get_oracle_foreign_accounts(
     client.sync_state().await?;
 
     Ok(foreign_accounts)
-}
-
-fn create_library(
-    library_path: &str,
-    source_code: &str,
-) -> Result<Arc<miden_client::assembly::Library>, Box<dyn std::error::Error>> {
-    let source_manager = Arc::new(DefaultSourceManager::default());
-    let assembler = TransactionKernel::assembler_with_source_manager(source_manager.clone());
-    let module = Module::parser(ModuleKind::Library).parse_str(
-        AssemblyPath::new(library_path),
-        source_code,
-        source_manager,
-    )?;
-    let library = assembler.assemble_library([module])?;
-    Ok(library)
 }
 
 #[tokio::main]
@@ -203,13 +186,9 @@ async fn main() -> Result<(), ClientError> {
     let script_path = Path::new("../masm/scripts/oracle_reader_script.masm");
     let script_code = fs::read_to_string(script_path).unwrap();
 
-    let library_path = "external_contract::oracle_reader";
-    let account_component_lib =
-        create_library(library_path, &contract_code).unwrap();
-
     let tx_script = client
         .code_builder()
-        .with_dynamically_linked_library(&account_component_lib)
+        .with_linked_module("external_contract::oracle_reader", &contract_code)
         .unwrap()
         .compile_tx_script(&script_code)
         .unwrap();

--- a/rust-client/src/bin/oracle_data_query.rs
+++ b/rust-client/src/bin/oracle_data_query.rs
@@ -16,7 +16,7 @@ use miden_client::{
 };
 use miden_client_sqlite_store::ClientBuilderSqliteExt;
 use rand::RngCore;
-use std::{fs, path::Path, sync::Arc};
+use std::sync::Arc;
 
 /// Import the oracle + its publishers and return the ForeignAccount list
 /// Due to Pragma's decentralized oracle architecture, we need to get the
@@ -147,13 +147,14 @@ async fn main() -> Result<(), ClientError> {
     // -------------------------------------------------------------------------
     // Create Oracle Reader contract
     // -------------------------------------------------------------------------
-    let contract_code =
-        fs::read_to_string(Path::new("../masm/accounts/oracle_reader.masm")).unwrap();
+    // Compile-time inclusion keeps the example independent of the directory
+    // from which the binary is launched.
+    let contract_code = include_str!("../../../masm/accounts/oracle_reader.masm");
 
     let contract_slot_name =
         StorageSlotName::new("miden::tutorials::oracle_reader").expect("valid slot name");
     let contract_component_code = CodeBuilder::new()
-        .compile_component_code("external_contract::oracle_reader", &contract_code)
+        .compile_component_code("external_contract::oracle_reader", contract_code)
         .unwrap();
     let contract_component = AccountComponent::new(
         contract_component_code,
@@ -183,14 +184,13 @@ async fn main() -> Result<(), ClientError> {
     // -------------------------------------------------------------------------
     // Build the script that calls our `get_price` procedure
     // -------------------------------------------------------------------------
-    let script_path = Path::new("../masm/scripts/oracle_reader_script.masm");
-    let script_code = fs::read_to_string(script_path).unwrap();
+    let script_code = include_str!("../../../masm/scripts/oracle_reader_script.masm");
 
     let tx_script = client
         .code_builder()
-        .with_linked_module("external_contract::oracle_reader", &contract_code)
+        .with_linked_module("external_contract::oracle_reader", contract_code)
         .unwrap()
-        .compile_tx_script(&script_code)
+        .compile_tx_script(script_code)
         .unwrap();
 
     let tx_increment_request = TransactionRequestBuilder::new()


### PR DESCRIPTION
Addresses part of #188 and the relative-path failure reported in #191.

- Replaces the remaining `TransactionKernel::assembler_with_source_manager` usage in the runnable oracle example with the client `CodeBuilder` linking pattern used by current tutorials.
- Removes the now-unneeded manual parser/source-manager helper and imports.
- Loads the oracle MASM contract and script with `include_str!`, so the example no longer depends on the process working directory.

No transaction behavior is changed.