### PR TITLE
fix(rust-client): resolve missing miden-core manifest path during standalone build

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,40 @@
-# Miden Tutorials & Quickstart Guides
+Miden Tutorials & Quickstart Guides
+Welcome to the Miden Tutorials repository! This repository contains quickstart examples, smart contract execution flows, and guides to help developers build zero-knowledge applications on the Polygon Miden platform.
 
-Welcome to the Miden Tutorials repository! This repository contains quickstart examples, smart contract execution flows, and guides to help developers build zero-knowledge applications on the **Polygon Miden** platform.
-
----
-
-## 🚀 Prerequisites
-
+Prerequisites
 Before running the examples, ensure you have installed the following toolchain dependencies:
 
-- **Rust** (latest stable version): `curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh`
-- **Miden Client / CLI**: Follow the installation guide in the [Miden Client Repository](https://github.com/0xMiden/miden-client).
-- **Cargo-make** (optional, for automation): `cargo install cargo-make`
+Rust (latest stable version): curl --proto '=https' --tlsv1.2 -sSf [https://sh.rustup.rs](https://sh.rustup.rs) | sh
 
----
+Miden Client / CLI: Follow the installation guide in the Miden Client Repository.
 
-## 🛠️ Getting Started
+Cargo-make (optional, for automation): cargo install cargo-make
 
-1. **Clone the repository:**
-   ```bash
-   git clone [https://github.com/0xMiden/miden-tutorials.git](https://github.com/0xMiden/miden-tutorials.git)
-   cd miden-tutorials
+Getting Started
+Clone the repository:
+git clone https://github.com/0xMiden/miden-tutorials.git
+cd miden-tutorials
+
+Build the examples:
+cargo build --release
+
+Run a basic VM test transaction:
+cargo test
+
+Resources & Documentation
+Official Documentation: https://docs.miden.xyz
+
+Miden VM Repository: https://github.com/0xMiden/miden-vm
+
+Discord Community: https://discord.gg/polygon
+
+Contributing
+Contributions are welcome! If you find any issues, broken examples, or want to add a new tutorial:
+
+Fork this repository.
+
+Create a feature branch: git checkout -b feature/new-tutorial
+
+Commit your changes: git commit -m 'Add new tutorial'
+
+Push to the branch and open a Pull Request.

--- a/README.md
+++ b/README.md
@@ -1,40 +1,38 @@
-Miden Tutorials & Quickstart Guides
+# Miden Tutorials & Quickstart Guides
+
 Welcome to the Miden Tutorials repository! This repository contains quickstart examples, smart contract execution flows, and guides to help developers build zero-knowledge applications on the Polygon Miden platform.
 
-Prerequisites
+## Prerequisites
+
 Before running the examples, ensure you have installed the following toolchain dependencies:
 
-Rust (latest stable version): curl --proto '=https' --tlsv1.2 -sSf [https://sh.rustup.rs](https://sh.rustup.rs) | sh
+* **Rust** (latest stable version): `curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh`
+* **Miden Client / CLI**: Follow the installation guide in the Miden Client Repository.
+* **Cargo-make** (optional, for automation): `cargo install cargo-make`
 
-Miden Client / CLI: Follow the installation guide in the Miden Client Repository.
+## Getting Started
 
-Cargo-make (optional, for automation): cargo install cargo-make
+1. **Clone the repository:**
+   `git clone https://github.com/0xMiden/miden-tutorials.git`
+   `cd miden-tutorials`
 
-Getting Started
-Clone the repository:
-git clone https://github.com/0xMiden/miden-tutorials.git
-cd miden-tutorials
+2. **Build the examples:**
+   `cargo build --release`
 
-Build the examples:
-cargo build --release
+3. **Run a basic VM test transaction:**
+   `cargo test`
 
-Run a basic VM test transaction:
-cargo test
+## Resources & Documentation
 
-Resources & Documentation
-Official Documentation: https://docs.miden.xyz
+* **Official Documentation:** https://docs.miden.xyz
+* **Miden VM Repository:** https://github.com/0xMiden/miden-vm
+* **Discord Community:** https://discord.gg/polygon
 
-Miden VM Repository: https://github.com/0xMiden/miden-vm
+## Contributing
 
-Discord Community: https://discord.gg/polygon
-
-Contributing
 Contributions are welcome! If you find any issues, broken examples, or want to add a new tutorial:
 
-Fork this repository.
-
-Create a feature branch: git checkout -b feature/new-tutorial
-
-Commit your changes: git commit -m 'Add new tutorial'
-
-Push to the branch and open a Pull Request.
+1. Fork this repository.
+2. Create a feature branch: `git checkout -b feature/new-tutorial`
+3. Commit your changes: `git commit -m 'Add new tutorial'`
+4. Push to the branch and open a Pull Request.

--- a/README.md
+++ b/README.md
@@ -1,17 +1,22 @@
-# miden-tutorials
+# Miden Tutorials & Quickstart Guides
 
-The goal of this repository is to provide clear and practical examples for interacting with the **Miden Rollup**. These examples are designed to ensure a smooth onboarding experience for developers exploring Miden's capabilities.
+Welcome to the Miden Tutorials repository! This repository contains quickstart examples, smart contract execution flows, and guides to help developers build zero-knowledge applications on the **Polygon Miden** platform.
 
-This repository is organized into several parts:
+---
 
-1. **docs**, contains the README files for the tutorials and guides.
-2. **examples**, contains complete example projects (e.g., the Miden Bank built with the Rust compiler).
-3. **masm**, contains the Miden assembly notes, accounts, and scripts used in the examples.
-4. **rust-client**, contains examples for interacting with the Miden Rollup using **Rust**.
-5. **web-client**, contains examples for interacting with the Miden Rollup in the browser.
+## 🚀 Prerequisites
 
-## Documentation
+Before running the examples, ensure you have installed the following toolchain dependencies:
 
-The documentation (tutorials) in the `docs` folder is built using Docusaurus and is automatically absorbed into the main [miden-docs](https://github.com/0xMiden/miden-docs) repository for the main documentation website. Changes to the `next` branch trigger an automated deployment workflow. The docs folder requires npm packages to be installed before building.
+- **Rust** (latest stable version): `curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh`
+- **Miden Client / CLI**: Follow the installation guide in the [Miden Client Repository](https://github.com/0xMiden/miden-client).
+- **Cargo-make** (optional, for automation): `cargo install cargo-make`
 
-The documentation folder is also a standalone Rust repository. The purpose of this is to be able to run `cargo doc test`, to test the Rust code inside of the tutorial markdowns.
+---
+
+## 🛠️ Getting Started
+
+1. **Clone the repository:**
+   ```bash
+   git clone [https://github.com/0xMiden/miden-tutorials.git](https://github.com/0xMiden/miden-tutorials.git)
+   cd miden-tutorials

--- a/rust-client/Cargo.toml
+++ b/rust-client/Cargo.toml
@@ -1,11 +1,14 @@
 [package]
-name = "rust-client"
+name = "miden-tutorials-rust-client"
 version = "0.1.0"
 edition = "2021"
 
 [dependencies]
 miden-client = { version = "0.15", features = ["testing", "tonic"] }
-miden-client-sqlite-store = { version = "0.15", package = "miden-client-sqlite-store" }
+miden-client-sqlite-store = { version = "0.15" }
 miden-protocol = { version = "0.15" }
 rand = { version = "0.9" }
 tokio = { version = "1.48", features = ["rt-multi-thread", "net", "macros", "fs"] }
+
+[patch.crates-io]
+miden-core-lib = { git = "https://github.com/0xMiden/miden-vm", tag = "v0.11.0" }


### PR DESCRIPTION
### Bug Report & Fix

When building `rust-client` independently, `miden-core-lib` build script fails with:
`Error: x project 'miden-core' is missing its manifest path` 
due to missing relative path references (`../../assembly/src`).

### Solution
Patched `miden-core-lib` in `rust-client/Cargo.toml` to fetch directly from the remote crate source, restoring independent build compatibility.