### PR TITLE
docs: fix broken next-page links in the miden-bank tutorial

### DIFF
--- a/docs/src/miden-bank/00-project-setup.md
+++ b/docs/src/miden-bank/00-project-setup.md
@@ -381,4 +381,4 @@ Your bank can be created, but doesn't do anything useful yet. In the next parts,
 
 ## Next Steps
 
-Now that your project is set up, let's dive deeper into account components and storage in [Part 1: Account Components and Storage](./account-components).
+Now that your project is set up, let's dive deeper into account components and storage in [Part 1: Account Components and Storage](./01-account-components.md).

--- a/docs/src/miden-bank/01-account-components.md
+++ b/docs/src/miden-bank/01-account-components.md
@@ -505,4 +505,4 @@ See the complete bank account implementation in [contracts/bank-account/src/lib.
 
 ## Next Steps
 
-Now that you understand account components and storage, let's learn how to define business rules with [Part 2: Constants and Constraints](./constants-constraints).
+Now that you understand account components and storage, let's learn how to define business rules with [Part 2: Constants and Constraints](./02-constants-constraints.md).

--- a/docs/src/miden-bank/02-constants-constraints.md
+++ b/docs/src/miden-bank/02-constants-constraints.md
@@ -511,4 +511,4 @@ See the complete constraint implementation in [contracts/bank-account/src/lib.rs
 
 ## Next Steps
 
-Now that you can define and enforce business rules, let's learn how to handle assets in [Part 3: Asset Management](./asset-management).
+Now that you can define and enforce business rules, let's learn how to handle assets in [Part 3: Asset Management](./03-asset-management.md).

--- a/docs/src/miden-bank/03-asset-management.md
+++ b/docs/src/miden-bank/03-asset-management.md
@@ -757,4 +757,4 @@ See the complete deposit and withdraw implementations in [contracts/bank-account
 
 ## Next Steps
 
-Now that you understand asset management, let's learn how to trigger these operations with [Part 4: Note Scripts](./note-scripts).
+Now that you understand asset management, let's learn how to trigger these operations with [Part 4: Note Scripts](./04-note-scripts.md).

--- a/docs/src/miden-bank/04-note-scripts.md
+++ b/docs/src/miden-bank/04-note-scripts.md
@@ -161,7 +161,7 @@ impl DepositNote {
 ```
 
 :::info Cross-Component Calls
-The `#[account(bank_account::Bank)] pub struct Wallet;` declaration and the `account.deposit(...)` call use Miden's cross-component binding system. The `#[account(...)]` macro wraps the consuming account so the note can call the bank's `Bank` methods directly. We'll explain exactly how this works in [Part 5: Cross-Component Calls](./cross-component-calls). For now, just know that building `bank-account` first generates the WIT files that `deposit-note` binds against.
+The `#[account(bank_account::Bank)] pub struct Wallet;` declaration and the `account.deposit(...)` call use Miden's cross-component binding system. The `#[account(...)]` macro wraps the consuming account so the note can call the bank's `Bank` methods directly. We'll explain exactly how this works in [Part 5: Cross-Component Calls](./05-cross-component-calls.md). For now, just know that building `bank-account` first generates the WIT files that `deposit-note` binds against.
 :::
 
 ### The #[note] and #[note_script] Attributes
@@ -573,4 +573,4 @@ See the complete note script implementations:
 
 ## Next Steps
 
-Now that you understand note scripts, let's learn how they call account methods in [Part 5: Cross-Component Calls](./cross-component-calls).
+Now that you understand note scripts, let's learn how they call account methods in [Part 5: Cross-Component Calls](./05-cross-component-calls.md).

--- a/docs/src/miden-bank/05-cross-component-calls.md
+++ b/docs/src/miden-bank/05-cross-component-calls.md
@@ -319,4 +319,4 @@ See the complete `miden-project.toml` configurations:
 
 ## Next Steps
 
-Now that you understand cross-component calls, let's create the transaction script that initializes the bank in [Part 6: Transaction Scripts](./transaction-scripts).
+Now that you understand cross-component calls, let's create the transaction script that initializes the bank in [Part 6: Transaction Scripts](./06-transaction-scripts.md).

--- a/docs/src/miden-bank/06-transaction-scripts.md
+++ b/docs/src/miden-bank/06-transaction-scripts.md
@@ -576,4 +576,4 @@ See the complete transaction script implementation in [contracts/init-tx-script/
 
 ## Next Steps
 
-Now that you understand transaction scripts, let's learn the advanced topic of creating output notes in [Part 7: Creating Output Notes](./output-notes).
+Now that you understand transaction scripts, let's learn the advanced topic of creating output notes in [Part 7: Creating Output Notes](./07-output-notes.md).

--- a/docs/src/miden-bank/07-output-notes.md
+++ b/docs/src/miden-bank/07-output-notes.md
@@ -827,4 +827,4 @@ See the complete implementation in the [examples/miden-bank](https://github.com/
 
 ## Next Steps
 
-Now that you've built all the components, let's see how they work together in [Part 8: Complete Flows](./complete-flows).
+Now that you've built all the components, let's see how they work together in [Part 8: Complete Flows](./08-complete-flows.md).


### PR DESCRIPTION
## Summary

The "next part" navigation links in the miden-bank tutorial series point to extension-less, un-prefixed targets (e.g. `[Part 1: Account Components and Storage](./account-components)`) that don't resolve to any file, so they 404 in the rendered book.

This points each link at the actual chapter file (`./01-account-components.md`, `./02-constants-constraints.md`, …), matching the working cross-references already used elsewhere in the series.

## Changes

Fixed 9 links across 8 files (chapters 00 → 07), each now targeting the correct numbered `.md` chapter. Markdown is Prettier-clean.