### PR TITLE
docs: fix stack comments in counter.masm

### DIFF
--- a/masm/accounts/counter.masm
+++ b/masm/accounts/counter.masm
@@ -6,27 +6,27 @@ use miden::core::sys
 const COUNTER_SLOT = word("miden::tutorials::counter")
 
 #! Inputs:  []
-#! Outputs: [count]
+#! Outputs: [COUNT]
 pub proc get_count
     push.COUNTER_SLOT[0..2] exec.active_account::get_item
-    # => [count]
+    # => [COUNT]
 
     exec.sys::truncate_stack
-    # => [count]
+    # => [COUNT]
 end
 
 #! Inputs:  []
-#! Outputs: []
+#! Outputs: [OLD_COUNT]
 pub proc increment_count
     push.COUNTER_SLOT[0..2] exec.active_account::get_item
-    # => [count]
+    # => [COUNT]
 
     add.1
-    # => [count+1]
+    # => [COUNT+1]
 
     push.COUNTER_SLOT[0..2] exec.native_account::set_item
-    # => []
+    # => [OLD_COUNT]
 
     exec.sys::truncate_stack
-    # => []
+    # => [OLD_COUNT]
 end


### PR DESCRIPTION
`counter.masm` is the first contract most people read, and its stack comments don't match what the procedures actually leave on the stack.

Per the protocol docstrings:

- `active_account::get_item` — `Inputs: [slot_id_suffix, slot_id_prefix]` → `Outputs: [VALUE]`, a word.
- `native_account::set_item` — `Inputs: [slot_id_suffix, slot_id_prefix, VALUE]` → `Outputs: [OLD_VALUE]`, also a word.

And `sys::truncate_stack` only removes elements *below* the top 16 ("the top 16 elements of the stack remain unchanged"), so it doesn't clear `OLD_VALUE` either.

That makes two comments in `increment_count` wrong rather than merely abbreviated: it is documented as `Outputs: []` and `# => []`, but it actually leaves the previous count on the stack. `get_count` is documented as returning `[count]` where `get_item` returns a full word.

The other account modules in this repo already get this right — `count_reader.masm` documents `# => [OLD_VALUE, pad(12)]` and `mapping_example_contract.masm` documents `# => [OLD_VALUE]` / `# => [VALUE]` — so this just brings `counter.masm` in line with its siblings.

Comments only; no behavioural change.

One thing I deliberately left alone: `increment_count` returning `OLD_COUNT` looks incidental rather than intended. If it should return nothing, a `dropw` after `set_item` would do it — happy to add that instead if you'd prefer the code change over the comment change.
