### PR TITLE
fix(miden-bank): avoid deposit namespace collision

### DIFF
--- a/docs/src/miden-bank/02-constants-constraints.md
+++ b/docs/src/miden-bank/02-constants-constraints.md
@@ -29,7 +29,7 @@ Part 1:                          Part 2:
 │ ────────────────────────│ ──►  │ ────────────────────────│
 │ + initialize()          │      │ + initialize()          │
 │ + get_depositor_balance()│     │ + get_depositor_balance()│
-│                         │      │ + deposit()             │ ◄── NEW (skeleton)
+│                         │      │ + bank_deposit()        │ ◄── NEW (skeleton)
 │                         │      │ + MAX_DEPOSIT_AMOUNT    │ ◄── NEW constant
 │                         │      │ + MAX_BALANCE           │ ◄── NEW constant
 └─────────────────────────┘      └─────────────────────────┘

--- a/docs/src/miden-bank/03-asset-management.md
+++ b/docs/src/miden-bank/03-asset-management.md
@@ -27,7 +27,7 @@ Part 2:                          Part 3:
 ┌──────────────────┐             ┌──────────────────┐
 │ Bank             │             │ Bank             │
 │ ─────────────────│    ──►      │ ─────────────────│
-│ + deposit()      │             │ + deposit()      │ ◄── COMPLETE
+│ + bank_deposit() │             │ + bank_deposit() │ ◄── COMPLETE
 │   (skeleton)     │             │   + balance tracking
 │                  │             │   + vault operations
 │                  │             │ + withdraw()     │ ◄── NEW (skeleton)

--- a/docs/src/miden-bank/04-note-scripts.md
+++ b/docs/src/miden-bank/04-note-scripts.md
@@ -28,7 +28,7 @@ Part 3:                          Part 4:
 ┌──────────────────┐             ┌──────────────────┐
 │ Bank (complete)  │             │ Bank (complete)  │
 │ ─────────────────│             │ ─────────────────│
-│ + deposit()      │             │ + deposit()      │
+│ + bank_deposit() │             │ + bank_deposit() │
 │ + withdraw()     │             │ + withdraw()     │
 └──────────────────┘             └──────────────────┘
                                           ▲
@@ -258,9 +258,9 @@ The Miden compiler prints non-fatal `ERROR` lines about `MAST` serialization on 
 3. Note script runs
    depositor = get_sender()  → User's AccountId
    assets = get_assets()     → [100 tokens]
-   account.deposit(depositor, 100 tokens)
+   account.bank_deposit(depositor, 100 tokens)
 
-4. Bank's deposit() method executes
+4. Bank's bank_deposit() method executes
    - Validates initialization and amount
    - Updates balance: balances[User] += 100
    - Adds asset to vault

--- a/docs/src/miden-bank/05-cross-component-calls.md
+++ b/docs/src/miden-bank/05-cross-component-calls.md
@@ -19,7 +19,7 @@ By the end of this section, you will have:
 
 ## Building on Part 4
 
-In Part 4, you wrote `account.deposit(depositor, asset)` in the deposit note. But how does that call actually work? This part explains the binding system:
+In Part 4, you wrote `account.bank_deposit(depositor, asset)` in the deposit note. But how does that call actually work? This part explains the binding system:
 
 ```text
 ┌────────────────────────────────────────────────────────────┐
@@ -28,7 +28,7 @@ In Part 4, you wrote `account.deposit(depositor, asset)` in the deposit note. Bu
 │                                                            │
 │   bank-account/                                            │
 │   └── src/lib.rs         miden build                       │
-│       fn deposit()      ─────────────▶  generated-wit/     │
+│       fn bank_deposit()      ─────────────▶  generated-wit/     │
 │       fn withdraw()                      miden-bank-account.wit
 │                                                            │
 │                              ┌───────────────────────────┐ │
@@ -37,7 +37,7 @@ In Part 4, you wrote `account.deposit(depositor, asset)` in the deposit note. Bu
 │   └── src/lib.rs                                         │ │
 │       #[account(bank_account::Bank)]                     │ │
 │       pub struct Wallet;                                 │ │
-│       account.deposit(...)  ────────────▶ calls via binding│
+│       account.bank_deposit(...)  ────────────▶ calls via binding│
 │                                                            │
 └────────────────────────────────────────────────────────────┘
 ```
@@ -112,7 +112,7 @@ impl DepositNote {
 
         // Deposit each asset into the bank
         for asset in assets {
-            account.deposit(depositor, asset);
+            account.bank_deposit(depositor, asset);
         }
     }
 }
@@ -265,7 +265,7 @@ miden-bank-account.wit
 
 </details>
 
-These files enable the deposit note's `#[account(bank_account::Bank)]` wrapper to call `account.deposit()`.
+These files enable the deposit note's `#[account(bank_account::Bank)]` wrapper to call `account.bank_deposit()`.
 
 ## Common Issues
 

--- a/docs/src/miden-bank/06-transaction-scripts.md
+++ b/docs/src/miden-bank/06-transaction-scripts.md
@@ -33,7 +33,7 @@ In Parts 4-5, you created note scripts that execute when notes are consumed. Now
 │   • Process incoming assets         • Setup, admin operations   │
 │                                                                 │
 │   deposit-note/                     init-tx-script/             │
-│   └── calls bank_account::deposit() └── calls account.initialize()
+│   └── calls bank_account::bank_deposit() └── calls account.initialize()
 │                                                                 │
 └────────────────────────────────────────────────────────────────┘
 ```

--- a/docs/src/miden-bank/07-output-notes.md
+++ b/docs/src/miden-bank/07-output-notes.md
@@ -93,7 +93,7 @@ impl Bank for BankStorage {
         // bound to the note metadata, so it cannot be spoofed by a malicious caller.
         let depositor = active_note::get_sender();
 
-        // Verify this is a fungible asset — see `deposit()` for the rationale.
+        // Verify this is a fungible asset — see `bank_deposit()` for the rationale.
         assert!(
             withdraw_asset.value[1].as_canonical_u64() == 0,
             "Only fungible assets are supported"
@@ -131,7 +131,7 @@ impl Bank for BankStorage {
 }
 ```
 
-The withdraw method derives the balance-map key inline by packing `depositor.prefix`, `depositor.suffix`, `withdraw_asset.key[3]`, and `withdraw_asset.key[2]` into a `Word`. In the v0.15 fungible-asset vault-key layout, `asset.key[3]` is the faucet id prefix and `asset.key[2]` is the faucet id suffix with the asset's metadata byte folded into its low 8 bits — so `key[2]` is NOT the raw faucet suffix. `withdraw()` and `deposit()` derive the key the same way so a withdrawal reconstructs the exact key the deposit was recorded under.
+The withdraw method derives the balance-map key inline by packing `depositor.prefix`, `depositor.suffix`, `withdraw_asset.key[3]`, and `withdraw_asset.key[2]` into a `Word`. In the v0.15 fungible-asset vault-key layout, `asset.key[3]` is the faucet id prefix and `asset.key[2]` is the faucet id suffix with the asset's metadata byte folded into its low 8 bits — so `key[2]` is NOT the raw faucet suffix. `withdraw()` and `bank_deposit()` derive the key the same way so a withdrawal reconstructs the exact key the deposit was recorded under.
 
 :::danger Critical Security: Balance Validation
 Always validate `current_balance >= withdraw_amount` BEFORE subtraction. Miden uses modular field arithmetic - subtracting a larger value silently wraps to a massive positive number!

--- a/docs/src/miden-bank/08-complete-flows.md
+++ b/docs/src/miden-bank/08-complete-flows.md
@@ -28,9 +28,9 @@ You've built all the pieces. Now let's see them work together:
 │                                                                 │
 │   Components Built:                                             │
 │   ┌─────────────────────────────────────────────────────────┐  │
-│   │ bank-account    │ Storage + deposit() + withdraw()       │  │
+│   │ bank-account    │ Storage + bank_deposit() + withdraw()       │  │
 │   ├─────────────────┼───────────────────────────────────────┤  │
-│   │ deposit-note    │ Note script → bank_account::deposit()  │  │
+│   │ deposit-note    │ Note script → bank_account::bank_deposit()  │  │
 │   ├─────────────────┼───────────────────────────────────────┤  │
 │   │ withdraw-note   │ Note script → bank_account::withdraw() │  │
 │   ├─────────────────┼───────────────────────────────────────┤  │

--- a/examples/miden-bank/contracts/bank-account/src/lib.rs
+++ b/examples/miden-bank/contracts/bank-account/src/lib.rs
@@ -103,7 +103,7 @@ trait Bank {
     /// Panics if the deposit amount exceeds `MAX_DEPOSIT_AMOUNT`.
     /// Panics if the resulting balance would exceed `MAX_BALANCE` (u64 overflow).
     /// Panics if the bank has not been initialized.
-    fn deposit(&mut self, depositor: AccountId, deposit_asset: Asset);
+    fn bank_deposit(&mut self, depositor: AccountId, deposit_asset: Asset);
 
     /// Withdraw assets back to the depositor.
     ///
@@ -153,7 +153,7 @@ impl Bank for BankStorage {
         self.balances.get(key)
     }
 
-    fn deposit(&mut self, depositor: AccountId, deposit_asset: Asset) {
+    fn bank_deposit(&mut self, depositor: AccountId, deposit_asset: Asset) {
         // Ensure the bank is initialized before accepting deposits
         self.require_initialized();
 

--- a/examples/miden-bank/contracts/deposit-note/src/lib.rs
+++ b/examples/miden-bank/contracts/deposit-note/src/lib.rs
@@ -18,7 +18,7 @@ pub struct Wallet;
 /// 1. Note is created by a user with fungible assets attached
 /// 2. Bank account consumes this note
 /// 3. Note script reads the sender (depositor) and assets
-/// 4. For each asset, calls `account.deposit(depositor, asset)`
+/// 4. For each asset, calls `account.bank_deposit(depositor, asset)`
 /// 5. Bank receives the asset and updates the depositor's balance
 ///
 /// # Note Inputs
@@ -38,7 +38,7 @@ impl DepositNote {
 
         // Deposit each asset into the bank
         for asset in assets {
-            account.deposit(depositor, asset);
+            account.bank_deposit(depositor, asset);
         }
     }
 }


### PR DESCRIPTION
## Summary

Renames the Miden Bank account method from `deposit()` to `bank_deposit()` to avoid the namespace collision with the deposit note component.

## Changes

- Renamed the `Bank::deposit()` method to `Bank::bank_deposit()`
- Updated the bank account implementation
- Updated the deposit-note cross-component call
- Updated all related Miden Bank tutorial documentation and diagrams
- Kept `withdraw()` unchanged

This makes the bank account method explicit while avoiding the `deposit` namespace collision between components.