### PR TITLE
refactor: share wait_for_tx helper across Rust tutorials

### DIFF
--- a/rust-client/src/bin/hash_preimage_note.rs
+++ b/rust-client/src/bin/hash_preimage_note.rs
@@ -1,6 +1,5 @@
 use rand::RngCore;
 use std::{path::PathBuf, sync::Arc};
-use tokio::time::{sleep, Duration};
 
 use miden_client::{
     account::{
@@ -18,12 +17,12 @@ use miden_client::{
     keystore::{FilesystemKeyStore, Keystore},
     note::{Note, NoteAssets, NoteRecipient, NoteStorage, NoteTag, NoteType, PartialNoteMetadata},
     rpc::{Endpoint, GrpcClient},
-    store::TransactionFilter,
-    transaction::{TransactionId, TransactionRequestBuilder, TransactionStatus},
+    transaction::TransactionRequestBuilder,
     Client, ClientError, Felt,
 };
 use miden_client_sqlite_store::ClientBuilderSqliteExt;
 use miden_protocol::Hasher;
+use rust_client::wait_for_tx;
 
 // Helper to create a basic account
 async fn create_basic_account(
@@ -86,38 +85,6 @@ async fn create_basic_faucet(
     keystore.add_key(&key_pair, account.id()).await.unwrap();
 
     Ok(account)
-}
-
-/// Waits for a specific transaction to be committed.
-async fn wait_for_tx(
-    client: &mut Client<FilesystemKeyStore>,
-    tx_id: TransactionId,
-) -> Result<(), ClientError> {
-    loop {
-        client.sync_state().await?;
-
-        // Check transaction status
-        let txs = client
-            .get_transactions(TransactionFilter::Ids(vec![tx_id]))
-            .await?;
-        let tx_committed = if !txs.is_empty() {
-            matches!(txs[0].status, TransactionStatus::Committed { .. })
-        } else {
-            false
-        };
-
-        if tx_committed {
-            println!("✅ transaction {} committed", tx_id.to_hex());
-            break;
-        }
-
-        println!(
-            "Transaction {} not yet committed. Waiting...",
-            tx_id.to_hex()
-        );
-        sleep(Duration::from_secs(2)).await;
-    }
-    Ok(())
 }
 
 #[tokio::main]

--- a/rust-client/src/bin/network_notes_counter_contract.rs
+++ b/rust-client/src/bin/network_notes_counter_contract.rs
@@ -15,47 +15,13 @@ use miden_client::{
         NoteRecipient, NoteStorage, NoteTag, NoteType, PartialNoteMetadata,
     },
     rpc::{Endpoint, GrpcClient},
-    store::TransactionFilter,
-    transaction::{
-        TransactionId, TransactionRequestBuilder, TransactionStatus,
-    },
-    Client, ClientError, Felt, Word,
+    transaction::TransactionRequestBuilder,
+    Felt, Word,
 };
 use miden_client_sqlite_store::ClientBuilderSqliteExt;
 use rand::RngCore;
+use rust_client::wait_for_tx;
 use tokio::time::{sleep, Duration};
-
-/// Waits for a specific transaction to be committed.
-async fn wait_for_tx(
-    client: &mut Client<FilesystemKeyStore>,
-    tx_id: TransactionId,
-) -> Result<(), ClientError> {
-    loop {
-        client.sync_state().await?;
-
-        // Check transaction status
-        let txs = client
-            .get_transactions(TransactionFilter::Ids(vec![tx_id]))
-            .await?;
-        let tx_committed = if !txs.is_empty() {
-            matches!(txs[0].status, TransactionStatus::Committed { .. })
-        } else {
-            false
-        };
-
-        if tx_committed {
-            println!("✅ transaction {} committed", tx_id.to_hex());
-            break;
-        }
-
-        println!(
-            "Transaction {} not yet committed. Waiting...",
-            tx_id.to_hex()
-        );
-        sleep(Duration::from_secs(2)).await;
-    }
-    Ok(())
-}
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/rust-client/src/bin/unauthenticated_note_transfer.rs
+++ b/rust-client/src/bin/unauthenticated_note_transfer.rs
@@ -1,6 +1,6 @@
 use rand::RngCore;
 use std::{path::PathBuf, sync::Arc};
-use tokio::time::{sleep, Duration, Instant};
+use tokio::time::{Duration, Instant};
 
 use miden_client::{
     account::{
@@ -17,44 +17,12 @@ use miden_client::{
     keystore::{FilesystemKeyStore, Keystore},
     note::{Note, NoteAttachments, NoteType, P2idNote},
     rpc::{Endpoint, GrpcClient},
-    store::TransactionFilter,
-    transaction::{TransactionId, TransactionRequestBuilder, TransactionStatus},
+    transaction::TransactionRequestBuilder,
     utils::{Deserializable, Serializable},
-    Client, ClientError,
+    ClientError,
 };
 use miden_client_sqlite_store::ClientBuilderSqliteExt;
-
-/// Waits for a specific transaction to be committed.
-async fn wait_for_tx(
-    client: &mut Client<FilesystemKeyStore>,
-    tx_id: TransactionId,
-) -> Result<(), ClientError> {
-    loop {
-        client.sync_state().await?;
-
-        // Check transaction status
-        let txs = client
-            .get_transactions(TransactionFilter::Ids(vec![tx_id]))
-            .await?;
-        let tx_committed = if !txs.is_empty() {
-            matches!(txs[0].status, TransactionStatus::Committed { .. })
-        } else {
-            false
-        };
-
-        if tx_committed {
-            println!("✅ transaction {} committed", tx_id.to_hex());
-            break;
-        }
-
-        println!(
-            "Transaction {} not yet committed. Waiting...",
-            tx_id.to_hex()
-        );
-        sleep(Duration::from_secs(2)).await;
-    }
-    Ok(())
-}
+use rust_client::wait_for_tx;
 
 #[tokio::main]
 async fn main() -> Result<(), ClientError> {

--- a/rust-client/src/lib.rs
+++ b/rust-client/src/lib.rs
@@ -1,0 +1,39 @@
+use std::time::Duration;
+
+use miden_client::{
+    keystore::FilesystemKeyStore,
+    store::TransactionFilter,
+    transaction::{TransactionId, TransactionStatus},
+    Client, ClientError,
+};
+use tokio::time::sleep;
+
+/// Waits until the specified transaction is committed, syncing the client between polls.
+pub async fn wait_for_tx(
+    client: &mut Client<FilesystemKeyStore>,
+    tx_id: TransactionId,
+) -> Result<(), ClientError> {
+    loop {
+        client.sync_state().await?;
+
+        let txs = client
+            .get_transactions(TransactionFilter::Ids(vec![tx_id]))
+            .await?;
+        let tx_committed = txs
+            .first()
+            .is_some_and(|tx| matches!(tx.status, TransactionStatus::Committed { .. }));
+
+        if tx_committed {
+            println!("✅ transaction {} committed", tx_id.to_hex());
+            break;
+        }
+
+        println!(
+            "Transaction {} not yet committed. Waiting...",
+            tx_id.to_hex()
+        );
+        sleep(Duration::from_secs(2)).await;
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
## What changed

- Adds a shared `rust_client::wait_for_tx` helper for Rust tutorial binaries.
- Migrates `hash_preimage_note.rs` off its local duplicated transaction polling helper.
- Migrates `network_notes_counter_contract.rs` to the same shared helper while preserving its separate network-note polling delay.
- Migrates `unauthenticated_note_transfer.rs` to the shared helper as well, removing another identical polling implementation and its now-unused imports.
- Keeps runnable tutorial behavior the same while reducing repeated boilerplate.

## Why

This advances #194 by moving repeated utility code into shared tutorial infrastructure so examples can focus on the protocol/client concept being demonstrated.

## Scope

This PR stays focused on the duplicated `wait_for_tx` path and three existing runnable consumers, establishing the shared helper without mixing in broader setup refactors.

Closes part of #194.