### PR TITLE
docs: link Rust tutorials to runnable source

### DIFF
--- a/docs/src/rust-client/create_deploy_tutorial.md
+++ b/docs/src/rust-client/create_deploy_tutorial.md
@@ -7,6 +7,8 @@ sidebar_position: 2
 
 _Using the Miden client in Rust to create accounts and deploy faucets_
 
+**[View the complete runnable example on GitHub](https://github.com/0xMiden/tutorials/blob/main/rust-client/src/bin/create_mint_consume_send.rs)**
+
 ## Overview
 
 In this tutorial, we will create a Miden account for _Alice_ and deploy a fungible faucet. In the next section, we will mint tokens from the faucet to fund her account and transfer tokens from Alice's account to other Miden accounts.

--- a/docs/src/rust-client/delegated_proving_tutorial.md
+++ b/docs/src/rust-client/delegated_proving_tutorial.md
@@ -7,6 +7,8 @@ sidebar_position: 12
 
 _Using delegated proving to minimize transaction proving times on computationally constrained devices_
 
+**[View the complete runnable example on GitHub](https://github.com/0xMiden/tutorials/blob/main/rust-client/src/bin/delegated_prover.rs)**
+
 ## Overview
 
 In this tutorial we will cover how to use delegated proving with the Miden Rust client to minimize the time it takes to generate a valid transaction proof. In the code below, we will create an account, mint tokens from a faucet, then send the tokens to another account using delegated proving.

--- a/docs/src/rust-client/index.md
+++ b/docs/src/rust-client/index.md
@@ -15,4 +15,6 @@ The Miden Rust client can be used for a variety of things, including:
 
 This section of the docs is an overview of the different things one can achieve using the Rust client, and how to implement them.
 
+For complete runnable examples, browse the [`rust-client/src/bin`](https://github.com/0xMiden/tutorials/tree/main/rust-client/src/bin) source directory. Individual tutorials also link directly to their corresponding example where available.
+
 Keep in mind that both the Rust client and the documentation are works-in-progress!

--- a/docs/src/rust-client/mappings_in_masm_how_to.md
+++ b/docs/src/rust-client/mappings_in_masm_how_to.md
@@ -7,6 +7,8 @@ sidebar_position: 10
 
 _Using mappings in Miden assembly for storing key value pairs_
 
+[View the complete runnable Rust example](https://github.com/0xMiden/tutorials/blob/main/rust-client/src/bin/mapping_example.rs)
+
 ## Overview
 
 In this example, we will explore how to use mappings in Miden Assembly. Mappings are essential data structures that store key-value pairs. We will demonstrate how to create an account that contains a mapping and then call a procedure in that account to update the mapping.

--- a/docs/src/rust-client/public_account_interaction_tutorial.md
+++ b/docs/src/rust-client/public_account_interaction_tutorial.md
@@ -7,6 +7,8 @@ sidebar_position: 5
 
 _Using the Miden client in Rust to interact with public smart contracts on Miden_
 
+**[View the complete runnable example on GitHub](https://github.com/0xMiden/tutorials/blob/main/rust-client/src/bin/counter_contract_increment.rs)**
+
 ## Overview
 
 In the previous tutorial, we built a simple counter contract and deployed it to the Miden testnet. However, we only covered how the contract’s deployer could interact with it. Now, let’s explore how anyone can interact with a public smart contract on Miden.


### PR DESCRIPTION
Advances the source-link portion of #111 by making runnable Rust examples easier to find from the docs.

Currently covers:
- Rust Client index → direct link to the complete `rust-client/src/bin` example directory
- Creating Accounts and Faucets → `rust-client/src/bin/create_mint_consume_send.rs`
- Interacting with Public Smart Contracts → `rust-client/src/bin/counter_contract_increment.rs`
- Delegated Proving → `rust-client/src/bin/delegated_prover.rs`
- Mappings in MASM → `rust-client/src/bin/mapping_example.rs`

This keeps the change documentation-only and leaves the broader client-tool migration out of scope.

Refs #111