### PR TITLE
fix: use procref for FPI procedure roots

### DIFF
--- a/masm/scripts/reader_script.masm
+++ b/masm/scripts/reader_script.masm
@@ -1,18 +1,19 @@
 use external_contract::count_reader_contract
+use external_contract::counter_contract
 use miden::core::sys
 
 begin
     padw padw padw padw
     # => [pad(16)]
 
-    push.{get_count_proc_hash}
-    # => [GET_COUNT_HASH, pad(16)]
+    procref.counter_contract::get_count
+    # => [GET_COUNT_ROOT, pad(16)]
 
     push.{account_id_prefix}
-    # => [account_id_prefix, GET_COUNT_HASH, pad(16)]
+    # => [account_id_prefix, GET_COUNT_ROOT, pad(16)]
 
     push.{account_id_suffix}
-    # => [account_id_suffix, account_id_prefix, GET_COUNT_HASH, pad(16)]
+    # => [account_id_suffix, account_id_prefix, GET_COUNT_ROOT, pad(16)]
 
     call.count_reader_contract::copy_count
     # => []

--- a/rust-client/src/bin/counter_contract_fpi.rs
+++ b/rust-client/src/bin/counter_contract_fpi.rs
@@ -120,34 +120,14 @@ async fn main() -> Result<(), ClientError> {
     // -------------------------------------------------------------------------
     println!("\n[STEP 3] Call counter contract with FPI from count reader contract");
 
+    // Link the local counter module so the MASM script can resolve
+    // `procref.counter_contract::get_count` directly.
     let counter_contract_code = include_str!("../../../masm/accounts/counter.masm");
 
-    // Compile the counter as a component (same path as the deploy binary) to get
-    // the correct procedure root that matches the on-chain MAST.
-    let counter_component_code = client
-        .code_builder()
-        .compile_component_code("external_contract::counter_contract", counter_contract_code)
-        .unwrap();
-    let counter_component = AccountComponent::new(
-        counter_component_code,
-        vec![],
-        AccountComponentMetadata::new("external_contract::counter_contract"),
-    )
-    .unwrap();
-
-    let get_count_root = counter_component
-        .component_code()
-        .as_library()
-        .get_procedure_root_by_path("external_contract::counter_contract::get_count")
-        .expect("get_count export not found");
-    let get_count_hash = format!("{}", get_count_root);
-
-    println!("get_count hash: {:?}", get_count_hash);
     println!("counter id prefix: {:?}", counter_contract_id.prefix());
     println!("counter id suffix: {:?}", counter_contract_id.suffix());
 
     let script_code = include_str!("../../../masm/scripts/reader_script.masm")
-        .replace("{get_count_proc_hash}", &get_count_hash)
         .replace(
             "{account_id_suffix}",
             &counter_contract_id.suffix().as_canonical_u64().to_string(),
@@ -157,11 +137,14 @@ async fn main() -> Result<(), ClientError> {
             &u64::from(counter_contract_id.prefix()).to_string(),
         );
 
-    // Link the count reader contract code into the same `CodeBuilder` chain
-    // that compiles the script.
+    // Link both modules into the same `CodeBuilder` chain that compiles the
+    // script. This lets MASM resolve the `procref` without formatting a
+    // procedure digest into the source string at runtime.
     let tx_script = client
         .code_builder()
         .with_linked_module("external_contract::count_reader_contract", count_reader_code)
+        .unwrap()
+        .with_linked_module("external_contract::counter_contract", counter_contract_code)
         .unwrap()
         .compile_tx_script(script_code.as_str())
         .unwrap();


### PR DESCRIPTION
Advances #122 by removing runtime string formatting for the `get_count` procedure digest in the runnable Rust FPI example.

- uses `procref.counter_contract::get_count` in `reader_script.masm`
- links the counter module into the same `CodeBuilder` chain as the count-reader module
- removes the extra component compilation and manual procedure-root lookup from `counter_contract_fpi.rs`

This keeps account-id substitution unchanged while letting MASM resolve the procedure root directly from the linked module.