### PR TITLE
docs: document no-auth MASM procedure

### DIFF
--- a/masm/accounts/auth/no_auth.masm
+++ b/masm/accounts/auth/no_auth.masm
@@ -1,5 +1,19 @@
 use miden::protocol::native_account
 
+#! Description
+#! Authentication script that performs no credential checks and only advances the account nonce.
+#!
+#! Inputs
+#! - None.
+#!
+#! Outputs
+#! - None.
+#!
+#! Panics if
+#! - The native account nonce cannot be incremented.
+#!
+#! Invocation
+#! - Invoked by the transaction kernel as this account's authentication procedure.
 @auth_script
 pub proc auth__basic
     exec.native_account::incr_nonce drop


### PR DESCRIPTION
Addresses a small part of #190.

Adds the standard MASM doc-comment sections to `masm/accounts/auth/no_auth.masm`, documenting the no-auth procedure's behavior, inputs/outputs, failure condition, and invocation context.

No runtime behavior changes.