### PR TITLE
chore: migrate tutorials to Miden SDK v0.16

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,4 +14,4 @@ This repository is organized into several parts:
 
 The documentation (tutorials) in the `docs` folder is built using Docusaurus and is automatically absorbed into the main [miden-docs](https://github.com/0xMiden/miden-docs) repository for the main documentation website. Changes to the `next` branch trigger an automated deployment workflow. The docs folder requires npm packages to be installed before building.
 
-The documentation folder is also a standalone Rust repository. The purpose of this is to be able to run `cargo doc test`, to test the Rust code inside of the tutorial markdowns.
+The documentation folder is also a Rust crate. Run `cargo test --doc` inside `docs/` to check the Rust examples in the tutorial markdowns.

--- a/docs/Cargo.lock
+++ b/docs/Cargo.lock
@@ -19,12 +19,12 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aead"
-version = "0.5.2"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+checksum = "1973cfbc1a2daf9cf550e74e1f088c28e7f7d8c1e1418fb6c9dc5184b7e84c99"
 dependencies = [
- "crypto-common",
- "generic-array",
+ "crypto-common 0.2.2",
+ "inout",
 ]
 
 [[package]]
@@ -50,7 +50,17 @@ dependencies = [
  "paste",
  "ruint",
  "rustc-hash",
- "sha3",
+ "sha3 0.10.8",
+]
+
+[[package]]
+name = "alloy-rlp"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24671b1f62edcf0f9b62994c7bf72cd621a04a4b99f5020ece1a647b40e2f103"
+dependencies = [
+ "arrayvec",
+ "bytes",
 ]
 
 [[package]]
@@ -76,11 +86,11 @@ dependencies = [
  "alloy-sol-macro-input",
  "const-hex",
  "heck",
- "indexmap",
+ "indexmap 2.14.0",
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "sha3",
+ "sha3 0.10.8",
  "syn 2.0.115",
  "syn-solidity",
 ]
@@ -180,6 +190,269 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-ff"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b3235cc41ee7a12aaaf2c575a2ad7b46713a8a50bda2fc3b003a04845c05dd6"
+dependencies = [
+ "ark-ff-asm 0.3.0",
+ "ark-ff-macros 0.3.0",
+ "ark-serialize 0.3.0",
+ "ark-std 0.3.0",
+ "derivative",
+ "num-bigint 0.4.6",
+ "num-traits",
+ "paste",
+ "rustc_version 0.3.3",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec847af850f44ad29048935519032c33da8aa03340876d351dfab5660d2966ba"
+dependencies = [
+ "ark-ff-asm 0.4.2",
+ "ark-ff-macros 0.4.2",
+ "ark-serialize 0.4.2",
+ "ark-std 0.4.0",
+ "derivative",
+ "digest 0.10.7",
+ "itertools 0.10.5",
+ "num-bigint 0.4.6",
+ "num-traits",
+ "paste",
+ "rustc_version 0.4.1",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a177aba0ed1e0fbb62aa9f6d0502e9b46dad8c2eab04c14258a1212d2557ea70"
+dependencies = [
+ "ark-ff-asm 0.5.0",
+ "ark-ff-macros 0.5.0",
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
+ "arrayvec",
+ "digest 0.10.7",
+ "educe",
+ "itertools 0.13.0",
+ "num-bigint 0.4.6",
+ "num-traits",
+ "paste",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7a806ac6c8307b929df4645776290a50ee2aac754ad09d8bdf73391309e43af"
+dependencies = [
+ "ark-ff-asm 0.6.0",
+ "ark-ff-macros 0.6.0",
+ "ark-serialize 0.6.0",
+ "ark-std 0.6.0",
+ "digest 0.10.7",
+ "educe",
+ "num-bigint 0.4.6",
+ "num-traits",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db02d390bf6643fb404d3d22d31aee1c4bc4459600aef9113833d17e786c6e44"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed4aa4fe255d0bc6d79373f7e31d2ea147bcf486cba1be5ba7ea85abdb92348"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62945a2f7e6de02a31fe400aa489f0e0f5b2502e69f95f853adb82a96c7a6b60"
+dependencies = [
+ "quote",
+ "syn 2.0.115",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1479009684adc073dff49a1025d3a7065b317a9ead25aaaca38cdc70058ba8a2"
+dependencies = [
+ "quote",
+ "syn 2.0.115",
+]
+
+[[package]]
+name = "ark-ff-macros"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db2fd794a08ccb318058009eefdf15bcaaaaf6f8161eb3345f907222bac38b20"
+dependencies = [
+ "num-bigint 0.4.6",
+ "num-traits",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-ff-macros"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7abe79b0e4288889c4574159ab790824d0033b9fdcb2a112a3182fac2e514565"
+dependencies = [
+ "num-bigint 0.4.6",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-ff-macros"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09be120733ee33f7693ceaa202ca41accd5653b779563608f1234f78ae07c4b3"
+dependencies = [
+ "num-bigint 0.4.6",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.115",
+]
+
+[[package]]
+name = "ark-ff-macros"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a0691ed21ef00ef89c1e9bda832eba493dda3ec2f8d892fb25b705f73f06bb8"
+dependencies = [
+ "num-bigint 0.4.6",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.115",
+]
+
+[[package]]
+name = "ark-serialize"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d6c2b318ee6e10f8c2853e73a83adc0ccb88995aa978d8a3408d492ab2ee671"
+dependencies = [
+ "ark-std 0.3.0",
+ "digest 0.9.0",
+]
+
+[[package]]
+name = "ark-serialize"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
+dependencies = [
+ "ark-std 0.4.0",
+ "digest 0.10.7",
+ "num-bigint 0.4.6",
+]
+
+[[package]]
+name = "ark-serialize"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f4d068aaf107ebcd7dfb52bc748f8030e0fc930ac8e360146ca54c1203088f7"
+dependencies = [
+ "ark-std 0.5.0",
+ "arrayvec",
+ "digest 0.10.7",
+ "num-bigint 0.4.6",
+]
+
+[[package]]
+name = "ark-serialize"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a74dd304fd536fb95d0a328e72be759209cc496a9da094c5bc56e5fea4f9e86b"
+dependencies = [
+ "ark-serialize-derive",
+ "ark-std 0.6.0",
+ "digest 0.10.7",
+ "num-bigint 0.4.6",
+ "serde_with",
+]
+
+[[package]]
+name = "ark-serialize-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f153690697a2b91e5e1251ff98411ee5371500a111a0fd317a70e588eb300f9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.115",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1df2c09229cbc5a028b1d70e00fdb2acee28b1055dfb5ca73eea49c5a25c4e7c"
+dependencies = [
+ "num-traits",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
+dependencies = [
+ "num-traits",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "246a225cc6131e9ee4f24619af0f19d67761fff15d7ccc22e42b80846e69449a"
+dependencies = [
+ "num-traits",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "367c9c827ed431bff6868b7aa926e05b16eb46603cc8b6e768e4a5553fa1d155"
+dependencies = [
+ "num-traits",
+ "rand 0.8.5",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -190,15 +463,6 @@ name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
-
-[[package]]
-name = "ascii-canvas"
-version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef1e3e699d84ab1b0911a1010c5c106aa34ae89aeac103be5ce0c3859db1e891"
-dependencies = [
- "term",
-]
 
 [[package]]
 name = "async-trait"
@@ -216,6 +480,17 @@ name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "auto_impl"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffdcb70bdbc4d478427380519163274ac86e52916e10f0a8889adf0f96d3fee7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.115",
+]
 
 [[package]]
 name = "autocfg"
@@ -249,9 +524,9 @@ dependencies = [
 
 [[package]]
 name = "base16ct"
-version = "0.2.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+checksum = "fd307490d624467aa6f74b0eabb77633d1f758a7b25f12bceb0b22e08d9726f6"
 
 [[package]]
 name = "base64"
@@ -278,34 +553,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
 
 [[package]]
-name = "bincode"
-version = "1.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "bit-set"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
-dependencies = [
- "bit-vec",
-]
-
-[[package]]
-name = "bit-vec"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
-
-[[package]]
 name = "bitflags"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+
+[[package]]
+name = "bitvec"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddcec3d12c579d40898fe0a9a358a803c23e9c52ca3c425707f81c9436211837"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
 
 [[package]]
 name = "blake3"
@@ -327,6 +590,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -355,6 +627,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "build-rs"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -368,6 +649,12 @@ name = "bumpalo"
 version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+
+[[package]]
+name = "byte-slice-cast"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7575182f7272186991736b70173b0ea045398f984bf5ebbb3804736ce1330c9d"
 
 [[package]]
 name = "byteorder"
@@ -400,27 +687,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
-name = "chacha20"
-version = "0.9.1"
+name = "cfg_aliases"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
+
+[[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.0",
 ]
 
 [[package]]
 name = "chacha20poly1305"
-version = "0.10.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+checksum = "9b89e1c441e926b9c82a8d023f6e1b7ae0adcfaa7d621814e4d60789bac751cb"
 dependencies = [
  "aead",
  "chacha20",
  "cipher",
  "poly1305",
- "zeroize",
 ]
 
 [[package]]
@@ -432,20 +725,27 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
+ "serde",
  "wasm-bindgen",
  "windows-link 0.2.1",
 ]
 
 [[package]]
 name = "cipher"
-version = "0.4.4"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
 dependencies = [
- "crypto-common",
+ "block-buffer 0.12.1",
+ "crypto-common 0.2.2",
  "inout",
- "zeroize",
 ]
+
+[[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "codegen"
@@ -453,7 +753,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "573800db6c3319bc125ddbf9b9cb001ad1602957f53642ba8d09ff3ddd4da7f1"
 dependencies = [
- "indexmap",
+ "indexmap 2.14.0",
 ]
 
 [[package]]
@@ -469,16 +769,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "531185e432bb31db1ecda541e9e7ab21468d4d844ad7505e0546a49b4945d49b"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "proptest",
  "serde_core",
 ]
 
 [[package]]
 name = "const-oid"
-version = "0.9.6"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
+name = "const_format"
+version = "0.2.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4481a617ad9a412be3b97c5d403fef8ed023103368908b9c50af598ff467cc1e"
+dependencies = [
+ "const_format_proc_macros",
+ "konst",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d57c2eccfb16dbac1f4e61e206105db5820c9d26c3c472bc17c774259ef7744"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
 
 [[package]]
 name = "constant_time_eq"
@@ -503,10 +824,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpubits"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -550,12 +886,15 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.5.5"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+checksum = "1a52aa3fcda4e6302a9f48734f234d35d4721b96f8fe07d073f07ce9df4f0271"
 dependencies = [
- "generic-array",
- "rand_core 0.6.4",
+ "cpubits",
+ "ctutils",
+ "hybrid-array",
+ "num-traits",
+ "rand_core 0.10.0",
  "subtle",
  "zeroize",
 ]
@@ -567,20 +906,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
- "rand_core 0.6.4",
  "typenum",
 ]
 
 [[package]]
-name = "curve25519-dalek"
-version = "4.1.3"
+name = "crypto-common"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+ "rand_core 0.10.0",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+ "subtle",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5eed333089e2e1c1ac8c6c0398e5e2497b4c9926ca6d0365ed1e099afa5bc23"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.3.0",
  "curve25519-dalek-derive",
- "digest",
+ "digest 0.11.3",
  "fiat-crypto",
  "rustc_version 0.4.1",
  "subtle",
@@ -664,12 +1022,32 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.7.10"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+checksum = "a69dedd701da44b0536442edf09c81a64b0ab97a7a4a5e3d1971f00027cbc63d"
 dependencies = [
  "const-oid",
  "zeroize",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -695,14 +1073,44 @@ dependencies = [
 
 [[package]]
 name = "digest"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.6",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
  "const-oid",
- "crypto-common",
- "subtle",
+ "crypto-common 0.2.2",
+ "ctutils",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -718,24 +1126,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
-name = "ecdsa"
-version = "0.16.9"
+name = "dyn-clone"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "ecdsa"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0681a4fc24c767085329728d8dfba959af91228aa4610cca4f8ce317ba46ae0"
 dependencies = [
  "der",
- "digest",
+ "digest 0.11.3",
  "elliptic-curve",
  "rfc6979",
  "signature",
  "spki",
+ "zeroize",
 ]
 
 [[package]]
 name = "ed25519"
-version = "2.2.3"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+checksum = "29fcf32e6c73d1079f83ab4d782de2d81620346a5f38c6237a86a22f8368980a"
 dependencies = [
  "pkcs8",
  "signature",
@@ -743,16 +1158,29 @@ dependencies = [
 
 [[package]]
 name = "ed25519-dalek"
-version = "2.2.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+checksum = "6ebaa1a2bf1290ab3bfe5a7b771d050ebffab2711c19a81691c683a5144a25de"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
  "serde",
- "sha2",
+ "sha2 0.11.0",
+ "signature",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "educe"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7bc049e1bd8cdeb31b68bbd586a9464ecf9f3944af3958a7a9d0f8b9799417"
+dependencies = [
+ "enum-ordinalize",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -763,31 +1191,43 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.13.8"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+checksum = "9d65aa39b3a5c1c9c1b745c9a019234bb7a21b77abcb4f4d266d706e2d577d65"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "digest",
+ "crypto-common 0.2.2",
+ "digest 0.11.3",
  "ff",
- "generic-array",
  "group",
  "hkdf",
+ "hybrid-array",
  "pkcs8",
- "rand_core 0.6.4",
+ "rand_core 0.10.0",
  "sec1",
  "subtle",
  "zeroize",
 ]
 
 [[package]]
-name = "ena"
-version = "0.14.3"
+name = "enum-ordinalize"
+version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d248bdd43ce613d87415282f69b9bb99d947d290b10962dd6c56233312c2ad5"
+checksum = "89dd01549b09589510cf0647475075d12071456586d70f5c75c98ae2a5537677"
 dependencies = [
- "log",
+ "enum-ordinalize-derive",
+]
+
+[[package]]
+name = "enum-ordinalize-derive"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a65863d15a4ce2888bd2f0f543cc963d3879c3a022c8ee43f6141d479a3ac815"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -859,20 +1299,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
-name = "ff"
-version = "0.13.1"
+name = "fastrlp"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+checksum = "139834ddba373bbdd213dffe02c8d110508dcf1726c2be27e8d1f7d7e1856418"
 dependencies = [
- "rand_core 0.6.4",
+ "arrayvec",
+ "auto_impl",
+ "bytes",
+]
+
+[[package]]
+name = "fastrlp"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce8dba4714ef14b8274c371879b175aa55b16b30f269663f19d576f380018dc4"
+dependencies = [
+ "arrayvec",
+ "auto_impl",
+ "bytes",
+]
+
+[[package]]
+name = "ff"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1f686ab92a9fb0eaf188f6c6c87b89490baa6fdb0db4544ba4dc47f7942489f"
+dependencies = [
+ "rand_core 0.10.0",
  "subtle",
 ]
 
 [[package]]
 name = "fiat-crypto"
-version = "0.2.9"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+checksum = "64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24"
 
 [[package]]
 name = "find-msvc-tools"
@@ -886,6 +1348,9 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
 dependencies = [
+ "byteorder",
+ "rand 0.8.5",
+ "rustc-hex",
  "static_assertions",
 ]
 
@@ -897,13 +1362,10 @@ checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flume"
-version = "0.11.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+checksum = "5e139bc46ca777eb5efaf62df0ab8cc5fd400866427e56c68b22e414e53bd3be"
 dependencies = [
- "futures-core",
- "futures-sink",
- "nanorand",
  "spin 0.9.8",
 ]
 
@@ -920,6 +1382,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
 name = "fs-err"
 version = "3.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -927,6 +1404,12 @@ checksum = "baf68cef89750956493a66a10f512b9e58d9db21f2a573c079c0bdf1207a54a7"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
@@ -1039,7 +1522,6 @@ checksum = "4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2"
 dependencies = [
  "typenum",
  "version_check",
- "zeroize",
 ]
 
 [[package]]
@@ -1079,6 +1561,7 @@ dependencies = [
  "js-sys",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.0",
  "wasip2",
  "wasip3",
  "wasm-bindgen",
@@ -1110,12 +1593,12 @@ dependencies = [
 
 [[package]]
 name = "group"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+checksum = "7fd1a1c7a5206c5b7a3f5a0d7ccd3ff85d0c8f5133d62a02680255b0004af5f4"
 dependencies = [
  "ff",
- "rand_core 0.6.4",
+ "rand_core 0.10.0",
  "subtle",
 ]
 
@@ -1131,7 +1614,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1140,11 +1623,17 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -1152,6 +1641,9 @@ name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+dependencies = [
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "hashlink"
@@ -1182,20 +1674,20 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hkdf"
-version = "0.12.4"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+checksum = "4aaa26c720c68b866f2c96ef5c1264b3e6f473fe5d4ce61cd44bbe913e553018"
 dependencies = [
  "hmac",
 ]
 
 [[package]]
 name = "hmac"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
- "digest",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -1245,6 +1737,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
+name = "hybrid-array"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
+dependencies = [
+ "subtle",
+ "typenum",
+ "zeroize",
+]
+
+[[package]]
 name = "hyper"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1268,6 +1771,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
+]
+
+[[package]]
 name = "hyper-timeout"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1286,6 +1805,7 @@ version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c6995591a8f1380fcb4ba966a252a4b29188d51d2b89e3a252f5305be65aea8"
 dependencies = [
+ "base64",
  "bytes",
  "futures-channel",
  "futures-core",
@@ -1293,7 +1813,9 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
+ "ipnet",
  "libc",
+ "percent-encoding",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -1326,6 +1848,89 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa68d21081c4a05d5a901a1c62add574c77048b6a1c67be3b50ce0b60d4ca513"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d56e28588da92eee5c3201a6eff33fabdd49b62269c8938d4ff050ce4d900deb"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f9cf5f235641ed274641dd81c3f28d870e276763d0797aeeab72317b1c646f"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1563da1ed3e0b3bf3d74c9b85917ac9c56464d2f57242270c09c9e752f8021a0"
+
+[[package]]
+name = "icu_properties"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e7ca276ad3145661a65914e6daf131ca5120cd3dcee8f8f3214b8875184a148"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e590f038c1464a96894fd6d10127e90a8be4509f56ff7ecef851b15cee0b7caa"
+
+[[package]]
+name = "icu_provider"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d27bbb9d3abbefac45d55f647c9de1d44aafcd1186eb91879afef17c396c3e73"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1338,10 +1943,62 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
+name = "impl-codec"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba6a270039626615617f3f36d15fc827041df3b78c439da2cadfa47455a77f2f"
+dependencies = [
+ "parity-scale-codec",
+]
+
+[[package]]
+name = "impl-trait-for-tuples"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0eb5a3343abf848c0984fe4604b2b105da9539376e24fc0a3b0007411ae4fd9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.115",
+]
+
+[[package]]
 name = "indenter"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "964de6e86d545b246d84badc0fef527924ace5134f30641c203ef52ba83f58d5"
+
+[[package]]
+name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+ "serde",
+]
 
 [[package]]
 name = "indexmap"
@@ -1357,12 +2014,18 @@ dependencies = [
 
 [[package]]
 name = "inout"
-version = "0.1.4"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
 dependencies = [
- "generic-array",
+ "hybrid-array",
 ]
+
+[[package]]
+name = "ipnet"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
 
 [[package]]
 name = "is_ci"
@@ -1378,9 +2041,36 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
 dependencies = [
  "either",
 ]
@@ -1398,10 +2088,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be1f93b8b1eb69c77f24bbb0afdf66f54b632ee39af40ca21c4365a1d7347e49"
 dependencies = [
  "jiff-static",
+ "jiff-tzdb-platform",
  "log",
  "portable-atomic",
  "portable-atomic-util",
  "serde",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1413,6 +2105,21 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.115",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "142bd39932ad231f10513df9ab62661fead8719872150b7ad02a2df79f4e141e"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
 ]
 
 [[package]]
@@ -1439,16 +2146,16 @@ dependencies = [
 
 [[package]]
 name = "k256"
-version = "0.13.4"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
+checksum = "93f50113171a713f4a4231ef82eb26703607139b35dcb56241f0ceab2ae1f7d8"
 dependencies = [
- "cfg-if",
+ "cpubits",
  "ecdsa",
  "elliptic-curve",
- "once_cell",
- "sha2",
- "signature",
+ "primeorder",
+ "sha2 0.11.0",
+ "wnaf",
 ]
 
 [[package]]
@@ -1457,38 +2164,33 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
-name = "lalrpop"
-version = "0.22.2"
+name = "keccak"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba4ebbd48ce411c1d10fb35185f5a51a7bfa3d8b24b4e330d30c9e3a34129501"
+checksum = "ffd9697dc4a9a62e2da93389f34400b77a28f0287711263cabb203b3ccb9c0e4"
 dependencies = [
- "ascii-canvas",
- "bit-set",
- "ena",
- "itertools",
- "lalrpop-util",
- "petgraph",
- "regex",
- "regex-syntax",
- "sha3",
- "string_cache",
- "term",
- "unicode-xid",
- "walkdir",
+ "cfg-if",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
-name = "lalrpop-util"
-version = "0.22.2"
+name = "konst"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5baa5e9ff84f1aefd264e6869907646538a52147a755d494517a8007fb48733"
+checksum = "128133ed7824fcd73d6e7b17957c5eb7bacb885649bd8c69708b2331a10bcefb"
 dependencies = [
- "rustversion",
+ "konst_macro_rules",
 ]
+
+[[package]]
+name = "konst_macro_rules"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
 
 [[package]]
 name = "lazy_static"
@@ -1530,6 +2232,12 @@ name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+
+[[package]]
+name = "litemap"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d9d19d1d6efa0109d2f65ff4c85cddd50bd572e5a00127ab10987290bcefae"
 
 [[package]]
 name = "lock_api"
@@ -1594,6 +2302,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "macro-string"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1621,10 +2335,11 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "miden-ace-codegen"
-version = "0.23.4"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd45076fe4fef71f0f8b30aa0f018eb39c3086eeb5f3cafc0e12d60cd28339e"
+checksum = "1219d5caa6fcb00a96e1ec0ffc66bc03d86fc3e6367d5d8021e7ed420973d64e"
 dependencies = [
+ "miden-constraint-compiler",
  "miden-core",
  "miden-crypto",
  "thiserror",
@@ -1632,37 +2347,38 @@ dependencies = [
 
 [[package]]
 name = "miden-agglayer"
-version = "0.15.3"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ead17cc16651de0fea5fc3ea67109ad449c7bb274ca8ff91c5b25e2be4a0c9f8"
+checksum = "3664d9d786b69d3ddef13eda4a2d8eb1138ad381ddb740367167fe721dd9cb76"
 dependencies = [
  "alloy-sol-types",
  "fs-err",
  "miden-assembly",
  "miden-core",
+ "miden-core-lib",
  "miden-crypto",
+ "miden-mast-package",
+ "miden-package-registry",
  "miden-protocol",
+ "miden-protocol-build-utils",
  "miden-standards",
  "miden-utils-sync",
- "primitive-types",
- "regex",
  "serde",
  "serde_json",
  "thiserror",
- "walkdir",
 ]
 
 [[package]]
 name = "miden-air"
-version = "0.23.4"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69f1a80330b3e3d3f98e08817dc6a5e3d90d11ab5e88aa9c0dad5d3b4202598b"
+checksum = "20a825f5e8b687969ad32107a669b9ae254ba780c18f2e43869407aa010bc5e8"
 dependencies = [
  "miden-ace-codegen",
  "miden-core",
  "miden-crypto",
- "miden-lifted-stark",
  "miden-utils-indexing",
+ "p3-field",
  "proptest",
  "thiserror",
  "tracing",
@@ -1670,9 +2386,9 @@ dependencies = [
 
 [[package]]
 name = "miden-assembly"
-version = "0.23.4"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8582d184360be35eb2111a99245f556f43e1066ed09192fbcd0f218c466862a5"
+checksum = "3f1487a11b83df90e74469fdf61ee0b27831562972c3a4689e0c9bb7b0158ba5"
 dependencies = [
  "env_logger",
  "log",
@@ -1688,15 +2404,13 @@ dependencies = [
 
 [[package]]
 name = "miden-assembly-syntax"
-version = "0.23.4"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffa307bc2cbd1f0cb74ed58981823f400a433900fb8f963762331fbb8389d5dc"
+checksum = "e77f0289745bb1887147ee67acfb47e14443579b7c7d0655660599f62545bc34"
 dependencies = [
- "aho-corasick",
  "env_logger",
- "lalrpop",
- "lalrpop-util",
  "log",
+ "miden-assembly-syntax-cst",
  "miden-core",
  "miden-debug-types",
  "miden-utils-diagnostics",
@@ -1712,10 +2426,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "miden-block-prover"
-version = "0.15.3"
+name = "miden-assembly-syntax-cst"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "292ded918a0ddd056dc34db471f0bef6ac7991467d513ba505a4fcc0b1ecfac4"
+checksum = "7f41c6c73726eb40149ca2d174c5dd5ac9fcbcd738d851bc4c7ddb7b7f6d4561"
+dependencies = [
+ "miden-debug-types",
+ "miden-rowan",
+ "miden-utils-diagnostics",
+ "thiserror",
+]
+
+[[package]]
+name = "miden-block-prover"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "286198b93e8ada957dc89fa920fdd442066c02bb0f28efbe0172fce03119545f"
 dependencies = [
  "miden-protocol",
  "thiserror",
@@ -1723,9 +2449,9 @@ dependencies = [
 
 [[package]]
 name = "miden-client"
-version = "0.15.2"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6eb783623b8f55d013833c4eef35190f44da3629d0d13a13693285004f8d3fe2"
+checksum = "c9862fde2ef60a6a1f1066834c9920f50973a2012465c451ec64381fea4654fc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1735,18 +2461,19 @@ dependencies = [
  "gloo-timers",
  "hex",
  "miden-agglayer",
+ "miden-assembly-syntax",
  "miden-node-proto-build",
  "miden-note-transport-proto-build",
+ "miden-processor",
  "miden-protocol",
- "miden-remote-prover-client",
  "miden-standards",
  "miden-testing",
  "miden-tx",
- "miden-tx-batch-prover",
+ "miden-tx-batch",
  "miette",
  "prost",
  "prost-types",
- "rand 0.9.2",
+ "rand 0.10.2",
  "serde",
  "serde_json",
  "tempfile",
@@ -1763,9 +2490,9 @@ dependencies = [
 
 [[package]]
 name = "miden-client-sqlite-store"
-version = "0.15.2"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efb7f78f6ce83e114c49c601aa563df2863ebebea471023d70c3577177356b39"
+checksum = "b1bdb490a10753418209cf9efcb8d923b3b0a39105b9cba987e9674dd1528b66"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1778,13 +2505,24 @@ dependencies = [
  "rusqlite_migration",
  "thiserror",
  "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "miden-constraint-compiler"
+version = "0.29.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec5809dc0c9bc973f90cdb76116bfc3f5463d1e1ef9ce73a671141ba9f6d89a"
+dependencies = [
+ "miden-core",
+ "miden-crypto",
 ]
 
 [[package]]
 name = "miden-core"
-version = "0.23.4"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80657c32850817f5f67dcf114866495a4b055531778b7c26d0602646ce777eb8"
+checksum = "e8727b184f044ca41e61c9c2c345336d0e570f29c041bb49575520aade3c8f2d"
 dependencies = [
  "derive_more",
  "log",
@@ -1794,36 +2532,47 @@ dependencies = [
  "miden-utils-core-derive",
  "miden-utils-indexing",
  "miden-utils-sync",
- "num-derive",
- "num-traits",
  "proptest",
- "proptest-derive",
  "serde",
  "thiserror",
 ]
 
 [[package]]
 name = "miden-core-lib"
-version = "0.23.4"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16410655f32f98537afc9ddf57b71cb6d1ca9d980da5f4eea164cafcaf891b2e"
+checksum = "e48b2c62c2c0144717e4219cb42aaf427d58ccd730a18ba97f2e37387a3c3193"
 dependencies = [
  "env_logger",
  "fs-err",
  "miden-assembly",
+ "miden-assembly-syntax",
  "miden-core",
+ "miden-core-lib-codegen",
  "miden-crypto",
+ "miden-mast-package",
  "miden-package-registry",
+ "miden-precompiles",
  "miden-processor",
  "miden-utils-sync",
  "thiserror",
 ]
 
 [[package]]
-name = "miden-crypto"
-version = "0.25.1"
+name = "miden-core-lib-codegen"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35198bebd353cddc25ad4aafb5f4ef9e71b283d71c787b8938c575c16974135d"
+checksum = "a0a0787b5fd63be0e6f5ee96bc531c075e96c0a787b3608fbaf60db0d82c47ed"
+dependencies = [
+ "miden-core",
+ "miden-precompiles",
+]
+
+[[package]]
+name = "miden-crypto"
+version = "0.29.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8202e1536816c254332798e27f5d46f4940766e01322826553b77489b78ce44d"
 dependencies = [
  "blake3",
  "cc",
@@ -1850,14 +2599,12 @@ dependencies = [
  "p3-maybe-rayon",
  "p3-symmetric",
  "p3-util",
- "rand 0.9.2",
- "rand_chacha",
- "rand_core 0.9.3",
- "rand_hc",
+ "rand 0.10.2",
+ "rand_chacha 0.10.0",
  "rayon",
  "serde",
- "sha2",
- "sha3",
+ "sha2 0.11.0",
+ "sha3 0.12.0",
  "subtle",
  "thiserror",
  "x25519-dalek",
@@ -1865,9 +2612,9 @@ dependencies = [
 
 [[package]]
 name = "miden-crypto-derive"
-version = "0.25.1"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9068c6554db0e051f62913575de9949841a46b96ae92d4b7d28e1fed5d8f052b"
+checksum = "dcdc897827882684b76ac4b45cae93885cc252ee69c578e6b8ce0e3954043674"
 dependencies = [
  "quote",
  "syn 2.0.115",
@@ -1875,9 +2622,9 @@ dependencies = [
 
 [[package]]
 name = "miden-debug-types"
-version = "0.23.4"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "956708ccb2f643db398b4b3d4f8d0baf199b1bfb5e34c8be1cd1bc811c005e8e"
+checksum = "da1533b6a269126a48dbcb14ce22c3e31be0d0284b516b84f0954261c79f1756"
 dependencies = [
  "memchr",
  "miden-crypto",
@@ -1890,22 +2637,23 @@ dependencies = [
  "serde",
  "serde_spanned",
  "thiserror",
+ "zerocopy",
 ]
 
 [[package]]
 name = "miden-field"
-version = "0.25.1"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "379a39db52cd932a95d4017a18b712ee53ed0f86cfedf8c63ed72d687a18a191"
+checksum = "8d9c9b62982fcb18fa1b6c3bcaefc7956da30859d5e881a7f88f77dcf972db99"
 dependencies = [
  "miden-serde-utils",
- "num-bigint",
+ "num-bigint 0.5.1",
  "p3-challenger",
  "p3-field",
  "p3-goldilocks",
  "p3-util",
  "paste",
- "rand 0.10.0",
+ "rand 0.10.2",
  "serde",
  "subtle",
  "thiserror",
@@ -1922,11 +2670,12 @@ dependencies = [
 
 [[package]]
 name = "miden-lifted-air"
-version = "0.25.1"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "789e0e469d1731012d8a018057317f31580611535c20d2a47c022213228cb733"
+checksum = "8314dec43170ef8549a7a00ae6dd016975d772c9bdf03c06fb8a69d39fed300f"
 dependencies = [
  "p3-air",
+ "p3-challenger",
  "p3-field",
  "p3-matrix",
  "p3-util",
@@ -1935,9 +2684,9 @@ dependencies = [
 
 [[package]]
 name = "miden-lifted-stark"
-version = "0.25.1"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f62cca91182917b22a47e150028b7c785df620a15b2974a39c64e2b1b7a889d3"
+checksum = "48166c2c8ee308ecbaea6ec8db07981973ff42f99bb39c09b914c30510942a9b"
 dependencies = [
  "miden-lifted-air",
  "miden-stark-transcript",
@@ -1950,7 +2699,7 @@ dependencies = [
  "p3-maybe-rayon",
  "p3-symmetric",
  "p3-util",
- "rand 0.10.0",
+ "rand 0.10.2",
  "serde",
  "thiserror",
  "tracing",
@@ -1958,15 +2707,20 @@ dependencies = [
 
 [[package]]
 name = "miden-mast-package"
-version = "0.23.4"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f37c21836b40785ce297d363c57740d4e33edcc411f84185a524eddadd5f53c7"
+checksum = "3e99190edc3ae5a8be14aa77aa38df7a06d28455f8e9c02f4486a653f92e21cc"
 dependencies = [
+ "hashbrown 0.17.0",
+ "log",
  "miden-assembly-syntax",
  "miden-core",
  "miden-debug-types",
+ "miden-utils-indexing",
+ "rustc-hash",
  "serde",
  "thiserror",
+ "zerocopy",
 ]
 
 [[package]]
@@ -2007,9 +2761,9 @@ dependencies = [
 
 [[package]]
 name = "miden-node-proto-build"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef3b301741cedd6d0b532583690bc21dbf856d4e14218c591f3924bc905c660a"
+checksum = "724a79e7663157e73de1fc19fcd6e30c7cee4e4c4189d44477922a3969797acb"
 dependencies = [
  "build-rs",
  "codegen",
@@ -2021,9 +2775,9 @@ dependencies = [
 
 [[package]]
 name = "miden-note-transport-proto-build"
-version = "0.4.1"
+version = "0.5.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7399c2999453c781601f16d82f328ecc695f9375e2415a05147449990f32f71f"
+checksum = "5a9d736051a42941788c6534caf8cf779b388c0ae72c9d5f0d729d2a9872d833"
 dependencies = [
  "fs-err",
  "miette",
@@ -2033,9 +2787,9 @@ dependencies = [
 
 [[package]]
 name = "miden-package-registry"
-version = "0.23.4"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ece6064beb0582d1c64ba30d0c548c4b7a45f87abae6d69e22fd49c8b343258"
+checksum = "5a4b2c12e20f45e74c24ef88819c1ba36724519ce3b76d367a72e1d958df62b8"
 dependencies = [
  "miden-assembly-syntax",
  "miden-core",
@@ -2048,15 +2802,50 @@ dependencies = [
 ]
 
 [[package]]
-name = "miden-processor"
-version = "0.23.4"
+name = "miden-precompiles"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea972ca9e45dbf26aa396367e8508db0f7292adea6f6ddf8d39d0e334285fe2b"
+checksum = "823d3e418adcbe5a8cea6843f2a167f6f5b521ab827075261974b807ef979ccf"
 dependencies = [
- "itertools",
+ "miden-core",
+ "miden-crypto",
+]
+
+[[package]]
+name = "miden-precompiles-prover"
+version = "0.29.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "467e9fb8d805d8c4621af093a31f0a2465eefd68d63208b49f5663eaf030f89f"
+dependencies = [
+ "miden-ace-codegen",
+ "miden-air",
+ "miden-core",
+ "miden-crypto",
+ "miden-lifted-air",
+ "miden-lifted-stark",
+ "miden-precompiles",
+ "miden-serde-utils",
+ "ruint",
+ "serde",
+ "serde-wincode",
+ "thiserror",
+ "tracing",
+ "wincode",
+]
+
+[[package]]
+name = "miden-processor"
+version = "0.29.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a350061ef4f412639475c5bd8d68ae665ce9fd34ffc768c6082acd3972f791c"
+dependencies = [
+ "hashbrown 0.17.0",
+ "itertools 0.15.0",
  "miden-air",
  "miden-core",
  "miden-debug-types",
+ "miden-mast-package",
+ "miden-precompiles",
  "miden-utils-diagnostics",
  "miden-utils-indexing",
  "paste",
@@ -2067,9 +2856,9 @@ dependencies = [
 
 [[package]]
 name = "miden-project"
-version = "0.23.4"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5320e7e5b562359bd6161ac752dfe43dd4f69bb06e87f94a21a27bb656e5a20d"
+checksum = "dbfb83107a2016867e3650e0b34bb8bc356ab2a039dce1992b808bab73da7385"
 dependencies = [
  "miden-assembly-syntax",
  "miden-core",
@@ -2084,13 +2873,13 @@ dependencies = [
 
 [[package]]
 name = "miden-protocol"
-version = "0.15.3"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66340243e37da5936cb278a8dd11037813f1dc6731c2fc866703b76ed465ebc3"
+checksum = "46b3c270a0fabe3618006176f1b9600e9b5b59a53a8e26ce6afcf65f1b02cb16"
 dependencies = [
  "bech32",
  "fs-err",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "miden-assembly",
  "miden-assembly-syntax",
  "miden-core",
@@ -2098,89 +2887,96 @@ dependencies = [
  "miden-crypto",
  "miden-crypto-derive",
  "miden-mast-package",
+ "miden-package-registry",
  "miden-processor",
+ "miden-protocol-build-utils",
  "miden-utils-sync",
  "miden-verifier",
- "rand 0.9.2",
- "rand_chacha",
+ "rand 0.10.2",
+ "rand_chacha 0.10.0",
  "rand_xoshiro",
  "regex",
  "semver 1.0.27",
  "serde",
  "thiserror",
  "toml 1.1.2+spec-1.1.0",
+]
+
+[[package]]
+name = "miden-protocol-build-utils"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffb3076db13d4b6d12bf01d96ffc3fea400f415fce26467d81081400dcdc59c9"
+dependencies = [
+ "fs-err",
+ "miden-assembly",
+ "miden-core",
+ "miden-mast-package",
+ "miden-package-registry",
+ "miden-project",
+ "regex",
  "walkdir",
 ]
 
 [[package]]
 name = "miden-prover"
-version = "0.23.4"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a91bcc00840b01126cd54e3b68ce3235def2ed48803f2eeb36a035d6951fbc1"
+checksum = "65268275b38d5add4cb2542b2e2f2047047a96d6f7bac3b43678e78e36d51794"
 dependencies = [
- "bincode",
  "miden-air",
  "miden-core",
  "miden-crypto",
+ "miden-precompiles-prover",
  "miden-processor",
  "serde",
+ "serde-wincode",
  "tracing",
 ]
 
 [[package]]
-name = "miden-remote-prover-client"
-version = "0.15.0"
+name = "miden-rowan"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2acdb9494689feeec0f60e3b61901b5eb2362b49b993b4cbc3eb75ad83514dd"
+checksum = "c13695bf99aabaa21d6572b807c66bb26251aa3d9b75e828b3c99b97a3b1ce7e"
 dependencies = [
- "build-rs",
- "fs-err",
- "getrandom 0.4.2",
- "miden-node-proto-build",
- "miden-protocol",
- "miden-tx",
- "miette",
- "prost",
- "thiserror",
- "tokio",
- "tonic",
- "tonic-prost",
- "tonic-prost-build",
- "tonic-web-wasm-client",
+ "hashbrown 0.17.0",
+ "rustc-hash",
 ]
 
 [[package]]
 name = "miden-serde-utils"
-version = "0.25.1"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d78cd1d4fcad937312e544f7d53423485e453598aa4fb989d2b6374027a8c136"
+checksum = "e1f37aa58c6ec69c19ed0edbdba0322c2112356fbbc131a42b5994462a2b794d"
 dependencies = [
  "p3-field",
  "p3-goldilocks",
+ "wincode",
 ]
 
 [[package]]
 name = "miden-standards"
-version = "0.15.3"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7c7146b028e637f4079b5bdefeefc54d7d6e47a805451fa0a18859d19efa2ff"
+checksum = "6be6c71d2114157431f3d5860450b189e902a1fdf3351c8a7d91be8906fd35ce"
 dependencies = [
  "bon",
- "fs-err",
  "miden-assembly",
  "miden-core-lib",
+ "miden-package-registry",
  "miden-protocol",
- "rand 0.9.2",
- "regex",
+ "miden-protocol-build-utils",
+ "primitive-types 0.14.0",
+ "rand 0.10.2",
  "thiserror",
- "walkdir",
 ]
 
 [[package]]
 name = "miden-stark-transcript"
-version = "0.25.1"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05901db2e30d3954243960fe21cea7fbec39f97c27774b56fd5031c28c4881ba"
+checksum = "5b3238f74844f9826a9ee41d39b1d726426fd298a5aba16c34346471d7d184db"
 dependencies = [
  "p3-challenger",
  "p3-field",
@@ -2190,9 +2986,9 @@ dependencies = [
 
 [[package]]
 name = "miden-stateful-hasher"
-version = "0.25.1"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faeb47a90c55c5d45051d23cf691588804dd531995b4582c79108b64e445a905"
+checksum = "88a5545db3e83e041e365c7bb1ba5b8c5953b45a7ad32d698d3b4c30e45727a8"
 dependencies = [
  "p3-field",
  "p3-symmetric",
@@ -2200,12 +2996,12 @@ dependencies = [
 
 [[package]]
 name = "miden-testing"
-version = "0.15.3"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4096fc44a4c88f37405be284e25efdce194d6051e9472ae136ab9249659433c"
+checksum = "dba121f560380c4cf70ba422098feedc512d897f41130163255a7dfd94c9aab3"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.15.0",
  "miden-block-prover",
  "miden-core-lib",
  "miden-crypto",
@@ -2213,9 +3009,9 @@ dependencies = [
  "miden-protocol",
  "miden-standards",
  "miden-tx",
- "miden-tx-batch-prover",
- "rand 0.9.2",
- "rand_chacha",
+ "miden-tx-batch",
+ "rand 0.10.2",
+ "rand_chacha 0.10.0",
  "thiserror",
 ]
 
@@ -2226,39 +3022,44 @@ dependencies = [
  "miden-client",
  "miden-client-sqlite-store",
  "miden-protocol",
- "rand 0.9.2",
+ "rand 0.10.2",
+ "rust-client",
  "tokio",
 ]
 
 [[package]]
 name = "miden-tx"
-version = "0.15.3"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94092b45bc0abc656af25473c9807d1e6cee8e682c58d3b1186f0bd0fb6471fb"
+checksum = "9dcc3e4708af1d15dc13baec1162fd9c1b9663fd4eeac1c2d2f79ef4202d018c"
 dependencies = [
+ "bon",
+ "miden-agglayer",
  "miden-processor",
  "miden-protocol",
  "miden-prover",
  "miden-standards",
+ "thiserror",
+]
+
+[[package]]
+name = "miden-tx-batch"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5db9201b5b56c96dbed1cd5540e7344530a83348fe82e31cabce2b0d963c1dbe"
+dependencies = [
+ "miden-processor",
+ "miden-protocol",
+ "miden-prover",
  "miden-verifier",
  "thiserror",
 ]
 
 [[package]]
-name = "miden-tx-batch-prover"
-version = "0.15.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60add2b40559352661bc86970541f88ffcf98c528f301295f9dc3bf15481b46"
-dependencies = [
- "miden-protocol",
- "miden-tx",
-]
-
-[[package]]
 name = "miden-utils-core-derive"
-version = "0.23.4"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0b1ee4662beb049a824e11bb21f95a79746c52874967983c9999f1b19a2f471"
+checksum = "d0e529fda0dc73e1fdb56d0c29ca92780a4f3d766cf5bf2bc688b95b0f8a8623"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2267,11 +3068,10 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-diagnostics"
-version = "0.23.4"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fdc1cd4eda372e1c4b99b9c3677e9b1f87a4d2e362a9f4b8f904273d395efc9"
+checksum = "197029df3c899525204f4a1f7e5b6e82c69427489b36032ae56fbcf53f9d6b2f"
 dependencies = [
- "miden-crypto",
  "miden-debug-types",
  "miden-miette",
  "tracing",
@@ -2279,11 +3079,11 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-indexing"
-version = "0.23.4"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c31444125649f4dad9cde647f614309b6be4f918fed276ada4eb99c01e8b9ca7"
+checksum = "5b87e9b3f949c27e56dc390d9c9e679f2886e6ea6adfbc7158de7f377c1b6940"
 dependencies = [
- "miden-crypto",
+ "miden-serde-utils",
  "proptest",
  "serde",
  "thiserror",
@@ -2291,9 +3091,9 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-sync"
-version = "0.23.4"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "807c8ae625b7652ae7246b225c907c05da72927c31a0fd71c835c4f80931e92e"
+checksum = "e9e911afc22a03dcf439a0d1d20a67631169a6757100230b257c57e546dd5c3a"
 dependencies = [
  "lock_api",
  "loom",
@@ -2303,24 +3103,26 @@ dependencies = [
 
 [[package]]
 name = "miden-verifier"
-version = "0.23.4"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec5556dac919a1c13edeb2bd7181fc6a4c2ce52764a3e518bcdcd9ed48e5b38e"
+checksum = "6aaf6b63aa6300832a302207f3e93932faae299679e75a0c993de6b1c02f5cde"
 dependencies = [
- "bincode",
  "miden-air",
  "miden-core",
  "miden-crypto",
+ "miden-precompiles",
+ "miden-precompiles-prover",
+ "miden-serde-utils",
  "serde",
+ "serde-wincode",
  "thiserror",
- "tracing",
 ]
 
 [[package]]
 name = "midenc-hir-type"
-version = "0.6.1"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ff0511aa2201f7098995e38a3c97a319d379c3b2d26fb83677b21b71f61a7b4"
+checksum = "f72909a4bae8dca4bbd34c28dcbcdff595afc47e48c312a683108f7452bd270b"
 dependencies = [
  "miden-formatting",
  "miden-serde-utils",
@@ -2387,21 +3189,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
-name = "nanorand"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
-dependencies = [
- "getrandom 0.2.16",
-]
-
-[[package]]
-name = "new_debug_unreachable"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
-
-[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2416,7 +3203,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
 dependencies = [
- "num-bigint",
+ "num-bigint 0.4.6",
  "num-complex",
  "num-integer",
  "num-iter",
@@ -2435,6 +3222,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93e7820bc0a80a0238e650327316f929ba18d5be054b647490a3a6a339f3e7c0"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-complex"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2444,15 +3241,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-derive"
-version = "0.4.2"
+name = "num-conv"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.115",
-]
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
@@ -2480,7 +3272,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
 dependencies = [
- "num-bigint",
+ "num-bigint 0.4.6",
  "num-integer",
  "num-traits",
 ]
@@ -2531,12 +3323,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
-name = "opaque-debug"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
-
-[[package]]
 name = "openssl-probe"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2550,9 +3336,9 @@ checksum = "9c6901729fa79e91a0913333229e9ca5dc725089d1c363b2f4b4760709dc4a52"
 
 [[package]]
 name = "p3-air"
-version = "0.5.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f2ec9cbfc642fc5173817287c3f8b789d07743b5f7e812d058b7a03e344f9ab"
+checksum = "ddb1be05c0d6f691afe0c9f468018a9a37cfa904dee78a8081ec96eb3cdd88e8"
 dependencies = [
  "p3-field",
  "p3-matrix",
@@ -2561,9 +3347,9 @@ dependencies = [
 
 [[package]]
 name = "p3-blake3"
-version = "0.5.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b667f43b19499dd939c9e2553aa95688936a88360d50117dae3c8848d07dbc70"
+checksum = "6f202f5fbcceb6f56f783d98efb5de27e5a171470e3364de97b0923b39c87ab5"
 dependencies = [
  "blake3",
  "p3-symmetric",
@@ -2572,9 +3358,9 @@ dependencies = [
 
 [[package]]
 name = "p3-challenger"
-version = "0.5.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a0b490c745a7d2adeeafff06411814c8078c432740162332b3cd71be0158a76"
+checksum = "84d5d5e1ecf2c80b09b48ce870e8abd08b643454101c5dc9d0fd71bfbd78224d"
 dependencies = [
  "p3-field",
  "p3-maybe-rayon",
@@ -2586,42 +3372,42 @@ dependencies = [
 
 [[package]]
 name = "p3-dft"
-version = "0.5.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55301e91544440254977108b85c32c09d7ea05f2f0dd61092a2825339906a4a7"
+checksum = "4321a952da2721ecd85ca593ea189798dfb4e439a2cc1378ce1442091880f173"
 dependencies = [
- "itertools",
+ "itertools 0.15.0",
  "p3-field",
  "p3-matrix",
  "p3-maybe-rayon",
  "p3-util",
- "spin 0.10.0",
+ "spin 0.12.3",
  "tracing",
 ]
 
 [[package]]
 name = "p3-field"
-version = "0.5.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85affca7fc983889f260655c4cf74163eebb94605f702e4b6809ead707cba54f"
+checksum = "53db75d38e04fc255826f388eca9d05976733dc9754aa3db411bc9ea1a37c1a0"
 dependencies = [
- "itertools",
- "num-bigint",
+ "itertools 0.15.0",
+ "num-bigint 0.5.1",
  "p3-maybe-rayon",
  "p3-util",
  "paste",
- "rand 0.10.0",
+ "rand 0.10.2",
  "serde",
  "tracing",
 ]
 
 [[package]]
 name = "p3-goldilocks"
-version = "0.5.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ca1081f5c47b940f2d75a11c04f62ea1cc58a5d480dd465fef3861c045c63cd"
+checksum = "d03b3f31080df31be723b876709246f8f1e532e1c5b82efb5281d705c8304c63"
 dependencies = [
- "num-bigint",
+ "num-bigint 0.5.1",
  "p3-challenger",
  "p3-dft",
  "p3-field",
@@ -2631,15 +3417,16 @@ dependencies = [
  "p3-symmetric",
  "p3-util",
  "paste",
- "rand 0.10.0",
+ "rand 0.10.2",
  "serde",
+ "spin 0.12.3",
 ]
 
 [[package]]
 name = "p3-keccak"
-version = "0.5.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebcf27615ece1995e4fcf4c69740f1cf515d1481367a20b4b3ce7f4f1b8d70f7"
+checksum = "ae50c8c37eb847c660298fb275e53c025c49b2623a8cfabf67f5322258b2b4db"
 dependencies = [
  "p3-symmetric",
  "p3-util",
@@ -2648,49 +3435,49 @@ dependencies = [
 
 [[package]]
 name = "p3-matrix"
-version = "0.5.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53428126b009071563d1d07305a9de8be0d21de00b57d2475289ee32ffca6577"
+checksum = "473eb920c446a6f4536e0d3528fbdca2a23c0e24e1d0d7767452e6d385dd335c"
 dependencies = [
- "itertools",
+ "itertools 0.15.0",
  "p3-field",
  "p3-maybe-rayon",
  "p3-util",
- "rand 0.10.0",
+ "rand 0.10.2",
  "serde",
  "tracing",
 ]
 
 [[package]]
 name = "p3-maybe-rayon"
-version = "0.5.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "082bf467011c06c768c579ec6eb9accb5e1e62108891634cc770396e917f978a"
+checksum = "e6fddfd435f96394769414cf5590b77058aa506659bf20d6592e9d1989e04440"
 dependencies = [
  "rayon",
 ]
 
 [[package]]
 name = "p3-mds"
-version = "0.5.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35209e6214102ea6ec6b8cb1b9c15a9b8e597a39f9173597c957f123bced81b3"
+checksum = "551ba0ab2cccd89f85a99450224898aff224e323bbf61f777ba6344f0896ef10"
 dependencies = [
  "p3-dft",
  "p3-field",
  "p3-symmetric",
  "p3-util",
- "rand 0.10.0",
+ "rand 0.10.2",
 ]
 
 [[package]]
 name = "p3-monty-31"
-version = "0.5.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffa8c99ec50c035020bbf5457c6a729ba6a975719c1a8dd3f16421081e4f650c"
+checksum = "871f635f7340cd0868b17e43e0c98fefdafdaed90469d0725caf6d8372a2a47c"
 dependencies = [
- "itertools",
- "num-bigint",
+ "itertools 0.15.0",
+ "num-bigint 0.5.1",
  "p3-dft",
  "p3-field",
  "p3-matrix",
@@ -2701,43 +3488,44 @@ dependencies = [
  "p3-symmetric",
  "p3-util",
  "paste",
- "rand 0.10.0",
+ "rand 0.10.2",
  "serde",
- "spin 0.10.0",
+ "spin 0.12.3",
  "tracing",
 ]
 
 [[package]]
 name = "p3-poseidon1"
-version = "0.5.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a018b618e3fa0aec8be933b1d8e404edd23f46991f6bf3f5c2f3f95e9413fe9"
+checksum = "8d0d304e9a1f29c0d66534aa84e69528e2118351fdce08dcf5898af4e0fecc32"
 dependencies = [
  "p3-field",
+ "p3-mds",
  "p3-symmetric",
- "rand 0.10.0",
+ "rand 0.10.2",
 ]
 
 [[package]]
 name = "p3-poseidon2"
-version = "0.5.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "256a668a9ba916f8767552f13d0ba50d18968bc74a623bfdafa41e2970c944d0"
+checksum = "43eb8a73a26d14becaed1c67c3e8a047e4311d7909b402383c82ca9643ba17c6"
 dependencies = [
  "p3-field",
  "p3-mds",
  "p3-symmetric",
  "p3-util",
- "rand 0.10.0",
+ "rand 0.10.2",
 ]
 
 [[package]]
 name = "p3-symmetric"
-version = "0.5.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c60a71a1507c13611b0f2b0b6e83669fd5b76f8e3115bcbced5ccfdf3ca7807"
+checksum = "2015ea80cad969b6aabf27a04884286fe1354393b166d968ee0d80a95126b2a4"
 dependencies = [
- "itertools",
+ "itertools 0.15.0",
  "p3-field",
  "p3-util",
  "serde",
@@ -2745,13 +3533,40 @@ dependencies = [
 
 [[package]]
 name = "p3-util"
-version = "0.5.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8b766b9e9254bf3fa98d76e42cf8a5b30628c182dfd5272d270076ee12f0fc0"
+checksum = "6c5466fc40e6df89d3b291a2eff16b33e68e8571207790370137ec18090aadab"
 dependencies = [
  "rayon",
  "serde",
- "transpose",
+]
+
+[[package]]
+name = "parity-scale-codec"
+version = "3.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799781ae679d79a948e13d4824a40970bfa500058d245760dd857301059810fa"
+dependencies = [
+ "arrayvec",
+ "bitvec",
+ "byte-slice-cast",
+ "const_format",
+ "impl-trait-for-tuples",
+ "parity-scale-codec-derive",
+ "rustversion",
+ "serde",
+]
+
+[[package]]
+name = "parity-scale-codec-derive"
+version = "3.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34b4653168b563151153c9e4c08ebed57fb8262bebfa79711552fa983c623e7a"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -2784,10 +3599,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pastey"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pest"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a07a60cc7a4d00c91f95c685609d1d2f79050e6804b70ebedd7650f0b839bcf"
+dependencies = [
+ "memchr",
+ "ucd-trie",
+]
 
 [[package]]
 name = "petgraph"
@@ -2796,16 +3627,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
 dependencies = [
  "fixedbitset",
- "indexmap",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
-dependencies = [
- "siphasher",
+ "indexmap 2.14.0",
 ]
 
 [[package]]
@@ -2842,9 +3664,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkcs8"
-version = "0.10.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+checksum = "451913da69c775a56034ea8d9003d27ee8948e12443eae7c038ba100a4f21cb7"
 dependencies = [
  "der",
  "spki",
@@ -2858,12 +3680,11 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "poly1305"
-version = "0.8.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+checksum = "6e2d0073b297041425c7c3df6eb4792d598a15323fe63346852b092eca02904c"
 dependencies = [
- "cpufeatures",
- "opaque-debug",
+ "cpufeatures 0.3.0",
  "universal-hash",
 ]
 
@@ -2883,6 +3704,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "potential_utf"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d83eb9bc6d8e5cf568e7a1101d60ee05e81ed50ea106026f3d18deeb046d7661"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2890,12 +3726,6 @@ checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
 ]
-
-[[package]]
-name = "precomputed-hash"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "prettyplease"
@@ -2908,13 +3738,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "primefield"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c555a6e4eb7d4e158fcb028c835c3b8642206ddc279b5c6b202ef9a8bdb592f4"
+dependencies = [
+ "crypto-bigint",
+ "crypto-common 0.2.2",
+ "ff",
+ "rand_core 0.10.0",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c9f42978c78a00e3d68f69fc03e57a234debae69da4020a4fb588fcdcd07b06"
+dependencies = [
+ "elliptic-curve",
+ "primefield",
+ "serdect",
+ "wnaf",
+]
+
+[[package]]
+name = "primitive-types"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b34d9fd68ae0b74a41b21c03c2f62847aa0ffea044eee893b4c140b37e244e2"
+dependencies = [
+ "fixed-hash",
+ "impl-codec",
+ "uint 0.9.5",
+]
+
+[[package]]
 name = "primitive-types"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "721a1da530b5a2633218dc9f75713394c983c352be88d2d7c9ee85e2c4c21794"
 dependencies = [
  "fixed-hash",
- "uint",
+ "uint 0.10.0",
 ]
 
 [[package]]
@@ -2924,8 +3791,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93980406f12d9f8140ed5abe7155acb10bb1e69ea55c88960b9c2f117445ef96"
 dependencies = [
  "equivalent",
- "indexmap",
+ "indexmap 2.14.0",
  "serde",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit",
 ]
 
 [[package]]
@@ -2952,9 +3828,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.101"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
@@ -2968,7 +3844,7 @@ dependencies = [
  "bitflags",
  "num-traits",
  "rand 0.9.2",
- "rand_chacha",
+ "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",
  "unarray",
@@ -3002,7 +3878,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac6c3320f9abac597dcbc668774ef006702672474aad53c6d596b62e487b40b1"
 dependencies = [
  "heck",
- "itertools",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "once_cell",
@@ -3024,7 +3900,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.115",
@@ -3084,7 +3960,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f5df7e552bc7edd075f5783a87fbfc21d6a546e32c16985679c488c18192d83"
 dependencies = [
- "indexmap",
+ "indexmap 2.14.0",
  "log",
  "priority-queue",
  "rustc-hash",
@@ -3113,10 +3989,66 @@ dependencies = [
 ]
 
 [[package]]
-name = "quote"
-version = "1.0.41"
+name = "quinn"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce25767e7b499d1b604768e7cde645d14cc8584231ea6b295e9c9eb22c02e1d1"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04759210543be93709136e28212294a659ef5001836ff4eab4d663e4529bba83"
+dependencies = [
+ "bytes",
+ "getrandom 0.4.2",
+ "lru-slab",
+ "rand 0.10.2",
+ "rand_pcg",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
@@ -3134,11 +4066,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
  "rand_core 0.6.4",
 ]
 
@@ -3148,17 +4088,29 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
- "rand_chacha",
+ "rand_chacha 0.9.0",
  "rand_core 0.9.3",
 ]
 
 [[package]]
 name = "rand"
-version = "0.10.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
  "rand_core 0.10.0",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -3169,6 +4121,16 @@ checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.9.3",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e6af7f3e25ded52c41df4e0b1af2d047e45896c2f3281792ed68a1c243daedb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.10.0",
 ]
 
 [[package]]
@@ -3196,12 +4158,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
 
 [[package]]
-name = "rand_hc"
-version = "0.3.2"
+name = "rand_pcg"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b363d4f6370f88d62bf586c80405657bde0f0e1b8945d47d2ad59b906cb4f54"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
 dependencies = [
- "rand_core 0.6.4",
+ "rand_core 0.10.0",
 ]
 
 [[package]]
@@ -3215,18 +4177,18 @@ dependencies = [
 
 [[package]]
 name = "rand_xoshiro"
-version = "0.7.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
+checksum = "662effc7698e08ea324d3acccf8d9d7f7bf79b9785e270a174ea36e56900c91d"
 dependencies = [
- "rand_core 0.9.3",
+ "rand_core 0.10.0",
 ]
 
 [[package]]
 name = "rayon"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
@@ -3249,6 +4211,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e440fb4e4b4147295338efb76001ab9e4efc0e5839df2c47fc5ac2381d365c3"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92ecd8964f8453721699a1ed72037b0db49ce2f5a5138486ee89bed6f67cdf3a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -3281,13 +4263,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
-name = "rfc6979"
-version = "0.4.0"
+name = "reqwest"
+version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
+name = "rfc6979"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4a459cddafb3fe76b31fd8f1108007566c40301feb64dc7b54656eb7388172b"
+dependencies = [
+ "crypto-bigint",
  "hmac",
- "subtle",
 ]
 
 [[package]]
@@ -3305,14 +4325,38 @@ dependencies = [
 ]
 
 [[package]]
-name = "ruint"
-version = "1.17.2"
+name = "rlp"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c141e807189ad38a07276942c6623032d3753c8859c146104ac2e4d68865945a"
+checksum = "bb919243f34364b6bd2fc10ef797edbfa75f33c252e7998527479c6d6b47e1ec"
 dependencies = [
+ "bytes",
+ "rustc-hex",
+]
+
+[[package]]
+name = "ruint"
+version = "1.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5e99bff0393163bb25029a6af25d3d8d202ba5b5438a74d1bd8789f5c822970"
+dependencies = [
+ "alloy-rlp",
+ "ark-ff 0.3.0",
+ "ark-ff 0.4.2",
+ "ark-ff 0.5.0",
+ "ark-ff 0.6.0",
+ "bytes",
+ "fastrlp 0.3.1",
+ "fastrlp 0.4.0",
+ "num-bigint 0.4.6",
+ "num-integer",
+ "num-traits",
+ "parity-scale-codec",
+ "primitive-types 0.12.2",
  "proptest",
  "rand 0.8.5",
  "rand 0.9.2",
+ "rlp",
  "ruint-macro",
  "serde_core",
  "valuable",
@@ -3350,6 +4394,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust-client"
+version = "0.1.0"
+dependencies = [
+ "hex",
+ "miden-client",
+ "miden-client-sqlite-store",
+ "miden-protocol",
+ "rand 0.10.2",
+ "reqwest",
+ "serde",
+ "sha2 0.10.9",
+ "tokio",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3362,12 +4421,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
+name = "rustc-hex"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
+
+[[package]]
 name = "rustc_version"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 dependencies = [
  "semver 0.9.0",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
+dependencies = [
+ "semver 0.11.0",
 ]
 
 [[package]]
@@ -3425,6 +4499,7 @@ version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -3470,6 +4545,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "687274d293b6cdc6e73e0fee520bf2049650090d7164f87672d212a3c530cf4a"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "scoped-tls"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3483,14 +4582,14 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sec1"
-version = "0.7.3"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+checksum = "d56d437c2f19203ce5f7122e507831de96f3d2d4d3be5af44a0b0a09d8a80e4d"
 dependencies = [
  "base16ct",
+ "ctutils",
  "der",
- "generic-array",
- "pkcs8",
+ "hybrid-array",
  "subtle",
  "zeroize",
 ]
@@ -3524,7 +4623,16 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 dependencies = [
- "semver-parser",
+ "semver-parser 0.7.0",
+]
+
+[[package]]
+name = "semver"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
+dependencies = [
+ "semver-parser 0.10.3",
 ]
 
 [[package]]
@@ -3542,6 +4650,15 @@ name = "semver-parser"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
+
+[[package]]
+name = "semver-parser"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9900206b54a3527fdc7b8a938bffd94a568bac4f4aa8113b209df75a09c0dec2"
+dependencies = [
+ "pest",
+]
 
 [[package]]
 name = "serde"
@@ -3563,6 +4680,17 @@ dependencies = [
  "serde",
  "serde_core",
  "typeid",
+]
+
+[[package]]
+name = "serde-wincode"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa9d3a86c66cf10ce79df36f555a5a4c8d72a82515d9ea8ca420e02c925c30f"
+dependencies = [
+ "serde",
+ "thiserror",
+ "wincode",
 ]
 
 [[package]]
@@ -3619,14 +4747,67 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_with"
+version = "3.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee78f1fbe43ac4a0e47aadb3dbd357b69eb0d3793e948624cd03dd2750ab1c0a"
+dependencies = [
+ "base64",
+ "bs58",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.14.0",
+ "jiff",
+ "schemars 0.9.0",
+ "schemars 1.2.2",
+ "serde_core",
+ "serde_json",
+ "time",
+]
+
+[[package]]
+name = "serdect"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66cf8fedced2fcf12406bcb34223dffb92eaf34908ede12fed414c82b7f00b3e"
+dependencies = [
+ "base16ct",
+ "serde",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -3635,8 +4816,19 @@ version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
 dependencies = [
- "digest",
- "keccak",
+ "digest 0.10.7",
+ "keccak 0.1.5",
+]
+
+[[package]]
+name = "sha3"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc9bad02c26382724b2d2692c6f179285e4b54eeecd7968f52a50059c3c11759"
+dependencies = [
+ "digest 0.11.3",
+ "keccak 0.2.1",
+ "sponge-cursor",
 ]
 
 [[package]]
@@ -3656,19 +4848,13 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signature"
-version = "2.2.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+checksum = "28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5"
 dependencies = [
- "digest",
- "rand_core 0.6.4",
+ "digest 0.11.3",
+ "rand_core 0.10.0",
 ]
-
-[[package]]
-name = "siphasher"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "slab"
@@ -3712,46 +4898,40 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.10.0"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
+checksum = "0134f9043ed38b087ac4f7d4af44c79e2c9e5094421fe3164f435ce585953b10"
 dependencies = [
  "lock_api",
 ]
 
 [[package]]
 name = "spki"
-version = "0.7.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+checksum = "1d9efca8738c78ee9484207732f728b1ef517bbb1833d6fc0879ca898a522f6f"
 dependencies = [
  "base64ct",
  "der",
 ]
 
 [[package]]
+name = "sponge-cursor"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a0219bd7d979d58245a4f41f695e1ac9f8befdffadd7f61f1bae9e39abc6620"
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
-name = "strength_reduce"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
-
-[[package]]
-name = "string_cache"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
-dependencies = [
- "new_debug_unreachable",
- "parking_lot",
- "phf_shared",
- "precomputed-hash",
-]
 
 [[package]]
 name = "strip-ansi-escapes"
@@ -3818,6 +4998,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "syn-solidity"
 version = "1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3834,6 +5025,26 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.115",
+]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "target-triple"
@@ -3851,15 +5062,6 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "term"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2111ef44dae28680ae9752bb89409e7310ca33a8c621ebe7b106cf5c928b3ac0"
-dependencies = [
  "windows-sys 0.61.2",
 ]
 
@@ -3895,22 +5097,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.17"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.17"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -3923,6 +5125,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
+
+[[package]]
+name = "time-macros"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
 name = "tiny-keccak"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3930,6 +5162,31 @@ checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
 dependencies = [
  "crunchy",
 ]
+
+[[package]]
+name = "tinystr"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1e27c91459209c2986af3dcf603a5a74a4368754ce37414f59acc971167f643"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
@@ -3998,7 +5255,7 @@ version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0dc8b1fb61449e27716ec0e1bdf0f6b8f3e8f6b05391e8497b8b6d7804ea6d8"
 dependencies = [
- "indexmap",
+ "indexmap 2.14.0",
  "serde_core",
  "serde_spanned",
  "toml_datetime 0.7.3",
@@ -4013,7 +5270,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
- "indexmap",
+ "indexmap 2.14.0",
  "serde_core",
  "serde_spanned",
  "toml_datetime 1.1.1+spec-1.1.0",
@@ -4038,6 +5295,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.13+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
+dependencies = [
+ "indexmap 2.14.0",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "winnow 1.0.1",
 ]
 
 [[package]]
@@ -4170,7 +5439,7 @@ checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap",
+ "indexmap 2.14.0",
  "pin-project-lite",
  "slab",
  "sync_wrapper",
@@ -4179,6 +5448,24 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "url",
 ]
 
 [[package]]
@@ -4255,16 +5542,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "transpose"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ad61aed86bc3faea4300c7aee358b4c6d0c8d6ccc36524c96e4c92ccf26e77e"
-dependencies = [
- "num-integer",
- "strength_reduce",
-]
-
-[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4294,9 +5571,27 @@ checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
+name = "uint"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76f64bba2c53b04fcab63c01a7d7427eadc821e3bc48c34dc9ba29c501164b52"
+dependencies = [
+ "byteorder",
+ "crunchy",
+ "hex",
+ "static_assertions",
+]
 
 [[package]]
 name = "uint"
@@ -4354,12 +5649,12 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "universal-hash"
-version = "0.5.1"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+checksum = "f4987bdc12753382e0bec4a65c50738ffaabc998b9cdd1f952fb5f39b0048a96"
 dependencies = [
- "crypto-common",
- "subtle",
+ "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -4367,6 +5662,24 @@ name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
@@ -4537,7 +5850,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap",
+ "indexmap 2.14.0",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -4563,7 +5876,7 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags",
  "hashbrown 0.15.5",
- "indexmap",
+ "indexmap 2.14.0",
  "semver 1.0.27",
 ]
 
@@ -4578,12 +5891,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "wincode"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfc6339f1ba427bf7ad7c42403b28e524832ba2ddb5eef1bb2cc3b85db6b7b75"
+dependencies = [
+ "pastey",
+ "proc-macro2",
+ "quote",
+ "thiserror",
 ]
 
 [[package]]
@@ -4901,6 +6245,9 @@ name = "winnow"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen"
@@ -4936,7 +6283,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap",
+ "indexmap 2.14.0",
  "prettyplease",
  "syn 2.0.115",
  "wasm-metadata",
@@ -4967,7 +6314,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags",
- "indexmap",
+ "indexmap 2.14.0",
  "log",
  "serde",
  "serde_derive",
@@ -4986,7 +6333,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap",
+ "indexmap 2.14.0",
  "log",
  "semver 1.0.27",
  "serde",
@@ -4997,13 +6344,62 @@ dependencies = [
 ]
 
 [[package]]
-name = "x25519-dalek"
-version = "2.0.1"
+name = "wnaf"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
+checksum = "ab12e7090f27e2ffd9322651492942d50c2926094af30601e1964337db39daf1"
+dependencies = [
+ "ff",
+ "group",
+ "hybrid-array",
+]
+
+[[package]]
+name = "writeable"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ad82d2a33cdc9674dc7465672f271e096168fcdbe0f799d9e6db8c5892679dc"
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
+
+[[package]]
+name = "x25519-dalek"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7e8131a03190127fb2263afc72b322ecadae46b6ff8c6f399ff5d02f5559af6"
 dependencies = [
  "curve25519-dalek",
- "rand_core 0.6.4",
+ "rand_core 0.10.0",
+]
+
+[[package]]
+name = "yoke"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.115",
+ "synstructure",
 ]
 
 [[package]]
@@ -5027,7 +6423,75 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.115",
+ "synstructure",
+]
+
+[[package]]
 name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.115",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ea269c3bd32f0a32c321907a2ae912ba6f4649bb0fc764a15627e99a7095a3f"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0464e17806c1d976d5cba29399c7f08e516e279e2ba493f63123b5fca67dd8"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34df6fc39dbd26ddc9c10e6a2984476e13acce22e64e4487636ef494369225da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]

--- a/docs/Cargo.toml
+++ b/docs/Cargo.toml
@@ -4,8 +4,9 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-miden-client = { version = "0.15", features = ["testing", "tonic"] }
-miden-client-sqlite-store = { version = "0.15", package = "miden-client-sqlite-store" }
-miden-protocol = { version = "0.15" }
-rand = { version = "0.9" }
+miden-client = { version = "=0.16.0", features = ["testing", "tonic"] }
+miden-client-sqlite-store = { version = "=0.16.0", package = "miden-client-sqlite-store" }
+miden-protocol = { version = "=0.16.0" }
+rust-client = { path = "../rust-client" }
+rand = { version = "0.10" }
 tokio = { version = "1.48", features = ["rt-multi-thread", "net", "macros", "fs"] }

--- a/docs/src/miden_node_setup.md
+++ b/docs/src/miden_node_setup.md
@@ -5,17 +5,27 @@ sidebar_position: 2
 
 # Miden Node Setup Tutorial
 
-To run the Miden tutorial examples, you connect to a Miden node. By default, **every tutorial in this book targets the public Miden testnet** — no local setup is required. If you would rather run against your own node, you can start a local network instead.
+The v0.16 client tutorials connect to public Miden testnet by default, so no local
+node is required. You can also configure them to use your own network.
 
-## Connecting to the Miden testnet
+## Connecting to the public networks
 
-The tutorials use the public testnet by default. Its RPC endpoint is:
+The testnet RPC endpoint is:
 
-```bash
-https://rpc.testnet.miden.io:443
+```text
+https://rpc.testnet.miden.io
 ```
 
-This is the endpoint the examples pass to the client (`Endpoint::testnet()` in the Rust client), so they work out of the box with no additional setup.
+Use `Endpoint::testnet()` in Rust or `MidenClient.createTestnet()` in the web SDK.
+The tutorial runner selects testnet by default:
+
+```bash
+yarn tutorials
+```
+
+Testnet transactions pay fees in the native asset. The examples fund new accounts
+from the public faucet before their first transaction. Use fresh local stores and
+reassemble MASM sources when migrating from an earlier release.
 
 ## Running a local network
 
@@ -25,4 +35,6 @@ Running against a local network is optional and only needed for a fully self-hos
 
 Network transactions additionally require the **network transaction builder** (`miden-ntx-builder`), the component that executes network notes on an account's behalf. The local-network setup linked above provisions it; a node without the builder will commit network notes but never execute them.
 
-Once your local network is running, point the tutorials at its RPC endpoint instead of `Endpoint::testnet()`.
+To use a local network, update the client's RPC endpoint and its address, native
+asset, and faucet configuration to match that deployment. The runner's
+`TUTORIAL_NETWORK` option accepts only `testnet` and `devnet`, not a local RPC URL.

--- a/docs/src/rust-client/counter_contract_tutorial.md
+++ b/docs/src/rust-client/counter_contract_tutorial.md
@@ -7,9 +7,11 @@ sidebar_position: 4
 
 _Using the Miden client in Rust to deploy and interact with a custom smart contract on Miden_
 
+For toolchain requirements and shared fee helpers, see the [Rust client setup](./index.md#running-the-v016-examples).
+
 ## Overview
 
-In this tutorial, we will build a simple counter smart contract that maintains a count, deploy it to the Miden testnet, and interact with it by incrementing the count. You can also deploy the counter contract on a locally running Miden node, similar to previous tutorials.
+In this tutorial, we will build a simple counter smart contract that maintains a count, deploy it to Miden testnet, and interact with it by incrementing the count.
 
 Using a script, we will invoke the increment function within the counter contract to update the count. This tutorial provides a foundational understanding of developing and deploying custom smart contracts on Miden.
 
@@ -18,7 +20,7 @@ Using a script, we will invoke the increment function within the counter contrac
 - Deploying a custom smart contract on Miden
 - Getting up to speed with the basics of Miden assembly
 - Calling procedures in an account
-- Pure vs state changing procedures
+- Read-only vs state-changing procedures
 
 ## Prerequisites
 
@@ -26,55 +28,66 @@ This tutorial assumes you have a basic understanding of Miden assembly. To quick
 
 ## Step 1: Initialize your repository
 
-Create a new Rust repository for your Miden project and navigate to it with the following command:
+From the parent directory of your `tutorials` clone, create a sibling Cargo project:
 
 ```bash
 cargo new miden-counter-contract
 cd miden-counter-contract
+rustup override set 1.98.1
+cp ../tutorials/rust-client/Cargo.lock Cargo.lock
 ```
 
 Add the following dependencies to your `Cargo.toml` file:
 
 ```toml
 [dependencies]
-miden-client = { version = "0.15", features = ["testing", "tonic"] }
-miden-client-sqlite-store = { version = "0.15", package = "miden-client-sqlite-store" }
-miden-protocol = { version = "0.15" }
-rand = { version = "0.9" }
-tokio = { version = "1.46", features = ["rt-multi-thread", "net", "macros", "fs"] }
+# Clone tutorials next to this Cargo project (see Rust client setup).
+rust-client = { path = "../tutorials/rust-client" }
+miden-client = { version = "=0.16.0", features = ["testing", "tonic"] }
+miden-client-sqlite-store = { version = "=0.16.0", package = "miden-client-sqlite-store" }
+miden-protocol = { version = "=0.16.0" }
+rand = { version = "0.10" }
+tokio = { version = "1.48", features = ["rt-multi-thread", "net", "macros", "fs"] }
+
+[profile.dev]
+opt-level = 2
 ```
 
 ### Set up your `src/main.rs` file
 
-In the previous section, we explained how to instantiate the Miden client. We can reuse the same `initialize_client` function for our counter contract.
+In the previous section, we explained how to instantiate the Miden client. We reuse that client setup and the shared fee helpers for our counter contract.
 
 Copy and paste the following code into your `src/main.rs` file:
 
 ```rust no_run
-use rand::RngCore;
+use rand::Rng;
+use rust_client::TutorialClientExt;
 use std::{path::PathBuf, sync::Arc};
 
 use miden_client::{
+    ClientError, Word,
     account::{
-        component::AccountComponentMetadata, AccountBuilder, AccountComponent,
-        AccountType, StorageSlot, StorageSlotName,
+        AccountBuilder, AccountComponent, AccountType, StorageSlot, StorageSlotName,
+        component::{AccountComponentMetadata, BasicWallet},
     },
-    address::NetworkId,
     auth::NoAuth,
     builder::ClientBuilder,
     keystore::FilesystemKeyStore,
-    rpc::{Endpoint, GrpcClient},
+    rpc::{GrpcClient, VerifyingRpcClient},
     transaction::TransactionRequestBuilder,
-    ClientError, Word,
 };
 use miden_client_sqlite_store::ClientBuilderSqliteExt;
+use rust_client::{FeeConfig, TutorialNetwork, fund_account_for_fees};
 
 #[tokio::main]
 async fn main() -> Result<(), ClientError> {
     // Initialize client
-    let endpoint = Endpoint::testnet();
+    let network = TutorialNetwork::from_env()?;
+    let endpoint = network.endpoint();
     let timeout_ms = 10_000;
-    let rpc_client = Arc::new(GrpcClient::new(&endpoint, timeout_ms));
+    let rpc_client = Arc::new(VerifyingRpcClient::new(GrpcClient::new(
+        &endpoint, timeout_ms,
+    )));
 
     // Initialize keystore
     let keystore_path = PathBuf::from("./keystore");
@@ -86,12 +99,12 @@ async fn main() -> Result<(), ClientError> {
         .rpc(rpc_client)
         .sqlite_store(store_path)
         .authenticator(keystore.clone())
-        .in_debug_mode(true.into())
         .build()
         .await?;
 
     let sync_summary = client.sync_state().await.unwrap();
     println!("Latest block: {}", sync_summary.block_num);
+    let fee_config = FeeConfig::from_client(&client, network).await?;
 
     Ok(())
 }
@@ -103,35 +116,20 @@ _When running the code above, there will be some unused imports, however, we wil
 
 ## Step 2: Build the counter contract
 
-For better code organization, we will separate the Miden assembly code from our Rust code.
-
-Create a directory named `masm` at the **root** of your `miden-counter-contract` directory. This will contain our contract and script masm code.
-
-Initialize the `masm` directory:
-
-```bash
-mkdir -p masm/accounts masm/scripts
-```
-
-This will create:
-
-```text
-masm/
-├── accounts/
-└── scripts/
-```
+The account and transaction-script sources are already in the repository. We examine them below before compiling them from Rust.
 
 ### Custom Miden smart contract
 
-Below is our counter contract. It has a two exported procedures: `get_count` and `increment_count`.
+Below is our counter contract. It has two exported procedures: `get_count` and `increment_count`.
 
 At the beginning of the MASM file, we define our imports. In this case, we import
-`miden::protocol::active_account`, `miden::protocol::native_account`, `miden::core::word`, and
+`miden::protocol::active_account`, `miden::protocol::native_account`, and
 `miden::core::sys`.
 
 The `miden::protocol::active_account` and `miden::protocol::native_account` modules contain
-procedures for reading and writing contract state. We use `miden::core::word` to convert the slot
-name into a slot ID for the account storage APIs.
+procedures for reading and writing contract state. The compile-time expression
+`word("miden::tutorials::counter")` derives the named storage slot's ID; `[0..2]`
+selects the two elements used by the account storage APIs.
 
 The import `miden::core::sys` contains a useful procedure for truncating the operand stack at the
 end of a procedure.
@@ -152,51 +150,68 @@ end of a procedure.
 4. Adds `1` to the count value returned from `active_account::get_item`.
 5. Pushes the slot ID prefix and suffix again so we can write the updated count.
 6. Calls `native_account::set_item` which saves the incremented count to storage.
-7. Calls `sys::truncate_stack` to clean up the stack.
+7. Drops the old storage word returned by `set_item`, then calls `sys::truncate_stack` to clean up the stack.
 
-Inside of the `masm/accounts/` directory, create the `counter.masm` file:
+The counter is defined in `masm/accounts/counter.masm`:
 
 ```masm
 use miden::protocol::active_account
 use miden::protocol::native_account
-use miden::core::word
 use miden::core::sys
+
+# CONSTANTS
+# =================================================================================================
 
 const COUNTER_SLOT = word("miden::tutorials::counter")
 
-#! Inputs:  []
-#! Outputs: [count]
-pub proc get_count
+# PUBLIC INTERFACE
+# =================================================================================================
+
+#! Returns the current count.
+#!
+#! Inputs:  [pad(16)]
+#! Outputs: [count, pad(15)]
+#!
+#! Invocation: call
+@account_procedure
+pub proc get_count() -> felt
     push.COUNTER_SLOT[0..2] exec.active_account::get_item
-    # => [count]
+    # => [[count, 0, 0, 0], pad(16)]
 
     exec.sys::truncate_stack
-    # => [count]
+    # => [count, pad(15)]
 end
 
-#! Inputs:  []
-#! Outputs: []
-pub proc increment_count
+#! Increments the current count by one.
+#!
+#! Inputs:  [pad(16)]
+#! Outputs: [pad(16)]
+#!
+#! Invocation: call
+@account_procedure
+pub proc increment_count()
     push.COUNTER_SLOT[0..2] exec.active_account::get_item
-    # => [count]
+    # => [[count, 0, 0, 0], pad(16)]
 
     add.1
-    # => [count+1]
+    # => [[count + 1, 0, 0, 0], pad(16)]
 
     push.COUNTER_SLOT[0..2] exec.native_account::set_item
-    # => []
+    # => [OLD_VALUE, pad(16)]
+
+    dropw
+    # => [pad(16)]
 
     exec.sys::truncate_stack
-    # => []
+    # => [pad(16)]
 end
-
 ```
 
 **Note**: _It's a good habit to add comments below each line of MASM code with the expected stack state. This improves readability and helps with debugging._
 
 ### Authentication Component
 
-**Important**: Starting with Miden Client 0.10.0, all accounts must have an authentication component. For smart contracts that don't require authentication (like our counter contract), we use a `NoAuth` component.
+Accounts require an authentication component. This public counter deliberately uses `NoAuth`, which pays transaction fees from the account's native-asset balance and updates its nonce without verifying a signature.
 
 This `NoAuth` component allows any user to interact with the smart contract without requiring signature verification.
 
@@ -204,21 +219,35 @@ This `NoAuth` component allows any user to interact with the smart contract with
 
 This is a Miden assembly script that will call the `increment_count` procedure during the transaction.
 
-The string `{increment_count}` will be replaced with the hash of the `increment_count` procedure in our rust program.
+The Rust code links the counter module as `external_contract::counter_contract`, so the script can call `counter_contract::increment_count` by name.
 
-Inside of the `masm/scripts/` directory, create the `counter_script.masm` file:
+The transaction script is defined in `masm/scripts/counter_script.masm`:
 
 ```masm
 use external_contract::counter_contract
 
-begin
+#! Increments the counter.
+#!
+#! Inputs:  [ARGS, pad(12)]
+#! Outputs: [pad(16)]
+#!
+#! Where:
+#! - ARGS contains unused transaction script arguments.
+#!
+#! Invocation: dyncall
+@transaction_script
+pub proc main(args: word)
+    dropw
+    # => [pad(16)]
+
     call.counter_contract::increment_count
+    # => [pad(16)]
 end
 ```
 
 ## Step 3: Build the counter smart contract
 
-To build the counter contract copy and paste the following code at the end of your `src/main.rs` file:
+To build the counter contract, insert the following code inside `main`, immediately before its final `Ok(())`:
 
 ```rust ignore
 // -------------------------------------------------------------------------
@@ -226,21 +255,22 @@ To build the counter contract copy and paste the following code at the end of yo
 // -------------------------------------------------------------------------
 println!("\n[STEP 1] Creating counter contract.");
 
-// Load the MASM file for the counter contract. `include_str!` resolves at
-// compile time relative to this source file, so the binary is independent of
-// the working directory it is run from.
-let counter_code = include_str!("../masm/accounts/counter.masm");
+// Read the MASM source from the tutorials repository.
+let counter_code = std::fs::read_to_string("../tutorials/masm/accounts/counter.masm").unwrap();
 
 // Compile the account code into `AccountComponent` with one storage slot.
 let counter_slot_name =
     StorageSlotName::new("miden::tutorials::counter").expect("valid slot name");
 let component_code = client
     .code_builder()
-    .compile_component_code("external_contract::counter_contract", counter_code)
+    .compile_component_code("external_contract::counter_contract", &counter_code)
     .unwrap();
 let counter_component = AccountComponent::new(
     component_code,
-    vec![StorageSlot::with_value(counter_slot_name.clone(), Word::default())],
+    vec![StorageSlot::with_value(
+        counter_slot_name.clone(),
+        Word::default(),
+    )],
     AccountComponentMetadata::new("external_contract::counter_contract"),
 )
 .unwrap();
@@ -253,7 +283,8 @@ client.rng().fill_bytes(&mut seed);
 let counter_contract = AccountBuilder::new(seed)
     .account_type(AccountType::Public)
     .with_component(counter_component.clone())
-    .with_auth_component(NoAuth)
+    .with_component(BasicWallet)
+    .with_component(NoAuth)
     .build()
     .unwrap();
 
@@ -265,28 +296,31 @@ println!("counter_contract id: {:?}", counter_contract.id());
 println!("counter_contract storage: {:?}", counter_contract.storage());
 
 client.add_account(&counter_contract, false).await.unwrap();
+fund_account_for_fees(&mut client, counter_contract.id(), &fee_config).await?;
 ```
 
 Run the following command to execute `src/main.rs`:
 
 ```bash
-cargo run --release
+TUTORIAL_NETWORK=testnet cargo run --release
 ```
 
-After the program executes, you should see the counter contract hash and contract id printed to the terminal, for example:
+After the program executes, it prints the initial account commitment, ID, and storage. Abridged output looks like this; generated values vary:
 
 ```text
 [STEP 1] Creating counter contract.
-counter_contract commitment: RpoDigest([3700134472268167470, 14878091556015233722, 3335592073702485043, 16978997897830363420])
-counter_contract id: "<testnet_account_id>"
-counter_contract storage: AccountStorage { slots: [Value([0, 0, 0, 0]), Value([0, 0, 0, 0])] }
+counter_contract commitment: Word([...])
+counter_contract id: V1(AccountIdV1 { suffix: ..., prefix: ... })
+counter_contract storage: AccountStorage { slots: [StorageSlot { ... content: Value(Word([0, 0, 0, 0])) }] }
 ```
+
+The funding helper then consumes a native-asset note and waits for confirmation. That first transaction publishes the account without incrementing its counter.
 
 ## Step 4: Incrementing the count
 
-Now that we built the counter contract, lets create a transaction request to increment the count:
+Now that we have built and funded the counter contract, let's create a transaction request to increment the count:
 
-Paste the following code at the end of your `src/main.rs` file:
+Insert the following code after the previous step, still inside `main` and before `Ok(())`:
 
 ```rust ignore
 // -------------------------------------------------------------------------
@@ -295,15 +329,16 @@ Paste the following code at the end of your `src/main.rs` file:
 println!("\n[STEP 2] Call Counter Contract With Script");
 
 // Load the MASM script referencing the increment procedure
-let script_code = include_str!("../masm/scripts/counter_script.masm");
+let script_code =
+    std::fs::read_to_string("../tutorials/masm/scripts/counter_script.masm").unwrap();
 
 // Compile the script with the counter contract code linked as a module
 // on the same `CodeBuilder` chain.
 let tx_script = client
     .code_builder()
-    .with_linked_module("external_contract::counter_contract", counter_code)
+    .with_linked_module("external_contract::counter_contract", &counter_code)
     .unwrap()
-    .compile_tx_script(script_code)
+    .compile_tx_script(&script_code)
     .unwrap();
 
 // Build a transaction request with the custom script
@@ -314,18 +349,19 @@ let tx_increment_request = TransactionRequestBuilder::new()
 
 // Execute and submit the transaction
 let tx_id = client
-    .submit_new_transaction(counter_contract.id(), tx_increment_request)
+    .submit_tutorial_transaction(counter_contract.id(), tx_increment_request)
     .await
     .unwrap();
 
 println!(
-    "View transaction on MidenScan: https://testnet.midenscan.com/tx/{:?}",
+    "View transaction on MidenScan: {}/tx/{:?}",
+    network.explorer_url(),
     tx_id
 );
 
 println!(
     "Counter contract id: {:?}",
-    counter_contract.id().to_bech32(NetworkId::Testnet)
+    counter_contract.id().to_bech32(network.network_id())
 );
 
 client.sync_state().await.unwrap();
@@ -340,39 +376,48 @@ println!(
     "counter contract storage: {:?}",
     account.storage().get_item(&counter_slot_name)
 );
+assert_eq!(
+    account.storage().get_item(&counter_slot_name).unwrap()[0].as_canonical_u64(),
+    1,
+    "the deployed counter must increment from zero to one",
+);
 ```
 
-**Note**: _Once our counter contract is deployed, other users can increment the count of the smart contract simply by knowing the account id of the contract and the procedure hash of the `increment_count` procedure._
+Because this counter uses `NoAuth`, another client can import its public state and execute the same increment script. Public visibility alone does not grant that permission; the account's authentication component does.
 
 ## Summary
 
 The final `src/main.rs` file should look like this:
 
 ```rust no_run
-use rand::RngCore;
+use rand::Rng;
+use rust_client::TutorialClientExt;
 use std::{path::PathBuf, sync::Arc};
 
 use miden_client::{
+    ClientError, Word,
     account::{
-        component::AccountComponentMetadata, AccountBuilder, AccountComponent,
-        AccountType, StorageSlot, StorageSlotName,
+        AccountBuilder, AccountComponent, AccountType, StorageSlot, StorageSlotName,
+        component::{AccountComponentMetadata, BasicWallet},
     },
-    address::NetworkId,
     auth::NoAuth,
     builder::ClientBuilder,
     keystore::FilesystemKeyStore,
-    rpc::{Endpoint, GrpcClient},
+    rpc::{GrpcClient, VerifyingRpcClient},
     transaction::TransactionRequestBuilder,
-    ClientError, Word,
 };
 use miden_client_sqlite_store::ClientBuilderSqliteExt;
+use rust_client::{FeeConfig, TutorialNetwork, fund_account_for_fees};
 
 #[tokio::main]
 async fn main() -> Result<(), ClientError> {
     // Initialize client
-    let endpoint = Endpoint::testnet();
+    let network = TutorialNetwork::from_env()?;
+    let endpoint = network.endpoint();
     let timeout_ms = 10_000;
-    let rpc_client = Arc::new(GrpcClient::new(&endpoint, timeout_ms));
+    let rpc_client = Arc::new(VerifyingRpcClient::new(GrpcClient::new(
+        &endpoint, timeout_ms,
+    )));
 
     // Initialize keystore
     let keystore_path = PathBuf::from("./keystore");
@@ -384,33 +429,34 @@ async fn main() -> Result<(), ClientError> {
         .rpc(rpc_client)
         .sqlite_store(store_path)
         .authenticator(keystore.clone())
-        .in_debug_mode(true.into())
         .build()
         .await?;
 
     let sync_summary = client.sync_state().await.unwrap();
     println!("Latest block: {}", sync_summary.block_num);
+    let fee_config = FeeConfig::from_client(&client, network).await?;
 
     // -------------------------------------------------------------------------
     // STEP 1: Create a basic counter contract
     // -------------------------------------------------------------------------
     println!("\n[STEP 1] Creating counter contract.");
 
-    // Load the MASM file for the counter contract. `include_str!` resolves at
-    // compile time relative to this source file, so the binary is independent
-    // of the working directory it is run from.
-    let counter_code = include_str!("../masm/accounts/counter.masm");
+    // Read the MASM source from the tutorials repository.
+    let counter_code = std::fs::read_to_string("../tutorials/masm/accounts/counter.masm").unwrap();
 
     // Compile the account code into `AccountComponent` with one storage slot.
     let counter_slot_name =
         StorageSlotName::new("miden::tutorials::counter").expect("valid slot name");
     let component_code = client
         .code_builder()
-        .compile_component_code("external_contract::counter_contract", counter_code)
+        .compile_component_code("external_contract::counter_contract", &counter_code)
         .unwrap();
     let counter_component = AccountComponent::new(
         component_code,
-        vec![StorageSlot::with_value(counter_slot_name.clone(), Word::default())],
+        vec![StorageSlot::with_value(
+            counter_slot_name.clone(),
+            Word::default(),
+        )],
         AccountComponentMetadata::new("external_contract::counter_contract"),
     )
     .unwrap();
@@ -423,7 +469,8 @@ async fn main() -> Result<(), ClientError> {
     let counter_contract = AccountBuilder::new(seed)
         .account_type(AccountType::Public)
         .with_component(counter_component.clone())
-        .with_auth_component(NoAuth)
+        .with_component(BasicWallet)
+        .with_component(NoAuth)
         .build()
         .unwrap();
 
@@ -435,6 +482,7 @@ async fn main() -> Result<(), ClientError> {
     println!("counter_contract storage: {:?}", counter_contract.storage());
 
     client.add_account(&counter_contract, false).await.unwrap();
+    fund_account_for_fees(&mut client, counter_contract.id(), &fee_config).await?;
 
     // -------------------------------------------------------------------------
     // STEP 2: Call the Counter Contract with a script
@@ -442,15 +490,16 @@ async fn main() -> Result<(), ClientError> {
     println!("\n[STEP 2] Call Counter Contract With Script");
 
     // Load the MASM script referencing the increment procedure
-    let script_code = include_str!("../masm/scripts/counter_script.masm");
+    let script_code =
+        std::fs::read_to_string("../tutorials/masm/scripts/counter_script.masm").unwrap();
 
     // Compile the script with the counter contract code linked as a module
     // on the same `CodeBuilder` chain.
     let tx_script = client
         .code_builder()
-        .with_linked_module("external_contract::counter_contract", counter_code)
+        .with_linked_module("external_contract::counter_contract", &counter_code)
         .unwrap()
-        .compile_tx_script(script_code)
+        .compile_tx_script(&script_code)
         .unwrap();
 
     // Build a transaction request with the custom script
@@ -461,18 +510,19 @@ async fn main() -> Result<(), ClientError> {
 
     // Execute and submit the transaction
     let tx_id = client
-        .submit_new_transaction(counter_contract.id(), tx_increment_request)
+        .submit_tutorial_transaction(counter_contract.id(), tx_increment_request)
         .await
         .unwrap();
 
     println!(
-        "View transaction on MidenScan: https://testnet.midenscan.com/tx/{:?}",
+        "View transaction on MidenScan: {}/tx/{:?}",
+        network.explorer_url(),
         tx_id
     );
 
     println!(
         "Counter contract id: {:?}",
-        counter_contract.id().to_bech32(NetworkId::Testnet)
+        counter_contract.id().to_bech32(network.network_id())
     );
 
     client.sync_state().await.unwrap();
@@ -487,62 +537,41 @@ async fn main() -> Result<(), ClientError> {
         "counter contract storage: {:?}",
         account.storage().get_item(&counter_slot_name)
     );
+    assert_eq!(
+        account.storage().get_item(&counter_slot_name).unwrap()[0].as_canonical_u64(),
+        1,
+        "the deployed counter must increment from zero to one",
+    );
 
     Ok(())
 }
 ```
 
-The output of our program will look something like this:
+Successful output includes the following lines (abridged; generated values vary):
 
 ```text
-Latest block: 374255
+Latest block: <block_number>
 
 [STEP 1] Creating counter contract.
-one or more warnings were emitted
-counter_contract commitment: Word([3964727668949550262, 4265714847747507878, 5784293172192015964, 16803438753763367241])
-counter_contract id: "<testnet_account_id>"
-counter_contract storage: AccountStorage { slots: [Value(Word([0, 0, 0, 0]))] }
+counter_contract commitment: Word([...])
+counter_contract id: V1(AccountIdV1 { suffix: ..., prefix: ... })
+counter_contract storage: AccountStorage { slots: [StorageSlot { ... content: Value(Word([0, 0, 0, 0])) }] }
 
 [STEP 2] Call Counter Contract With Script
-Stack state before step 2610:
-├──  0: 1
-├──  1: 0
-├──  2: 0
-├──  3: 0
-├──  4: 0
-├──  5: 0
-├──  6: 0
-├──  7: 0
-├──  8: 0
-├──  9: 0
-├── 10: 0
-├── 11: 0
-├── 12: 0
-├── 13: 0
-├── 14: 0
-├── 15: 0
-├── 16: 0
-├── 17: 0
-├── 18: 0
-└── 19: 0
-
-└── (0 more items)
-
-View transaction on MidenScan: https://testnet.midenscan.com/tx/0x9767940bbed7bd3a74c24dc43f1ea8fe90a876dc7925621c217f648c63c4ab7a
-counter contract storage: Ok(Word([0, 0, 0, 1]))
+View transaction on MidenScan: https://testnet.midenscan.com/tx/<transaction_id>
+Counter contract id: "<testnet_account_id>"
+counter contract storage: Ok(Word([1, 0, 0, 0]))
 ```
 
-The line in the output `Stack state before step 2505` ouputs the stack state when we call "debug.stack" in the `counter.masm` file.
-
-To increment the count of the counter contract all you need is to know the account id of the counter and the procedure hash of the `increment_count` procedure. To increment the count without deploying the counter each time, you can modify the program above to hardcode the account id of the counter and the procedure hash of the `increment_count` prodedure in the masm script.
+To increment the contract again without redeploying it, pass the printed testnet account ID to the [public-account interaction tutorial](./public_account_interaction_tutorial.md). Keeping the ID as an input avoids hard-coding an address that becomes invalid after a testnet reset.
 
 ### Running the example
 
-To run the full example, navigate to the `rust-client` directory in the [miden-tutorials](https://github.com/0xMiden/miden-tutorials/) repository and run this command:
+To run the checked-in example, return to the root of the [tutorials repository](https://github.com/0xMiden/tutorials/) and run:
 
 ```bash
 cd rust-client
-cargo run --release --bin counter_contract_deploy
+TUTORIAL_NETWORK=testnet cargo run --release --bin counter_contract_deploy
 ```
 
 ### Continue learning

--- a/docs/src/rust-client/create_deploy_tutorial.md
+++ b/docs/src/rust-client/create_deploy_tutorial.md
@@ -7,6 +7,8 @@ sidebar_position: 2
 
 _Using the Miden client in Rust to create accounts and deploy faucets_
 
+For toolchain requirements and shared fee helpers, see the [Rust client setup](./index.md#running-the-v016-examples).
+
 ## Overview
 
 In this tutorial, we will create a Miden account for _Alice_ and deploy a fungible faucet. In the next section, we will mint tokens from the faucet to fund her account and transfer tokens from Alice's account to other Miden accounts.
@@ -20,39 +22,46 @@ In this tutorial, we will create a Miden account for _Alice_ and deploy a fungib
 
 ## Prerequisites
 
-Before you begin, ensure that a Miden node is running locally in a separate terminal window. To get the Miden node running locally, you can follow the instructions on the [Miden Node Setup](../miden_node_setup.md) page.
+The commands in this guide select the public testnet explicitly. If you change the endpoint to a local node, start that node first by following [Miden Node Setup](../miden_node_setup.md).
 
 ## Public vs. private accounts & notes
 
 Before diving into coding, let's clarify the concepts of public and private accounts & notes on Miden:
 
 - Public accounts: The account's data and code are stored on-chain and are openly visible, including its assets.
-- Private accounts: The account's state and logic are off-chain, only known to its owner.
+- Private accounts: Only a commitment to the account state is stored on-chain. The owner keeps the full state locally and may share it with others.
 - Public notes: The note's state is visible to anyone - perfect for scenarios where transparency is desired.
 - Private notes: The note's state is stored off-chain, you will need to share the note data with the relevant parties (via email or Telegram) for them to be able to consume the note.
 
 Note: _The term "account" can be used interchangeably with the term "smart contract" since account abstraction on Miden is handled natively._
 
-_It is useful to think of notes on Miden as "cryptographic cashier's checks" that allow users to send tokens. If the note is private, the note transfer is only known to the sender and receiver._
+_It is useful to think of notes on Miden as "cryptographic cashier's checks" that allow users to send tokens. Private note details must be shared with the recipient; the chain still records the note commitment and its eventual nullifier._
 
 ## Step 1: Initialize your repository
 
-Create a new Rust repository for your Miden project and navigate to it with the following command:
+Start in the directory containing your `tutorials` clone and create a sibling Cargo project. The dependency path below assumes the clone is named `tutorials`.
 
 ```bash
 cargo new miden-rust-client
 cd miden-rust-client
+rustup override set 1.98.1
+cp ../tutorials/rust-client/Cargo.lock Cargo.lock
 ```
 
-Add the following dependencies to your `Cargo.toml` file:
+Keep the generated `[package]` section in `Cargo.toml`, replace its empty `[dependencies]` section with the following, and add the development profile:
 
 ```toml
 [dependencies]
-miden-client = { version = "0.15", features = ["testing", "tonic"] }
-miden-client-sqlite-store = { version = "0.15", package = "miden-client-sqlite-store" }
-miden-protocol = { version = "0.15" }
-rand = { version = "0.9" }
-tokio = { version = "1.46", features = ["rt-multi-thread", "net", "macros", "fs"] }
+# Clone tutorials next to this Cargo project (see Rust client setup).
+rust-client = { path = "../tutorials/rust-client" }
+miden-client = { version = "=0.16.0", features = ["testing", "tonic"] }
+miden-client-sqlite-store = { version = "=0.16.0", package = "miden-client-sqlite-store" }
+miden-protocol = { version = "=0.16.0" }
+rand = { version = "0.10" }
+tokio = { version = "1.48", features = ["rt-multi-thread", "net", "macros", "fs"] }
+
+[profile.dev]
+opt-level = 2
 ```
 
 ## Step 2: Initialize the client
@@ -67,41 +76,41 @@ Before interacting with the Miden network, we must instantiate the client. In th
 Copy and paste the following code into your `src/main.rs` file.
 
 ```rust no_run
-use miden_client::auth::{AuthSchemeId, AuthSingleSig};
-use rand::RngCore;
+use rand::Rng;
+use rust_client::TutorialClientExt;
 use std::{path::PathBuf, sync::Arc};
 use tokio::time::Duration;
 
 use miden_client::{
-    account::{
-        component::{
-            BasicWallet, BurnPolicyConfig, FungibleFaucet, MintPolicyConfig, PolicyRegistration,
-            TokenName, TokenPolicyManager,
-        },
-        AccountId,
-    },
-    address::NetworkId,
-    auth::AuthSecretKey,
-    builder::ClientBuilder,
-    keystore::FilesystemKeyStore,
-    note::{NoteAttachments, NoteType, P2idNote},
-    rpc::{Endpoint, GrpcClient},
-    transaction::TransactionRequestBuilder,
     ClientError,
+    account::{
+        AccountBuilder, AccountId, AccountType,
+        component::{
+            create_singlesig_user_fungible_faucet, BasicWallet, BurnPolicy, FungibleFaucet,
+            MintPolicy, TokenName, TokenPolicyManager,
+        },
+    },
+    asset::{AssetAmount, AssetCallbackFlag, AssetId, FungibleAsset, TokenSymbol},
+    auth::{AuthSecretKey, AuthSingleSig},
+    builder::ClientBuilder,
+    keystore::{FilesystemKeyStore, Keystore},
+    note::{Note, NoteType, P2idNote},
+    rpc::{GrpcClient, VerifyingRpcClient},
+    transaction::{PaymentNoteDescription, TransactionRequestBuilder},
 };
 use miden_client_sqlite_store::ClientBuilderSqliteExt;
 use miden_protocol::account::AccountIdVersion;
-use miden_client::{
-    account::{AccountBuilder, AccountType},
-    asset::{AssetAmount, FungibleAsset, TokenSymbol},
-};
+use rust_client::{FeeConfig, TutorialNetwork, fund_account_for_fees};
 
 #[tokio::main]
 async fn main() -> Result<(), ClientError> {
     // Initialize client
-    let endpoint = Endpoint::testnet();
+    let network = TutorialNetwork::from_env()?;
+    let endpoint = network.endpoint();
     let timeout_ms = 10_000;
-    let rpc_client = Arc::new(GrpcClient::new(&endpoint, timeout_ms));
+    let rpc_client = Arc::new(VerifyingRpcClient::new(GrpcClient::new(
+        &endpoint, timeout_ms,
+    )));
 
     // Initialize keystore
     let keystore_path = PathBuf::from("./keystore");
@@ -113,12 +122,12 @@ async fn main() -> Result<(), ClientError> {
         .rpc(rpc_client)
         .sqlite_store(store_path)
         .authenticator(keystore.clone())
-        .in_debug_mode(true.into())
         .build()
         .await?;
 
     let sync_summary = client.sync_state().await.unwrap();
     println!("Latest block: {}", sync_summary.block_num);
+    let fee_config = FeeConfig::from_client(&client, network).await?;
 
     Ok(())
 }
@@ -131,24 +140,24 @@ _When running the code above, there will be some unused imports, however, we wil
 Run the following command to execute `src/main.rs`:
 
 ```bash
-cargo run --release
+TUTORIAL_NETWORK=testnet cargo run --release
 ```
 
 After the program executes, you should see the latest block number printed to the terminal, for example:
 
 ```text
-Latest block number: 3855
+Latest block: <current_block_number>
 ```
 
 ## Step 3: Creating a wallet
 
 Now that we've initialized the client, we can create a wallet for Alice.
 
-To create a wallet for Alice using the Miden client, we specify whether the account is public or private via `AccountType` (in v0.15 the account type is simply `AccountType::Public` or `AccountType::Private`). A wallet on Miden is simply an account with standardized code.
+To create a wallet for Alice using the Miden client, we select `AccountType::Public` or `AccountType::Private`. A wallet on Miden is simply an account with standardized code.
 
 In the example below we create a public account for Alice.
 
-Add this snippet to the end of your file in the `main()` function:
+Insert this snippet inside `main()`, immediately before its final `Ok(())`:
 
 ```rust ignore
 //------------------------------------------------------------
@@ -165,7 +174,7 @@ let key_pair = AuthSecretKey::new_falcon512_poseidon2_with_rng(client.rng());
 // Build the account
 let alice_account = AccountBuilder::new(init_seed)
     .account_type(AccountType::Public)
-    .with_auth_component(AuthSingleSig::new(key_pair.public_key().to_commitment(), AuthSchemeId::Falcon512Poseidon2))
+    .with_component(AuthSingleSig::from_public_key(key_pair.public_key()))
     .with_component(BasicWallet)
     .build()
     .unwrap();
@@ -174,20 +183,24 @@ let alice_account = AccountBuilder::new(init_seed)
 client.add_account(&alice_account, false).await?;
 
 // Add the key pair to the keystore
-use miden_client::keystore::Keystore;
-keystore.add_key(&key_pair, alice_account.id()).await.unwrap();
+keystore
+    .add_key(&key_pair, alice_account.id())
+    .await
+    .unwrap();
 
-let alice_account_id_bech32 = alice_account.id().to_bech32(NetworkId::Testnet);
+let alice_account_id_bech32 = alice_account.id().to_bech32(network.network_id());
 println!("Alice's account ID: {:?}", alice_account_id_bech32);
+
+fund_account_for_fees(&mut client, alice_account.id(), &fee_config).await?;
 ```
 
 ## Step 4: Deploying a fungible faucet
 
-To provide Alice with testnet assets, we must first deploy a faucet. A faucet account on Miden mints fungible tokens.
+To provide Alice with the tutorial's `MID` asset, we first deploy a faucet. This is separate from the public testnet faucet that supplies the native asset used to pay transaction fees. A faucet account on Miden mints its own fungible token.
 
-We'll create a public faucet with a token symbol, decimals, and a max supply. We will use this faucet to mint tokens to Alice's account in the next section.
+We'll create a public faucet with a token symbol, decimals, and a max supply. Amounts in these examples are raw units: with eight decimals, `100` units means `0.000001 MID`. The faucet's maximum supply is `1_000_000` raw units. We will use it to mint tokens to Alice's account in the next section.
 
-Add this snippet to the end of your file in the `main()` function:
+Insert this snippet inside `main()`, immediately before its final `Ok(())`:
 
 ```rust ignore
 //------------------------------------------------------------
@@ -208,45 +221,50 @@ let max_supply = AssetAmount::new(1_000_000).unwrap();
 let key_pair = AuthSecretKey::new_falcon512_poseidon2_with_rng(client.rng());
 
 // Build the faucet account.
-// In v0.15 the faucet is a `FungibleFaucet` component plus a `TokenPolicyManager`
+// The faucet is a `FungibleFaucet` component plus a `TokenPolicyManager`
 // that registers an "allow all" mint (and burn) policy; minting is rejected
 // unless an active mint policy is present.
-let faucet_account = AccountBuilder::new(init_seed)
-    .account_type(AccountType::Public)
-    .with_auth_component(AuthSingleSig::new(key_pair.public_key().to_commitment(), AuthSchemeId::Falcon512Poseidon2))
-    .with_component(
-        FungibleFaucet::builder()
-            .name(TokenName::new("MID").unwrap())
-            .symbol(symbol)
-            .decimals(decimals)
-            .max_supply(max_supply)
-            .build()
-            .unwrap(),
-    )
-    .with_components(
-        TokenPolicyManager::new()
-            .with_mint_policy(MintPolicyConfig::AllowAll, PolicyRegistration::Active)
-            .unwrap()
-            .with_burn_policy(BurnPolicyConfig::AllowAll, PolicyRegistration::Active)
-            .unwrap(),
-    )
+let faucet = FungibleFaucet::builder()
+    .name(TokenName::new("MID").unwrap())
+    .symbol(symbol)
+    .decimals(decimals)
+    .max_supply(max_supply)
     .build()
     .unwrap();
+let policies = TokenPolicyManager::builder()
+    .active_mint_policy(MintPolicy::allow_all())
+    .active_burn_policy(BurnPolicy::allow_all())
+    .build();
+// The SDK factory includes BasicWallet so the faucet can receive the native fee asset.
+let faucet_account = create_singlesig_user_fungible_faucet(
+    init_seed,
+    faucet,
+    AuthSingleSig::from_public_key(key_pair.public_key()),
+    policies,
+    AccountType::Public,
+)
+.unwrap();
 
 // Add the faucet to the client
 client.add_account(&faucet_account, false).await?;
 
 // Add the key pair to the keystore
-use miden_client::keystore::Keystore;
-keystore.add_key(&key_pair, faucet_account.id()).await.unwrap();
+keystore
+    .add_key(&key_pair, faucet_account.id())
+    .await
+    .unwrap();
 
-let faucet_account_id_bech32 = faucet_account.id().to_bech32(NetworkId::Testnet);
+let faucet_account_id_bech32 = faucet_account.id().to_bech32(network.network_id());
 println!("Faucet account ID: {:?}", faucet_account_id_bech32);
+
+fund_account_for_fees(&mut client, faucet_account.id(), &fee_config).await?;
 
 // Resync to show newly deployed faucet
 client.sync_state().await?;
 tokio::time::sleep(Duration::from_secs(2)).await;
 ```
+
+`client.add_account` registers each new account locally. `fund_account_for_fees` then consumes a native-asset funding note; this first confirmed transaction deploys the account and gives it a fee balance.
 
 _When tokens are minted from this faucet, each token batch is represented as a "note" (UTXO). You can think of a Miden Note as a cryptographic cashier's check that has certain spend conditions attached to it._
 
@@ -255,41 +273,41 @@ _When tokens are minted from this faucet, each token batch is represented as a "
 Your updated `main()` function in `src/main.rs` should look like this:
 
 ```rust no_run
-use miden_client::auth::{AuthSchemeId, AuthSingleSig};
-use rand::RngCore;
+use rand::Rng;
+use rust_client::TutorialClientExt;
 use std::{path::PathBuf, sync::Arc};
 use tokio::time::Duration;
 
 use miden_client::{
+    ClientError,
     account::{
+        AccountBuilder, AccountId, AccountType,
         component::{
-            BasicWallet, BurnPolicyConfig, FungibleFaucet, MintPolicyConfig, PolicyRegistration,
-            TokenName, TokenPolicyManager,
+            create_singlesig_user_fungible_faucet, BasicWallet, BurnPolicy, FungibleFaucet,
+            MintPolicy, TokenName, TokenPolicyManager,
         },
-        AccountId,
     },
-    address::NetworkId,
-    auth::AuthSecretKey,
+    asset::{AssetAmount, AssetCallbackFlag, AssetId, FungibleAsset, TokenSymbol},
+    auth::{AuthSecretKey, AuthSingleSig},
     builder::ClientBuilder,
     keystore::{FilesystemKeyStore, Keystore},
-    note::{NoteAttachments, NoteType, P2idNote},
-    rpc::{Endpoint, GrpcClient},
-    transaction::TransactionRequestBuilder,
-    ClientError,
+    note::{Note, NoteType, P2idNote},
+    rpc::{GrpcClient, VerifyingRpcClient},
+    transaction::{PaymentNoteDescription, TransactionRequestBuilder},
 };
 use miden_client_sqlite_store::ClientBuilderSqliteExt;
 use miden_protocol::account::AccountIdVersion;
-use miden_client::{
-    account::{AccountBuilder, AccountType},
-    asset::{AssetAmount, FungibleAsset, TokenSymbol},
-};
+use rust_client::{FeeConfig, TutorialNetwork, fund_account_for_fees};
 
 #[tokio::main]
 async fn main() -> Result<(), ClientError> {
     // Initialize client
-    let endpoint = Endpoint::testnet();
+    let network = TutorialNetwork::from_env()?;
+    let endpoint = network.endpoint();
     let timeout_ms = 10_000;
-    let rpc_client = Arc::new(GrpcClient::new(&endpoint, timeout_ms));
+    let rpc_client = Arc::new(VerifyingRpcClient::new(GrpcClient::new(
+        &endpoint, timeout_ms,
+    )));
 
     // Initialize keystore
     let keystore_path = PathBuf::from("./keystore");
@@ -301,12 +319,12 @@ async fn main() -> Result<(), ClientError> {
         .rpc(rpc_client)
         .sqlite_store(store_path)
         .authenticator(keystore.clone())
-        .in_debug_mode(true.into())
         .build()
         .await?;
 
     let sync_summary = client.sync_state().await.unwrap();
     println!("Latest block: {}", sync_summary.block_num);
+    let fee_config = FeeConfig::from_client(&client, network).await?;
 
     //------------------------------------------------------------
     // STEP 1: Create a basic wallet for Alice
@@ -322,7 +340,7 @@ async fn main() -> Result<(), ClientError> {
     // Build the account
     let alice_account = AccountBuilder::new(init_seed)
         .account_type(AccountType::Public)
-        .with_auth_component(AuthSingleSig::new(key_pair.public_key().to_commitment(), AuthSchemeId::Falcon512Poseidon2))
+        .with_component(AuthSingleSig::from_public_key(key_pair.public_key()))
         .with_component(BasicWallet)
         .build()
         .unwrap();
@@ -331,10 +349,15 @@ async fn main() -> Result<(), ClientError> {
     client.add_account(&alice_account, false).await?;
 
     // Add the key pair to the keystore
-    keystore.add_key(&key_pair, alice_account.id()).await.unwrap();
+    keystore
+        .add_key(&key_pair, alice_account.id())
+        .await
+        .unwrap();
 
-    let alice_account_id_bech32 = alice_account.id().to_bech32(NetworkId::Testnet);
+    let alice_account_id_bech32 = alice_account.id().to_bech32(network.network_id());
     println!("Alice's account ID: {:?}", alice_account_id_bech32);
+
+    fund_account_for_fees(&mut client, alice_account.id(), &fee_config).await?;
 
     //------------------------------------------------------------
     // STEP 2: Deploy a fungible faucet
@@ -354,39 +377,43 @@ async fn main() -> Result<(), ClientError> {
     let key_pair = AuthSecretKey::new_falcon512_poseidon2_with_rng(client.rng());
 
     // Build the faucet account.
-    // In v0.15 the faucet is a `FungibleFaucet` component plus a `TokenPolicyManager`
+    // The faucet is a `FungibleFaucet` component plus a `TokenPolicyManager`
     // that registers an "allow all" mint (and burn) policy; minting is rejected
     // unless an active mint policy is present.
-    let faucet_account = AccountBuilder::new(init_seed)
-        .account_type(AccountType::Public)
-        .with_auth_component(AuthSingleSig::new(key_pair.public_key().to_commitment(), AuthSchemeId::Falcon512Poseidon2))
-        .with_component(
-            FungibleFaucet::builder()
-                .name(TokenName::new("MID").unwrap())
-                .symbol(symbol)
-                .decimals(decimals)
-                .max_supply(max_supply)
-                .build()
-                .unwrap(),
-        )
-        .with_components(
-            TokenPolicyManager::new()
-                .with_mint_policy(MintPolicyConfig::AllowAll, PolicyRegistration::Active)
-                .unwrap()
-                .with_burn_policy(BurnPolicyConfig::AllowAll, PolicyRegistration::Active)
-                .unwrap(),
-        )
+    let faucet = FungibleFaucet::builder()
+        .name(TokenName::new("MID").unwrap())
+        .symbol(symbol)
+        .decimals(decimals)
+        .max_supply(max_supply)
         .build()
         .unwrap();
+    let policies = TokenPolicyManager::builder()
+        .active_mint_policy(MintPolicy::allow_all())
+        .active_burn_policy(BurnPolicy::allow_all())
+        .build();
+    // The SDK factory includes BasicWallet so the faucet can receive the native fee asset.
+    let faucet_account = create_singlesig_user_fungible_faucet(
+        init_seed,
+        faucet,
+        AuthSingleSig::from_public_key(key_pair.public_key()),
+        policies,
+        AccountType::Public,
+    )
+    .unwrap();
 
     // Add the faucet to the client
     client.add_account(&faucet_account, false).await?;
 
     // Add the key pair to the keystore
-    keystore.add_key(&key_pair, faucet_account.id()).await.unwrap();
+    keystore
+        .add_key(&key_pair, faucet_account.id())
+        .await
+        .unwrap();
 
-    let faucet_account_id_bech32 = faucet_account.id().to_bech32(NetworkId::Testnet);
+    let faucet_account_id_bech32 = faucet_account.id().to_bech32(network.network_id());
     println!("Faucet account ID: {:?}", faucet_account_id_bech32);
+
+    fund_account_for_fees(&mut client, faucet_account.id(), &fee_config).await?;
 
     // Resync to show newly deployed faucet
     client.sync_state().await?;
@@ -399,19 +426,19 @@ async fn main() -> Result<(), ClientError> {
 Let's run the `src/main.rs` program again:
 
 ```bash
-cargo run --release
+TUTORIAL_NETWORK=testnet cargo run --release
 ```
 
-The output will look like this:
+The following is an abbreviated output; account IDs and block numbers vary, and the funding helper also prints transaction confirmations:
 
 ```text
-Latest block: 17771
+Latest block: <current_block_number>
 
 [STEP 1] Creating a new account for Alice
-Alice's account ID: "0x3cb3e596d14ad410000017901eaa7b"
+Alice's account ID: "<alice_testnet_account_id>"
 
 [STEP 2] Deploying a new fungible faucet.
-Faucet account ID: "0x6ad1894ac233e4200000088311bb6b"
+Faucet account ID: "<faucet_testnet_account_id>"
 ```
 
 In this section we explained how to instantiate the Miden client, create a wallet account, and deploy a faucet.
@@ -420,11 +447,11 @@ In the next section we will cover how to mint tokens from the faucet, consume no
 
 ### Running the example
 
-To run a full working example navigate to the `rust-client` directory in the [miden-tutorials](https://github.com/0xMiden/miden-tutorials/) repository and run this command:
+From the root of your `tutorials` clone, run the checked-in example:
 
 ```bash
 cd rust-client
-cargo run --release --bin create_mint_consume_send
+TUTORIAL_NETWORK=testnet cargo run --release --bin create_mint_consume_send
 ```
 
 ### Continue learning

--- a/docs/src/rust-client/creating_notes_in_masm_tutorial.md
+++ b/docs/src/rust-client/creating_notes_in_masm_tutorial.md
@@ -7,13 +7,15 @@ sidebar_position: 11
 
 _Creating notes inside the MidenVM using Miden assembly_
 
+For toolchain requirements and shared fee helpers, see the [Rust client setup](./index.md#running-the-v016-examples).
+
 ## Overview
 
 In this tutorial, we will create a custom note that generates a copy of itself when it is consumed by an account. The purpose of this tutorial is to demonstrate how to create notes inside the MidenVM using Miden assembly (MASM). By the end of this tutorial, you will understand how to write MASM code that creates notes.
 
 ## What We'll Cover
 
-- Computing the note inputs commitment in MASM
+- Computing the note storage commitment and recipient in MASM
 - Creating notes in MASM
 
 ## Prerequisites
@@ -26,7 +28,7 @@ Being able to create a note in MASM enables you to build various types of applic
 
 Here are some tangible examples of when creating a note in MASM is useful in a DeFi context:
 
-- Creating snapshots of an account's state at a specific point in time (not possible in an EVM context)
+- Creating notes that record selected values from an account's state
 - Representing partially fillable buy/sell orders as notes (SWAPP)
 - Handling withdrawals from a smart contract
 
@@ -36,166 +38,184 @@ Here are some tangible examples of when creating a note in MASM is useful in a D
 
 In the diagram above, note A is consumed by an account, and during the transaction, note A' is created.
 
-In this tutorial, we will create a note that contains an asset. When consumed, it outputs a copy of itself and allows the consuming account to take half of the asset. Although this type of note would not be used in a real-world context, it demonstrates several key concepts for writing MASM code that can create notes.
+In this tutorial, Alice creates a note containing 100 raw units of a fungible asset. Bob consumes it, keeps 50 units, and creates a successor note with the other 50, the same script and storage, and an incremented serial number. The script does not restrict consumption to a particular account.
+
+This example requires exactly one fungible asset with a positive even amount and performs one split, from 100 to 50. MASM `div` is field division, so this script does not implement rounding for odd integer amounts and should not be used as an arbitrary repeated-halving contract.
 
 ## Step 1: Initialize Your Repository
 
-Create a new Rust repository for your Miden project and navigate to it with the following command:
+Start in the directory containing your `tutorials` clone and create a sibling Cargo project. The dependency path below assumes the clone is named `tutorials`.
 
 ```bash
 cargo new miden-project
 cd miden-project
+rustup override set 1.98.1
+cp ../tutorials/rust-client/Cargo.lock Cargo.lock
 ```
 
-Add the following dependencies to your `Cargo.toml` file:
+Keep the generated `[package]` section in `Cargo.toml`, replace its empty `[dependencies]` section with the following, and add the development profile:
 
 ```toml
 [dependencies]
-miden-client = { version = "0.15", features = ["testing", "tonic"] }
-miden-client-sqlite-store = { version = "0.15", package = "miden-client-sqlite-store" }
-miden-protocol = { version = "0.15" }
-rand = { version = "0.9" }
-tokio = { version = "1.46", features = ["rt-multi-thread", "net", "macros", "fs"] }
+# Clone tutorials next to this Cargo project (see Rust client setup).
+rust-client = { path = "../tutorials/rust-client" }
+miden-client = { version = "=0.16.0", features = ["testing", "tonic"] }
+miden-client-sqlite-store = { version = "=0.16.0", package = "miden-client-sqlite-store" }
+miden-protocol = { version = "=0.16.0" }
+rand = { version = "0.10" }
+tokio = { version = "1.48", features = ["rt-multi-thread", "net", "macros", "fs"] }
+
+[profile.dev]
+opt-level = 2
 ```
 
 ## Step 2: Write the Note Script
 
-For better code organization, we will separate the Miden assembly code from our Rust code.
-
-Create a directory named `masm` at the **root** of your `miden-project` directory. This directory will contain our contract and MASM script code.
-
-Initialize the `masm` directory:
-
-```bash
-mkdir masm/notes
-```
-
-This will create:
-
-```text
-masm/
-└── notes/
-```
-
-Inside the `masm/notes/` directory, create the file `iterative_output_note.masm`. Note scripts are compiled as libraries; the `@note_script` attribute marks the entrypoint procedure.
+The note script is in `masm/notes/iterative_output_note.masm`. Note scripts are compiled as libraries; the `@note_script` attribute marks the entrypoint procedure.
 
 ```masm
 use miden::protocol::active_note
 use miden::protocol::note
-use miden::protocol::output_note
 use miden::core::sys
-use miden::standards::wallets::basic->wallet
+use miden::standards::wallets::basic as wallet
+use miden::standards::note::note_creator
 
-# Memory Addresses
-# get_assets writes: ASSET_KEY at ASSET_KEY_PTR, ASSET_VALUE at ASSET_KEY_PTR+4 (ASSET_SIZE=8)
-const ASSET_KEY_PTR=0
-const ASSET_VALUE_PTR=4
-const ASSET_HALF_VALUE_PTR=8    # half-amount ASSET_VALUE stored here
-const ACCOUNT_ID_PREFIX=12      # storage: [prefix, suffix, tag, 0]
-const TAG=14                    # = ACCOUNT_ID_PREFIX + 2
+# CONSTANTS
+# =================================================================================================
 
-#! Inputs:  []
-#! Outputs: []
+# get_initial_assets writes the eight-felt asset as ASSET_ID followed by ASSET_VALUE
+const ASSET_ID_PTR = 0
+const ASSET_VALUE_PTR = 4
+const ASSET_HALF_VALUE_PTR = 8
+const ACCOUNT_ID_PREFIX = 12      # storage: [prefix, suffix, tag, 0]
+const TAG = 14                    # ACCOUNT_ID_PREFIX + 2
+
+# PUBLIC INTERFACE
+# =================================================================================================
+
+#! Receives this note's assets and creates a successor with half its fungible amount.
+#!
+#! This example expects exactly one fungible asset with a positive, even amount. Field division
+#! by two is not integer rounding, so an odd amount does not produce a valid half-amount transfer.
+#! Any account exposing the wallet and note-creator procedures may consume the note; the account
+#! ID in storage is copied into the successor's storage and does not restrict consumption.
+#!
+#! Inputs:  [ARGS, pad(12)]
+#! Outputs: [pad(16)]
+#!
+#! Where:
+#! - ARGS contains unused note arguments.
+#! - note storage contains a copied account ID and the successor's note tag.
+#!
+#! Panics if:
+#! - the account cannot receive the note's assets or move the computed half amount to the successor.
+#!
+#! Invocation: dyncall
 @note_script
-pub proc main
-    # Drop word if user accidentally pushes note_args
+pub proc main(args: word)
+    # discard the unused note arguments
     dropw
-    # => []
-
-    # Get asset contained in note into memory (ASSET_KEY at 0, ASSET_VALUE at 4)
-    # get_assets leaves [num_assets] on the stack in v0.15; drop it.
-    push.ASSET_KEY_PTR exec.active_note::get_assets drop
-    # => []
-
-    # Load ASSET_VALUE and compute half amount
-    padw push.ASSET_VALUE_PTR mem_loadw_le
-    # => [av0, av1, av2, av3]  (av0 = amount for fungible asset, av1/av2/av3 = 0)
-
-    # Halve the amount (av0 is the amount for fungible assets)
-    push.2 div
-    # => [av0/2, av1, av2, av3]
-
-    # Store as ASSET_HALF_VALUE
-    mem_storew_le.ASSET_HALF_VALUE_PTR dropw
-    # => []
-
-    # Receive all assets from note into the account wallet
-    exec.wallet::add_assets_to_account
-    # => []
-
-    # Push script hash
-    exec.active_note::get_script_root
-    # => [SCRIPT_HASH]
-
-    # Get the current note serial number
-    exec.active_note::get_serial_number
-    # => [SERIAL_NUM, SCRIPT_HASH]
-
-    # Increment the last element of the serial number by 1
-    # (serial_num[3] is at depth 3; matches Rust: serial_num[3] + 1)
-    swap.3 push.1 add swap.3
-    # => [SERIAL_NUM+1, SCRIPT_HASH]
-
-    # Load note storage into memory for recipient construction.
-    # get_storage consumes dest_ptr and leaves only [num_storage_items],
-    # so re-push the storage_ptr for the recipient call rather than swapping.
-    push.ACCOUNT_ID_PREFIX
-    exec.active_note::get_storage
-    # => [num_storage_items, SERIAL_NUM+1, SCRIPT_HASH]
-
-    push.ACCOUNT_ID_PREFIX
-    # => [storage_ptr, num_storage_items, SERIAL_NUM+1, SCRIPT_HASH]
-
-    # v0.15 renamed note::build_recipient -> note::compute_and_store_recipient
-    # (arg shape [storage_ptr, num_storage_items, SERIAL_NUM, SCRIPT_ROOT]).
-    exec.note::compute_and_store_recipient
-    # => [RECIPIENT]
-
-    # Push note type to stack (public note = 1)
-    push.1
-    # => [note_type, RECIPIENT]
-
-    # Load tag from memory
-    mem_load.TAG
-    # => [tag, note_type, RECIPIENT]
-
-    exec.output_note::create
-    # => [note_idx]
-
-    # Build [ASSET_KEY, ASSET_HALF_VALUE, note_idx] for move_asset_to_note
-    # Inputs: [ASSET_KEY, ASSET_VALUE, note_idx, pad(7)]
-
-    # Push ASSET_HALF_VALUE (note_idx moves to depth 4)
-    padw push.ASSET_HALF_VALUE_PTR mem_loadw_le
-    # => [ASSET_HALF_VALUE, note_idx]
-
-    # Push ASSET_KEY (ASSET_HALF_VALUE moves to depth 4, note_idx to depth 8)
-    padw push.ASSET_KEY_PTR mem_loadw_le
-    # => [ASSET_KEY, ASSET_HALF_VALUE, note_idx]
-
-    call.wallet::move_asset_to_note
     # => [pad(16)]
 
+    # get asset contained in note into memory (ASSET_ID at 0, ASSET_VALUE at 4)
+    # get_initial_assets leaves [num_assets] on the stack; drop it.
+    push.ASSET_ID_PTR exec.active_note::get_initial_assets drop
+    # => [pad(16)]
+
+    # load ASSET_VALUE and compute half amount
+    padw push.ASSET_VALUE_PTR mem_loadw_le
+    # => [[amount, 0, 0, 0], pad(16)]
+
+    # halve the even fungible amount
+    push.2 div
+    # => [[amount / 2, 0, 0, 0], pad(16)]
+
+    # store as ASSET_HALF_VALUE
+    mem_storew_le.ASSET_HALF_VALUE_PTR dropw
+    # => [pad(16)]
+
+    # receive all assets from note into the account wallet
+    exec.wallet::move_note_assets_to_account
+    # => [pad(16)]
+
+    # push script hash
+    exec.active_note::get_script_root
+    # => [SCRIPT_ROOT, pad(16)]
+
+    # get the current note serial number
+    exec.active_note::get_serial_number
+    # => [SERIAL_NUM, SCRIPT_ROOT, pad(16)]
+
+    # increment the last element of the serial number by 1
+    # (serial_num[3] is at depth 3; matches Rust: serial_num[3] + 1)
+    swap.3 push.1 add swap.3
+    # => [NEXT_SERIAL_NUM, SCRIPT_ROOT, pad(16)]
+
+    # load note storage into memory for recipient construction
+    push.ACCOUNT_ID_PREFIX
+    exec.active_note::get_storage
+    # => [num_storage_items, NEXT_SERIAL_NUM, SCRIPT_ROOT, pad(16)]
+
+    push.ACCOUNT_ID_PREFIX
+    # => [storage_ptr, num_storage_items, NEXT_SERIAL_NUM, SCRIPT_ROOT, pad(16)]
+
+    # argument shape: [storage_ptr, num_storage_items, SERIAL_NUM, SCRIPT_ROOT].
+    exec.note::compute_and_store_recipient
+    # => [RECIPIENT, pad(16)]
+
+    # push note type to stack (public note = 1)
+    push.1
+    # => [note_type, RECIPIENT, pad(16)]
+
+    # load tag from memory
+    mem_load.TAG
+    # => [tag, note_type, RECIPIENT, pad(16)]
+
+    # note creation from a note script must call the account's note-creator procedure.
+    # pad the stack for the account procedure call convention.
+    push.0 movdn.6 push.0 movdn.6 padw padw swapdw
+    # => [tag, note_type, RECIPIENT, pad(26)]
+
+    call.note_creator::create_note
+    # => [note_idx, pad(31)]
+
+    movdn.15 dropw dropw dropw drop drop drop
+    # => [note_idx, pad(16)]
+
+    # build [ASSET_ID, ASSET_HALF_VALUE, note_idx] for move_asset_to_note
+    # inputs: [ASSET_ID, ASSET_VALUE, note_idx, pad(7)]
+
+    # push ASSET_HALF_VALUE (note_idx moves to depth 4)
+    padw push.ASSET_HALF_VALUE_PTR mem_loadw_le
+    # => [ASSET_HALF_VALUE, note_idx, pad(16)]
+
+    # push ASSET_ID (ASSET_HALF_VALUE moves to depth 4, note_idx to depth 8)
+    padw push.ASSET_ID_PTR mem_loadw_le
+    # => [ASSET_ID, ASSET_HALF_VALUE, note_idx, pad(16)]
+
+    call.wallet::move_asset_to_note
+    # => [pad(25)]
+
     dropw dropw dropw dropw
-    # => []
+    # => [pad(16)]
 
     exec.sys::truncate_stack
-    # => []
+    # => [pad(16)]
 end
 ```
 
 ### How the Assembly Code Works:
 
 1. **Retrieving the asset:**  
-   The note calls `active_note::get_assets` to write the asset into memory, with `ASSET_KEY` at address 0 and `ASSET_VALUE` at address 4. It halves the amount in `ASSET_VALUE` and stores it at `ASSET_HALF_VALUE_PTR`. Finally, it calls `wallet::add_assets_to_account` to receive all note assets into the consuming account.
+   The note calls `active_note::get_initial_assets` to copy the initial asset into memory, with `ASSET_ID` at address 0 and `ASSET_VALUE` at address 4. It halves the amount in `ASSET_VALUE` and stores it at `ASSET_HALF_VALUE_PTR`. Finally, it calls `wallet::move_note_assets_to_account`, which explicitly removes the assets from the note and receives them into the consuming account.
 2. **Getting the script hash and serial number:**  
    The note script calls `active_note::get_script_root` to fetch the script hash and `active_note::get_serial_number` to fetch the current serial number, then increments element 3 (the last element) by 1 to avoid duplicate recipients.
 3. **Building the `RECIPIENT`:**  
    The script loads the note storage into memory with `active_note::get_storage`, then calls `note::compute_and_store_recipient`. This computes the storage commitment and stores the preimage in the advice map, which is required for public notes.
 4. **Creating the note:**  
-   To create the note, the script pushes the note type and tag onto the stack, then calls the `output_note::create` procedure, which returns the note index.
+   To create the note from a note script, the script pads the stack for the account-call ABI and calls the account's exported `note_creator::create_note` procedure, which enters the account context and returns the note index. The consuming account must expose `NoteCreator`; `BasicWallet` includes it.
 5. **Moving assets to the note:**  
-   After the note is created, the script loads `ASSET_KEY` and `ASSET_HALF_VALUE` from memory onto the stack and calls `wallet::move_asset_to_note` with the note index.
+   After the note is created, the script loads `ASSET_ID` and `ASSET_HALF_VALUE` from memory onto the stack and calls `wallet::move_asset_to_note` with the note index.
 6. **Stack cleanup:**  
    Finally, the script cleans up the stack by calling `sys::truncate_stack`.
 
@@ -206,21 +226,23 @@ With the Miden assembly note script written, we can move on to writing the Rust 
 Copy and paste the following code into your `src/main.rs` file.
 
 ```rust no_run
-use rand::RngCore;
+use rand::Rng;
+use rust_client::TutorialClientExt;
 use std::{path::PathBuf, sync::Arc};
-use tokio::time::{sleep, Duration};
+use tokio::time::{Duration, sleep};
 
 use miden_client::{
+    Client, ClientError, Felt,
     account::{
-        component::{
-            BasicWallet, BurnPolicyConfig, FungibleFaucet, MintPolicyConfig, PolicyRegistration,
-            TokenName, TokenPolicyManager,
-        },
         Account, AccountBuilder, AccountType,
+        component::{
+            create_singlesig_user_fungible_faucet, BasicWallet, BurnPolicy, FungibleFaucet,
+            MintPolicy, TokenName, TokenPolicyManager,
+        },
     },
     address::NetworkId,
-    asset::{AssetAmount, FungibleAsset, TokenSymbol},
-    auth::{AuthSchemeId, AuthSecretKey, AuthSingleSig},
+    asset::{AssetAmount, AssetId, FungibleAsset, TokenSymbol},
+    auth::{AuthSecretKey, AuthSingleSig},
     builder::ClientBuilder,
     crypto::FeltRng,
     keystore::{FilesystemKeyStore, Keystore},
@@ -228,12 +250,11 @@ use miden_client::{
         Note, NoteAssets, NoteDetails, NoteRecipient, NoteStorage, NoteTag, NoteType,
         PartialNoteMetadata,
     },
-    rpc::{Endpoint, GrpcClient},
-    store::TransactionFilter,
-    transaction::{TransactionId, TransactionRequestBuilder, TransactionStatus},
-    Client, ClientError, Felt,
+    rpc::{GrpcClient, VerifyingRpcClient},
+    transaction::{TransactionId, TransactionRequestBuilder},
 };
 use miden_client_sqlite_store::ClientBuilderSqliteExt;
+use rust_client::{FeeConfig, TutorialNetwork, fund_account_for_fees};
 
 // Helper to create a basic account
 async fn create_basic_account(
@@ -247,7 +268,7 @@ async fn create_basic_account(
 
     let account = AccountBuilder::new(init_seed)
         .account_type(AccountType::Public)
-        .with_auth_component(AuthSingleSig::new(key_pair.public_key().to_commitment(), AuthSchemeId::Falcon512Poseidon2))
+        .with_component(AuthSingleSig::from_public_key(key_pair.public_key()))
         .with_component(BasicWallet)
         .build()
         .unwrap();
@@ -270,27 +291,25 @@ async fn create_basic_faucet(
     let decimals = 8;
     let max_supply = AssetAmount::new(1_000_000).unwrap();
 
-    let account = AccountBuilder::new(init_seed)
-        .account_type(AccountType::Public)
-        .with_auth_component(AuthSingleSig::new(key_pair.public_key().to_commitment(), AuthSchemeId::Falcon512Poseidon2))
-        .with_component(
-            FungibleFaucet::builder()
-                .name(TokenName::new("MID").unwrap())
-                .symbol(symbol)
-                .decimals(decimals)
-                .max_supply(max_supply)
-                .build()
-                .unwrap(),
-        )
-        .with_components(
-            TokenPolicyManager::new()
-                .with_mint_policy(MintPolicyConfig::AllowAll, PolicyRegistration::Active)
-                .unwrap()
-                .with_burn_policy(BurnPolicyConfig::AllowAll, PolicyRegistration::Active)
-                .unwrap(),
-        )
+    let faucet = FungibleFaucet::builder()
+        .name(TokenName::new("MID").unwrap())
+        .symbol(symbol)
+        .decimals(decimals)
+        .max_supply(max_supply)
         .build()
         .unwrap();
+    let policies = TokenPolicyManager::builder()
+        .active_mint_policy(MintPolicy::allow_all())
+        .active_burn_policy(BurnPolicy::allow_all())
+        .build();
+    let account = create_singlesig_user_fungible_faucet(
+        init_seed,
+        faucet,
+        AuthSingleSig::from_public_key(key_pair.public_key()),
+        policies,
+        AccountType::Public,
+    )
+    .unwrap();
 
     client.add_account(&account, false).await?;
     keystore.add_key(&key_pair, account.id()).await.unwrap();
@@ -303,21 +322,29 @@ async fn wait_for_notes(
     client: &mut Client<FilesystemKeyStore>,
     account_id: &Account,
     expected: usize,
+    network_id: NetworkId,
 ) -> Result<(), ClientError> {
-    loop {
+    for _ in 0..24 {
         client.sync_state().await?;
-        let notes = client.get_consumable_notes(Some(account_id.id())).await?;
+        let notes = client
+            .get_consumable_tutorial_notes(Some(account_id.id()))
+            .await?;
         if notes.len() >= expected {
-            break;
+            return Ok(());
         }
         println!(
             "{} consumable notes found for account {}. Waiting...",
             notes.len(),
-            account_id.id().to_bech32(NetworkId::Testnet)
+            account_id.id().to_bech32(network_id.clone())
         );
         sleep(Duration::from_secs(3)).await;
     }
-    Ok(())
+    Err(ClientError::Observer(Box::new(std::io::Error::other(
+        format!(
+            "timed out waiting for {expected} tutorial notes for {}",
+            account_id.id()
+        ),
+    ))))
 }
 
 /// Waits for a specific transaction to be committed.
@@ -325,39 +352,18 @@ async fn wait_for_tx(
     client: &mut Client<FilesystemKeyStore>,
     tx_id: TransactionId,
 ) -> Result<(), ClientError> {
-    loop {
-        client.sync_state().await?;
-
-        // Check transaction status
-        let txs = client
-            .get_transactions(TransactionFilter::Ids(vec![tx_id]))
-            .await?;
-        let tx_committed = if !txs.is_empty() {
-            matches!(txs[0].status, TransactionStatus::Committed { .. })
-        } else {
-            false
-        };
-
-        if tx_committed {
-            println!("✅ transaction {} committed", tx_id.to_hex());
-            break;
-        }
-
-        println!(
-            "Transaction {} not yet committed. Waiting...",
-            tx_id.to_hex()
-        );
-        sleep(Duration::from_secs(2)).await;
-    }
-    Ok(())
+    rust_client::wait_for_transaction(client, tx_id).await
 }
 
 #[tokio::main]
 async fn main() -> Result<(), ClientError> {
     // Initialize client
-    let endpoint = Endpoint::testnet();
+    let network = TutorialNetwork::from_env()?;
+    let endpoint = network.endpoint();
     let timeout_ms = 10_000;
-    let rpc_client = Arc::new(GrpcClient::new(&endpoint, timeout_ms));
+    let rpc_client = Arc::new(VerifyingRpcClient::new(GrpcClient::new(
+        &endpoint, timeout_ms,
+    )));
 
     // Initialize keystore
     let keystore_path = PathBuf::from("./keystore");
@@ -369,12 +375,12 @@ async fn main() -> Result<(), ClientError> {
         .rpc(rpc_client)
         .sqlite_store(store_path)
         .authenticator(keystore.clone())
-        .in_debug_mode(true.into())
         .build()
         .await?;
 
     let sync_summary = client.sync_state().await.unwrap();
     println!("Latest block: {}", sync_summary.block_num);
+    let fee_config = FeeConfig::from_client(&client, network).await?;
 
     // -------------------------------------------------------------------------
     // STEP 1: Create accounts and deploy faucet
@@ -383,20 +389,23 @@ async fn main() -> Result<(), ClientError> {
     let alice_account = create_basic_account(&mut client, &keystore).await?;
     println!(
         "Alice's account ID: {:?}",
-        alice_account.id().to_bech32(NetworkId::Testnet)
+        alice_account.id().to_bech32(network.network_id())
     );
     let bob_account = create_basic_account(&mut client, &keystore).await?;
     println!(
         "Bob's account ID: {:?}",
-        bob_account.id().to_bech32(NetworkId::Testnet)
+        bob_account.id().to_bech32(network.network_id())
     );
 
     println!("\nDeploying a new fungible faucet.");
     let faucet = create_basic_faucet(&mut client, &keystore).await?;
     println!(
         "Faucet account ID: {:?}",
-        faucet.id().to_bech32(NetworkId::Testnet)
+        faucet.id().to_bech32(network.network_id())
     );
+    for account_id in [alice_account.id(), bob_account.id(), faucet.id()] {
+        fund_account_for_fees(&mut client, account_id, &fee_config).await?;
+    }
     client.sync_state().await?;
 
     // -------------------------------------------------------------------------
@@ -416,14 +425,16 @@ async fn main() -> Result<(), ClientError> {
         )
         .unwrap();
 
-    let tx_id = client.submit_new_transaction(faucet.id(), tx_req).await?;
+    let tx_id = client
+        .submit_tutorial_transaction(faucet.id(), tx_req)
+        .await?;
     println!("Minted tokens. TX: {:?}", tx_id);
 
-    wait_for_notes(&mut client, &alice_account, 1).await?;
+    wait_for_notes(&mut client, &alice_account, 1, network.network_id()).await?;
 
     // Consume the minted note
     let consumable_notes = client
-        .get_consumable_notes(Some(alice_account.id()))
+        .get_consumable_tutorial_notes(Some(alice_account.id()))
         .await?;
 
     if let Some((note_record, _)) = consumable_notes.first() {
@@ -431,7 +442,7 @@ async fn main() -> Result<(), ClientError> {
         let consume_req = TransactionRequestBuilder::new().build_consume_notes(vec![note])?;
 
         let tx_id = client
-            .submit_new_transaction(alice_account.id(), consume_req)
+            .submit_tutorial_transaction(alice_account.id(), consume_req)
             .await?;
         println!("Consumed minted note. TX: {:?}", tx_id);
     }
@@ -443,15 +454,15 @@ async fn main() -> Result<(), ClientError> {
     // -------------------------------------------------------------------------
     println!("\n[STEP 3] Create iterative output note");
 
-    // `include_str!` resolves at compile time relative to this source file,
-    // so the binary is independent of the working directory it is run from.
-    let code = include_str!("../masm/notes/iterative_output_note.masm");
+    // Read the MASM source from the tutorials repository.
+    let code =
+        std::fs::read_to_string("../tutorials/masm/notes/iterative_output_note.masm").unwrap();
     let serial_num = client.rng().draw_word();
 
     // Create note metadata and tag
     let tag = NoteTag::new(0);
     let metadata = PartialNoteMetadata::new(alice_account.id(), NoteType::Public).with_tag(tag);
-    let note_script = client.code_builder().compile_note_script(code).unwrap();
+    let note_script = client.code_builder().compile_note_script(&code).unwrap();
     let note_storage = NoteStorage::new(vec![
         alice_account.id().prefix().as_felt(),
         alice_account.id().suffix(),
@@ -470,10 +481,11 @@ async fn main() -> Result<(), ClientError> {
         .unwrap();
 
     let tx_id = client
-        .submit_new_transaction(alice_account.id(), note_req)
+        .submit_tutorial_transaction(alice_account.id(), note_req)
         .await?;
     println!(
-        "View transaction on MidenScan: https://testnet.midenscan.com/tx/{:?}",
+        "View transaction on MidenScan: {}/tx/{:?}",
+        network.explorer_url(),
         tx_id
     );
 
@@ -505,24 +517,52 @@ async fn main() -> Result<(), ClientError> {
 
     let consume_custom_req = TransactionRequestBuilder::new()
         .input_notes([(custom_note, None)])
-        .expected_future_notes(vec![(
-            NoteDetails::from(output_note.clone()),
-            output_note.metadata().tag(),
-        )
-            .clone()])
+        .expected_future_notes(vec![
+            (
+                NoteDetails::from(output_note.clone()),
+                output_note.metadata().tag(),
+            )
+                .clone(),
+        ])
         .expected_output_recipients(vec![output_note.recipient().clone()])
         .build()
         .unwrap();
 
     let tx_id = client
-        .submit_new_transaction(bob_account.id(), consume_custom_req)
+        .submit_tutorial_transaction(bob_account.id(), consume_custom_req)
         .await?;
     println!(
-        "Consumed Note Tx on MidenScan: https://testnet.midenscan.com/tx/{:?}",
+        "Consumed Note Tx on MidenScan: {}/tx/{:?}",
+        network.explorer_url(),
         tx_id
     );
 
     wait_for_tx(&mut client, tx_id).await?;
+
+    // The SDK verifies expected recipients; also check the actual successor's assets and metadata.
+    let successor = client
+        .get_output_note(output_note.id())
+        .await?
+        .expect("the transaction must create the expected successor note");
+    assert!(successor.is_committed(), "the successor must be committed");
+    assert_eq!(successor.assets(), output_note.assets());
+    assert_eq!(successor.metadata(), output_note.metadata());
+    println!(
+        "Successor note committed with 50 tokens: {}",
+        successor.id()
+    );
+
+    let bob = client
+        .get_account(bob_account.id())
+        .await?
+        .expect("Bob's account must exist after consuming the note");
+    let balance = bob.vault().get_balance(AssetId::new_fungible(faucet_id))?;
+    assert_eq!(
+        balance.as_u64(),
+        50,
+        "Bob must retain the other half of the note's tokens",
+    );
+    println!("Bob's retained token balance: {balance}");
 
     Ok(())
 }
@@ -531,44 +571,44 @@ async fn main() -> Result<(), ClientError> {
 Run the following command to execute `src/main.rs`:
 
 ```bash
-cargo run --release
+TUTORIAL_NETWORK=testnet cargo run --release
 ```
 
-The output will look something like this:
+The following is an abbreviated output; IDs vary, and funding and repeated confirmation messages are omitted:
 
 ```text
-Latest block: 488715
+Latest block: <current_block_number>
 
 [STEP 1] Creating new accounts
-Alice's account ID: "mtst1azvwquwfvh0jyytq0dk9xya9tvhvu935"
-Bob's account ID: "mtst1ap9hwvau7sy9tvtka6smn0ev7cxtgt03"
+Alice's account ID: "<testnet_account_id>"
+Bob's account ID: "<testnet_account_id>"
 
 Deploying a new fungible faucet.
-Faucet account ID: "mtst1apj3jthkj4mweyf7qt254h5m5gdemp9u"
+Faucet account ID: "<testnet_account_id>"
 
 [STEP 2] Mint tokens with P2ID
-Minted tokens. TX: 0xf3c8f183aeefb086ca4a63f2a6f34535ea4217849e8e870033f892503302fb7d
-0 consumable notes found for account mtst1azvwquwfvh0jyytq0dk9xya9tvhvu935. Waiting...
-Consumed minted note. TX: 0x2d31ce827549d8bf35d1c3613610f8388d6c2369dbd1aa34f4f3406f86fdff55
+Minted tokens. TX: <transaction_id>
+Consumed minted note. TX: <transaction_id>
 
 [STEP 3] Create iterative output note
-View transaction on MidenScan: https://testnet.midenscan.com/tx/0xadabf7a920ee27bf1fabd3b02e8e6f3d80f84ece31a23d73f27b0b56bbc2fdc3
+View transaction on MidenScan: https://testnet.midenscan.com/tx/<transaction_id>
 
 [STEP 4] Bob consumes the note and creates a copy
-Consumed Note Tx on MidenScan: https://testnet.midenscan.com/tx/0xa003d298db5e7de263a8b98930b6e75336c3cca7cd4a090c707edb6a7f061ad5
-Transaction 0xa003d298db5e7de263a8b98930b6e75336c3cca7cd4a090c707edb6a7f061ad5 not yet committed. Waiting...
-✅ transaction 0xa003d298db5e7de263a8b98930b6e75336c3cca7cd4a090c707edb6a7f061ad5 committed
+Consumed Note Tx on MidenScan: https://testnet.midenscan.com/tx/<transaction_id>
+Transaction committed: <transaction_id>
+Successor note committed with 50 tokens: <successor_note_id>
+Bob's retained token balance: 50
 ```
 
 ---
 
 ### Running the example
 
-To run the full example, navigate to the `rust-client` directory in the [miden-tutorials](https://github.com/0xMiden/miden-tutorials/) repository and run this command:
+From the root of your `tutorials` clone, run the checked-in example:
 
 ```bash
 cd rust-client
-cargo run --release --bin note_creation_in_masm
+TUTORIAL_NETWORK=testnet cargo run --release --bin note_creation_in_masm
 ```
 
 ### Continue learning

--- a/docs/src/rust-client/custom_note_how_to.md
+++ b/docs/src/rust-client/custom_note_how_to.md
@@ -7,6 +7,8 @@ sidebar_position: 7
 
 _Creating notes with custom logic_
 
+For toolchain requirements and shared fee helpers, see the [Rust client setup](./index.md#running-the-v016-examples).
+
 ## Overview
 
 In this guide, we will create a custom note on Miden that can only be consumed by someone who knows the preimage of the hash stored in the note. This approach securely embeds assets into the note and restricts spending to those who possess the correct secret number.
@@ -14,9 +16,9 @@ In this guide, we will create a custom note on Miden that can only be consumed b
 By following the steps below and using the Miden Assembly code and Rust example, you will learn how to:
 
 - Create a note with custom logic.
-- Leverage Miden’s privacy features to keep certain transaction details private.
+- Store the hash publicly while providing its preimage only to the transaction that consumes the note.
 
-Unlike Ethereum, where all pending transactions are publicly visible in the mempool, Miden enables you to partially or completely hide transaction details.
+This example uses public accounts and a public note. Its script checks knowledge of the secret, rather than a particular account ID, so any account with the secret and the required wallet procedure can consume it.
 
 ## What we'll cover
 
@@ -37,67 +39,77 @@ First, we create two basic accounts for the two users:
 The security of the custom note hinges on a secret number. Here, we will:
 
 - Choose a secret number (for example, an array of four integers).
-- For simplicity, we're only hashing 4 elements. Therefore, we prepend an empty word—consisting of 4 zero integers—as a placeholder. This is required by the RPO hashing algorithm to ensure the input has the correct structure and length for proper processing.
-- Compute the hash of the secret. The resulting hash will serve as the note’s input, meaning that the note can only be consumed if the secret number’s hash preimage is provided during consumption.
+- Hash the four field elements directly with `miden_protocol::Hasher::hash_elements`, which uses Poseidon2 in v0.16. The MASM `hash` instruction computes the matching digest; do not prepend an extra zero word to the Rust input.
+- Compute the hash of the secret. The resulting hash will be stored in the note’s storage, meaning that the note can only be consumed if the secret number’s hash preimage is provided during consumption.
 
 ### 3. Creating the custom note
 
 Now, combine the minted asset and the secret hash to build the custom note. The note is created using the following key steps:
 
-1. **Note Inputs:**
-   - The note is set up with the asset and the hash of the secret number as its input.
+1. **Assets and storage:**
+   - The note carries 100 raw units of the tutorial asset and stores the secret's digest in `NoteStorage`. The secret itself is supplied later as the consuming transaction's note arguments.
 2. **Miden Assembly Code:**
-   - The Miden assembly note script ensures that the note can only be consumed if the provided secret, when hashed, matches the hash stored in the note input.
+   - The Miden assembly note script ensures that the note can only be consumed if the provided secret, when hashed, matches the hash stored in the note storage.
 
 Below is the Miden Assembly code for the note. Note scripts are compiled as libraries; the `@note_script` attribute marks the entrypoint procedure.
 
 ```masm
 use miden::protocol::active_note
-use miden::standards::wallets::basic->wallet
+use miden::standards::wallets::basic as wallet
 
 # CONSTANTS
 # =================================================================================================
 
-const EXPECTED_DIGEST_PTR=0
+const EXPECTED_DIGEST_PTR = 0
 
 # ERRORS
 # =================================================================================================
 
-const ERROR_DIGEST_MISMATCH="Expected digest does not match computed digest"
+const ERROR_DIGEST_MISMATCH = "Expected digest does not match computed digest"
 
-#! Inputs (arguments):  [HASH_PREIMAGE_SECRET]
-#! Outputs: []
+# PUBLIC INTERFACE
+# =================================================================================================
+
+#! Consumes the note's assets when the secret hashes to its stored digest.
 #!
-#! Note storage is assumed to be as follows:
-#!  => EXPECTED_DIGEST
+#! Inputs:  [HASH_PREIMAGE_SECRET, pad(12)]
+#! Outputs: [pad(16)]
+#!
+#! Where:
+#! - HASH_PREIMAGE_SECRET is the four-felt secret supplied as note arguments.
+#!
+#! Panics if:
+#! - the supplied secret does not match the digest stored in the note.
+#!
+#! Invocation: dyncall
 @note_script
-pub proc main
-    # => HASH_PREIMAGE_SECRET
-    # Hashing the secret number
+pub proc main(hash_preimage_secret: word)
+    # => [HASH_PREIMAGE_SECRET, pad(12)]
+    # hashing the secret number
     hash
-    # => [DIGEST]
+    # => [DIGEST, pad(12)]
 
-    # Writing the note storage to memory.
+    # writing the note storage to memory.
     # get_storage leaves only [num_storage_items], so drop a single element
     # here, not two, to keep the computed DIGEST intact.
     push.EXPECTED_DIGEST_PTR exec.active_note::get_storage drop
 
-    # Pad stack and load expected digest from memory (LE: mem[addr] ends up on top)
+    # pad stack and load expected digest from memory (LE: mem[addr] ends up on top)
     padw push.EXPECTED_DIGEST_PTR mem_loadw_le
-    # => [EXPECTED_DIGEST, DIGEST]
+    # => [EXPECTED_DIGEST, DIGEST, pad(12)]
 
-    # Assert that the note input matches the digest
-    # Will fail if the two hashes do not match
+    # assert that the note input matches the digest
+    # will fail if the two hashes do not match
     assert_eqw.err=ERROR_DIGEST_MISMATCH
-    # => []
+    # => [pad(16)]
 
     # ---------------------------------------------------------------------------------------------
-    # If the check is successful, we allow for the asset to be consumed
+    # if the check is successful, we allow for the asset to be consumed
     # ---------------------------------------------------------------------------------------------
 
-    # Add all assets from the note to the account
-    exec.wallet::add_assets_to_account
-    # => []
+    # add all assets from the note to the account
+    exec.wallet::move_note_assets_to_account
+    # => [pad(16)]
 end
 ```
 
@@ -112,45 +124,73 @@ end
 4. **Digest Comparison:**  
    The assembly code loads the expected digest from note storage into memory, then reads it back with `mem_loadw_le` (which places `mem[addr]` on top, matching the hash output order) and compares with the computed hash. If they don't match, the transaction fails with a clear error message.
 5. **Asset Transfer:**  
-   If the hash matches, `wallet::add_assets_to_account` transfers all note assets into the consuming account's vault.
+   If the hash matches, `wallet::move_note_assets_to_account` explicitly removes all assets from the note and transfers them into the consuming account's vault.
 
-### 5. Consuming the note
+### 4. Consuming the note
 
 With the note created, Bob can now consume it—but only if he provides the correct secret. When Bob initiates the transaction to consume the note, he must supply the same secret number used when Alice created the note. The custom note’s logic will hash the secret and compare it with its stored hash. If they match, Bob’s wallet receives the asset.
 
 ---
+
+## Set up the Rust project
+
+Start in the directory containing your `tutorials` clone and create a sibling Cargo project:
+
+```bash
+cargo new miden-custom-note
+cd miden-custom-note
+rustup override set 1.98.1
+cp ../tutorials/rust-client/Cargo.lock Cargo.lock
+```
+
+Keep the generated `[package]` section in `Cargo.toml`, replace its empty `[dependencies]` section with the following, and add the development profile. The path assumes the repository clone is named `tutorials`.
+
+```toml
+[dependencies]
+# Clone tutorials next to this Cargo project (see Rust client setup).
+rust-client = { path = "../tutorials/rust-client" }
+miden-client = { version = "=0.16.0", features = ["testing", "tonic"] }
+miden-client-sqlite-store = { version = "=0.16.0", package = "miden-client-sqlite-store" }
+miden-protocol = { version = "=0.16.0" }
+rand = { version = "0.10" }
+tokio = { version = "1.48", features = ["rt-multi-thread", "net", "macros", "fs"] }
+
+[profile.dev]
+opt-level = 2
+```
+
+Copy the complete Rust example below into `src/main.rs`. Run it from this new project's directory with `TUTORIAL_NETWORK=testnet cargo run --release`. The client creates `store.sqlite3` and `keystore/` here; keep both out of version control.
 
 ## Full Rust code example
 
 The following Rust code demonstrates how to implement the steps outlined above using the Miden client library:
 
 ```rust no_run
-use rand::RngCore;
+use rand::Rng;
+use rust_client::TutorialClientExt;
 use std::{path::PathBuf, sync::Arc};
-use tokio::time::{sleep, Duration};
 
 use miden_client::{
+    Client, ClientError, Felt,
     account::{
-        component::{
-            BasicWallet, BurnPolicyConfig, FungibleFaucet, MintPolicyConfig, PolicyRegistration,
-            TokenName, TokenPolicyManager,
-        },
         Account, AccountBuilder, AccountType,
+        component::{
+            create_singlesig_user_fungible_faucet, BasicWallet, BurnPolicy, FungibleFaucet,
+            MintPolicy, TokenName, TokenPolicyManager,
+        },
     },
-    address::NetworkId,
-    asset::{AssetAmount, FungibleAsset, TokenSymbol},
-    auth::{AuthSchemeId, AuthSecretKey, AuthSingleSig},
+    asset::{AssetAmount, AssetId, FungibleAsset, TokenSymbol},
+    auth::{AuthSecretKey, AuthSingleSig},
     builder::ClientBuilder,
     crypto::FeltRng,
     keystore::{FilesystemKeyStore, Keystore},
     note::{Note, NoteAssets, NoteRecipient, NoteStorage, NoteTag, NoteType, PartialNoteMetadata},
-    rpc::{Endpoint, GrpcClient},
-    store::TransactionFilter,
-    transaction::{TransactionId, TransactionRequestBuilder, TransactionStatus},
-    Client, ClientError, Felt,
+    rpc::{GrpcClient, VerifyingRpcClient},
+    transaction::{TransactionId, TransactionRequestBuilder},
 };
 use miden_client_sqlite_store::ClientBuilderSqliteExt;
 use miden_protocol::Hasher;
+use rust_client::{FeeConfig, TutorialNetwork, fund_account_for_fees};
 
 // Helper to create a basic account
 async fn create_basic_account(
@@ -164,7 +204,7 @@ async fn create_basic_account(
 
     let account = AccountBuilder::new(init_seed)
         .account_type(AccountType::Public)
-        .with_auth_component(AuthSingleSig::new(key_pair.public_key().to_commitment(), AuthSchemeId::Falcon512Poseidon2))
+        .with_component(AuthSingleSig::from_public_key(key_pair.public_key()))
         .with_component(BasicWallet)
         .build()
         .unwrap();
@@ -187,27 +227,25 @@ async fn create_basic_faucet(
     let decimals = 8;
     let max_supply = AssetAmount::new(1_000_000).unwrap();
 
-    let account = AccountBuilder::new(init_seed)
-        .account_type(AccountType::Public)
-        .with_auth_component(AuthSingleSig::new(key_pair.public_key().to_commitment(), AuthSchemeId::Falcon512Poseidon2))
-        .with_component(
-            FungibleFaucet::builder()
-                .name(TokenName::new("MID").unwrap())
-                .symbol(symbol)
-                .decimals(decimals)
-                .max_supply(max_supply)
-                .build()
-                .unwrap(),
-        )
-        .with_components(
-            TokenPolicyManager::new()
-                .with_mint_policy(MintPolicyConfig::AllowAll, PolicyRegistration::Active)
-                .unwrap()
-                .with_burn_policy(BurnPolicyConfig::AllowAll, PolicyRegistration::Active)
-                .unwrap(),
-        )
+    let faucet = FungibleFaucet::builder()
+        .name(TokenName::new("MID").unwrap())
+        .symbol(symbol)
+        .decimals(decimals)
+        .max_supply(max_supply)
         .build()
         .unwrap();
+    let policies = TokenPolicyManager::builder()
+        .active_mint_policy(MintPolicy::allow_all())
+        .active_burn_policy(BurnPolicy::allow_all())
+        .build();
+    let account = create_singlesig_user_fungible_faucet(
+        init_seed,
+        faucet,
+        AuthSingleSig::from_public_key(key_pair.public_key()),
+        policies,
+        AccountType::Public,
+    )
+    .unwrap();
 
     client.add_account(&account, false).await?;
     keystore.add_key(&key_pair, account.id()).await.unwrap();
@@ -220,39 +258,18 @@ async fn wait_for_tx(
     client: &mut Client<FilesystemKeyStore>,
     tx_id: TransactionId,
 ) -> Result<(), ClientError> {
-    loop {
-        client.sync_state().await?;
-
-        // Check transaction status
-        let txs = client
-            .get_transactions(TransactionFilter::Ids(vec![tx_id]))
-            .await?;
-        let tx_committed = if !txs.is_empty() {
-            matches!(txs[0].status, TransactionStatus::Committed { .. })
-        } else {
-            false
-        };
-
-        if tx_committed {
-            println!("✅ transaction {} committed", tx_id.to_hex());
-            break;
-        }
-
-        println!(
-            "Transaction {} not yet committed. Waiting...",
-            tx_id.to_hex()
-        );
-        sleep(Duration::from_secs(2)).await;
-    }
-    Ok(())
+    rust_client::wait_for_transaction(client, tx_id).await
 }
 
 #[tokio::main]
 async fn main() -> Result<(), ClientError> {
     // Initialize client
-    let endpoint = Endpoint::testnet();
+    let network = TutorialNetwork::from_env()?;
+    let endpoint = network.endpoint();
     let timeout_ms = 10_000;
-    let rpc_client = Arc::new(GrpcClient::new(&endpoint, timeout_ms));
+    let rpc_client = Arc::new(VerifyingRpcClient::new(GrpcClient::new(
+        &endpoint, timeout_ms,
+    )));
 
     // Initialize keystore
     let keystore_path = PathBuf::from("./keystore");
@@ -264,12 +281,12 @@ async fn main() -> Result<(), ClientError> {
         .rpc(rpc_client)
         .sqlite_store(store_path)
         .authenticator(keystore.clone())
-        .in_debug_mode(true.into())
         .build()
         .await?;
 
     let sync_summary = client.sync_state().await.unwrap();
     println!("Latest block: {}", sync_summary.block_num);
+    let fee_config = FeeConfig::from_client(&client, network).await?;
 
     // -------------------------------------------------------------------------
     // STEP 1: Create accounts and deploy faucet
@@ -278,20 +295,23 @@ async fn main() -> Result<(), ClientError> {
     let alice_account = create_basic_account(&mut client, &keystore).await?;
     println!(
         "Alice's account ID: {:?}",
-        alice_account.id().to_bech32(NetworkId::Testnet)
+        alice_account.id().to_bech32(network.network_id())
     );
     let bob_account = create_basic_account(&mut client, &keystore).await?;
     println!(
         "Bob's account ID: {:?}",
-        bob_account.id().to_bech32(NetworkId::Testnet)
+        bob_account.id().to_bech32(network.network_id())
     );
 
     println!("\nDeploying a new fungible faucet.");
     let faucet = create_basic_faucet(&mut client, &keystore).await?;
     println!(
         "Faucet account ID: {:?}",
-        faucet.id().to_bech32(NetworkId::Testnet)
+        faucet.id().to_bech32(network.network_id())
     );
+    for account_id in [alice_account.id(), bob_account.id(), faucet.id()] {
+        fund_account_for_fees(&mut client, account_id, &fee_config).await?;
+    }
     client.sync_state().await?;
 
     // -------------------------------------------------------------------------
@@ -311,7 +331,7 @@ async fn main() -> Result<(), ClientError> {
         .unwrap();
 
     let tx_id = client
-        .submit_new_transaction(faucet.id(), tx_request)
+        .submit_tutorial_transaction(faucet.id(), tx_request)
         .await?;
     println!("Minted tokens. TX: {:?}", tx_id);
 
@@ -321,17 +341,15 @@ async fn main() -> Result<(), ClientError> {
 
     // Consume the minted note
     let consumable_notes = client
-        .get_consumable_notes(Some(alice_account.id()))
+        .get_consumable_tutorial_notes(Some(alice_account.id()))
         .await?;
 
     if let Some((note_record, _)) = consumable_notes.first() {
         let note: Note = note_record.clone().try_into()?;
-        let consume_request = TransactionRequestBuilder::new()
-            .build_consume_notes(vec![note])
-            .unwrap();
+        let consume_request = TransactionRequestBuilder::new().build_consume_notes(vec![note])?;
 
         let tx_id = client
-            .submit_new_transaction(alice_account.id(), consume_request)
+            .submit_tutorial_transaction(alice_account.id(), consume_request)
             .await?;
         println!("Consumed minted note. TX: {:?}", tx_id);
     }
@@ -342,16 +360,20 @@ async fn main() -> Result<(), ClientError> {
     // STEP 3: Create custom note
     // -------------------------------------------------------------------------
     println!("\n[STEP 3] Create custom note");
-    let secret_vals = vec![Felt::new_unchecked(1), Felt::new_unchecked(2), Felt::new_unchecked(3), Felt::new_unchecked(4)];
+    let secret_vals = vec![
+        Felt::new_unchecked(1),
+        Felt::new_unchecked(2),
+        Felt::new_unchecked(3),
+        Felt::new_unchecked(4),
+    ];
     let digest = Hasher::hash_elements(&secret_vals);
     println!("digest: {:?}", digest);
 
-    // `include_str!` resolves at compile time relative to this source file,
-    // so the binary is independent of the working directory it is run from.
-    let code = include_str!("../masm/notes/hash_preimage_note.masm");
+    // Read the MASM source from the tutorials repository.
+    let code = std::fs::read_to_string("../tutorials/masm/notes/hash_preimage_note.masm").unwrap();
     let serial_num = client.rng().draw_word();
 
-    let note_script = client.code_builder().compile_note_script(code).unwrap();
+    let note_script = client.code_builder().compile_note_script(&code).unwrap();
     let note_storage = NoteStorage::new(digest.to_vec()).unwrap();
     let recipient = NoteRecipient::new(serial_num, note_script, note_storage);
     let tag = NoteTag::new(0);
@@ -366,10 +388,11 @@ async fn main() -> Result<(), ClientError> {
         .unwrap();
 
     let tx_id = client
-        .submit_new_transaction(alice_account.id(), note_request)
+        .submit_tutorial_transaction(alice_account.id(), note_request)
         .await?;
     println!(
-        "View transaction on MidenScan: https://testnet.midenscan.com/tx/{:?}",
+        "View transaction on MidenScan: {}/tx/{:?}",
+        network.explorer_url(),
         tx_id
     );
 
@@ -380,30 +403,48 @@ async fn main() -> Result<(), ClientError> {
     // -------------------------------------------------------------------------
     println!("\n[STEP 4] Bob consumes the Custom Note with Correct Secret");
 
-    let secret = [Felt::new_unchecked(1), Felt::new_unchecked(2), Felt::new_unchecked(3), Felt::new_unchecked(4)];
+    let secret = [
+        Felt::new_unchecked(1),
+        Felt::new_unchecked(2),
+        Felt::new_unchecked(3),
+        Felt::new_unchecked(4),
+    ];
     let consume_custom_request = TransactionRequestBuilder::new()
         .input_notes([(custom_note, Some(secret.into()))])
         .build()
         .unwrap();
 
     let tx_id = client
-        .submit_new_transaction(bob_account.id(), consume_custom_request)
+        .submit_tutorial_transaction(bob_account.id(), consume_custom_request)
         .await?;
     println!(
-        "Consumed Note Tx on MidenScan: https://testnet.midenscan.com/tx/{:?} \n",
+        "Consumed Note Tx on MidenScan: {}/tx/{:?} \n",
+        network.explorer_url(),
         tx_id
     );
 
     wait_for_tx(&mut client, tx_id).await?;
 
+    let bob = client
+        .get_account(bob_account.id())
+        .await?
+        .expect("Bob's account must exist after consuming the note");
+    let balance = bob.vault().get_balance(AssetId::new_fungible(faucet_id))?;
+    assert_eq!(
+        balance.as_u64(),
+        amount,
+        "Bob must receive all assets from the hash-preimage note",
+    );
+    println!("Bob's custom-note token balance: {balance}");
+
     Ok(())
 }
 ```
 
-The output of our program will look something like this:
+The following is an abbreviated output; IDs vary, and funding and repeated confirmation messages are omitted:
 
 ```text
-Latest block: 488704
+Latest block: <current_block_number>
 
 [STEP 1] Creating new accounts
 Alice's account ID: "<testnet_account_id>"
@@ -413,21 +454,20 @@ Deploying a new fungible faucet.
 Faucet account ID: "<testnet_account_id>"
 
 [STEP 2] Mint tokens with P2ID
-Minted tokens. TX: 0x970265408eb22068b22ec677f6ad09a2524913ab11b3dbf010e4cae73587e2e3
-Transaction 0x970265408eb22068b22ec677f6ad09a2524913ab11b3dbf010e4cae73587e2e3 not yet committed. Waiting...
-✅ transaction 0x970265408eb22068b22ec677f6ad09a2524913ab11b3dbf010e4cae73587e2e3 committed
-Consumed minted note. TX: 0x47850a0c44d9e147b8866285c24ba05a0d4bed0a99c1f25a13f32e57feecfe1b
+Minted tokens. TX: <transaction_id>
+Transaction committed: <transaction_id>
+Consumed minted note. TX: <transaction_id>
 
 [STEP 3] Create custom note
 digest: Word([14206540680072267069, 9571949196318390099, 5950603493574130513, 3457190364553631046])
 note hash: "0xf48f362f1817bbc5575e0bb8b77c496dd67e4b85d8ff45d21dff5743de2b174d"
-View transaction on MidenScan: https://testnet.midenscan.com/tx/0x9911ef1b9d2b066e017de187b7c1f8d95012748366358474b11adc91e49971b5
+View transaction on MidenScan: https://testnet.midenscan.com/tx/<transaction_id>
 
 [STEP 4] Bob consumes the Custom Note with Correct Secret
-Consumed Note Tx on MidenScan: https://testnet.midenscan.com/tx/0x2a7a192b692984ae649dd1a13d15e4b79178e9e554615ffec7426e25e75193fa
+Consumed Note Tx on MidenScan: https://testnet.midenscan.com/tx/<transaction_id>
 
-Transaction 0x2a7a192b692984ae649dd1a13d15e4b79178e9e554615ffec7426e25e75193fa not yet committed. Waiting...
-✅ transaction 0x2a7a192b692984ae649dd1a13d15e4b79178e9e554615ffec7426e25e75193fa committed
+Transaction committed: <transaction_id>
+Bob's custom-note token balance: 100
 ```
 
 ## Conclusion
@@ -439,15 +479,15 @@ You have now seen how to create a custom note on Miden that requires a secret pr
 3. Building a note with custom logic in Miden Assembly
 4. Consuming the note by providing the correct secret
 
-By leveraging Miden’s privacy features, you can create customized logic for secure asset transfers that depend on keeping parts of the transaction private.
+The fixed secret `[1, 2, 3, 4]` is for demonstration. A real secret must be unpredictable and shared only with the intended consumer. Anyone who learns it can satisfy this note's spending condition.
 
 ### Running the example
 
-To run the custom note example, navigate to the `rust-client` directory in the [miden-tutorials](https://github.com/0xMiden/miden-tutorials/) repository and run this command:
+From the root of your `tutorials` clone, run the checked-in example:
 
 ```bash
 cd rust-client
-cargo run --release --bin hash_preimage_note
+TUTORIAL_NETWORK=testnet cargo run --release --bin hash_preimage_note
 ```
 
 ### Continue learning

--- a/docs/src/rust-client/delegated_proving_tutorial.md
+++ b/docs/src/rust-client/delegated_proving_tutorial.md
@@ -7,9 +7,11 @@ sidebar_position: 12
 
 _Using delegated proving to minimize transaction proving times on computationally constrained devices_
 
+For toolchain requirements and shared fee helpers, see the [Rust client setup](./index.md#running-the-v016-examples).
+
 ## Overview
 
-In this tutorial we will cover how to use delegated proving with the Miden Rust client to minimize the time it takes to generate a valid transaction proof. In the code below, we will create an account, mint tokens from a faucet, then send the tokens to another account using delegated proving.
+In this tutorial we will cover how to use delegated proving with the Miden Rust client to minimize the time it takes to generate a valid transaction proof. We create and fund an account, execute a minimal transaction locally, prove it with the network's remote prover, and verify that its confirmed nonce increases by one. Even this minimal transaction pays a verification fee on testnet.
 
 ## Prerequisites
 
@@ -26,9 +28,9 @@ Before diving into our code example, let's clarify what "delegated proving" mean
 
 Delegated proving is the process of outsourcing the ZK proof generation of your transaction to a third party. For certain computationally constrained devices such as mobile phones and web browser environments, generating ZK proofs might take too long to ensure an acceptable user experience. Devices that do not have the computational resources to generate Miden proofs in under 1-2 seconds can use delegated proving to provide a more responsive user experience.
 
-_How does it work?_ When a user choses to use delegated proving, they send off their locally executed transaction to a dedicated server. This dedicated server generates the ZK proof for the executed transaction and sends the proof back to the user. Proving a transaction with delegated proving is trustless, meaning if the delegated prover is malicious, they could not compromise the security of the account that is submitting a transaction to be processed by the delegated prover.
+_How does it work?_ When a user chooses to use delegated proving, they send off their locally executed transaction to a dedicated server. This dedicated server generates the ZK proof for the executed transaction and sends the proof back to the user. The transaction proof is verified under the same rules as a locally generated proof: the delegated prover cannot make an invalid state transition valid. This protects transaction integrity, but does not keep the witness private from the prover.
 
-The only downside of using delegated proving is that it reduces the privacy of the account that uses delegated proving, because the delegated prover would have knowledge of the inputs to the transaction that is being proven. For example, it would not be advisable to use delegated proving in the case of our "How to Create a Custom Note" tutorial, since the note we create requires knowledge of a hash preimage to redeem the assets in the note. Using delegated proving would reveal the hash preimage to the server running the delegated proving service.
+Delegated proving reveals the transaction witness to the prover and depends on that service being available. The witness can include private account state and note arguments. For example, it would not be advisable to use delegated proving in the case of our "How to Create a Custom Note" tutorial, since the note we create requires knowledge of a hash preimage to redeem the assets in the note. Using delegated proving would reveal the hash preimage to the server running the delegated proving service.
 
 Anyone can run their own delegated prover server. If you are building a product on Miden, it may make sense to run your own delegated prover server for your users. To run your own delegated proving server, follow the instructions here: https://crates.io/crates/miden-remote-prover.
 
@@ -38,52 +40,61 @@ prover instead, point `RemoteTransactionProver` at its URL.
 
 ## Step 1: Initialize your repository
 
-Create a new Rust repository for your Miden project and navigate to it with the following command:
+Start in the directory containing your `tutorials` clone and create a sibling Cargo project. The dependency path below assumes the clone is named `tutorials`.
 
 ```bash
 cargo new miden-delegated-proving-app
 cd miden-delegated-proving-app
+rustup override set 1.98.1
+cp ../tutorials/rust-client/Cargo.lock Cargo.lock
 ```
 
-Add the following dependencies to your `Cargo.toml` file:
+Keep the generated `[package]` section in `Cargo.toml`, replace its empty `[dependencies]` section with the following, and add the development profile:
 
 ```toml
 [dependencies]
-miden-client = { version = "0.15", features = ["testing", "tonic"] }
-miden-client-sqlite-store = { version = "0.15", package = "miden-client-sqlite-store" }
-miden-protocol = { version = "0.15" }
-rand = { version = "0.9" }
-tokio = { version = "1.46", features = ["rt-multi-thread", "net", "macros", "fs"] }
+# Clone tutorials next to this Cargo project (see Rust client setup).
+rust-client = { path = "../tutorials/rust-client" }
+miden-client = { version = "=0.16.0", features = ["testing", "tonic"] }
+miden-client-sqlite-store = { version = "=0.16.0", package = "miden-client-sqlite-store" }
+miden-protocol = { version = "=0.16.0" }
+rand = { version = "0.10" }
+tokio = { version = "1.48", features = ["rt-multi-thread", "net", "macros", "fs"] }
+
+[profile.dev]
+opt-level = 2
 ```
 
 ## Step 2: Initialize the client and prover and construct transactions
 
 Similarly to previous tutorials, we must instantiate the client.
-We construct a `RemoteTransactionProver` pointed at the public Miden testnet delegated prover for this walkthrough.
+We construct a `RemoteTransactionProver` pointed at the public Miden testnet delegated prover for this walkthrough. Copy this complete example into `src/main.rs`. The client creates `store.sqlite3` and `keystore/` in the project directory; keep both out of version control.
 
 ```rust no_run
-use miden_client::auth::AuthSecretKey;
-use miden_client::auth::{AuthSchemeId, AuthSingleSig};
-use rand::RngCore;
+use rand::Rng;
 use std::{path::PathBuf, sync::Arc};
 
 use miden_client::{
-    account::component::BasicWallet,
+    ClientError, RemoteTransactionProver,
+    account::{AccountBuilder, AccountType, component::BasicWallet},
+    auth::{AuthSecretKey, AuthSingleSig},
     builder::ClientBuilder,
     keystore::{FilesystemKeyStore, Keystore},
-    rpc::{Endpoint, GrpcClient},
+    rpc::{GrpcClient, VerifyingRpcClient},
     transaction::{TransactionProver, TransactionRequestBuilder},
-    ClientError, RemoteTransactionProver,
 };
 use miden_client_sqlite_store::ClientBuilderSqliteExt;
-use miden_client::account::{AccountBuilder, AccountType};
+use rust_client::{FeeConfig, TutorialNetwork, fund_account_for_fees};
 
 #[tokio::main]
 async fn main() -> Result<(), ClientError> {
     // Initialize client
-    let endpoint = Endpoint::testnet();
+    let network = TutorialNetwork::from_env()?;
+    let endpoint = network.endpoint();
     let timeout_ms = 10_000;
-    let rpc_client = Arc::new(GrpcClient::new(&endpoint, timeout_ms));
+    let rpc_client = Arc::new(VerifyingRpcClient::new(GrpcClient::new(
+        &endpoint, timeout_ms,
+    )));
 
     // Initialize keystore
     let keystore_path = PathBuf::from("./keystore");
@@ -95,12 +106,12 @@ async fn main() -> Result<(), ClientError> {
         .rpc(rpc_client)
         .sqlite_store(store_path)
         .authenticator(keystore.clone())
-        .in_debug_mode(true.into())
         .build()
         .await?;
 
     let sync_summary = client.sync_state().await.unwrap();
     println!("Latest block: {}", sync_summary.block_num);
+    let fee_config = FeeConfig::from_client(&client, network).await?;
 
     // Create Alice's account
     let mut init_seed = [0_u8; 32];
@@ -110,29 +121,37 @@ async fn main() -> Result<(), ClientError> {
 
     let alice_account = AccountBuilder::new(init_seed)
         .account_type(AccountType::Private)
-        .with_auth_component(AuthSingleSig::new(key_pair.public_key().to_commitment(), AuthSchemeId::Falcon512Poseidon2))
+        .with_component(AuthSingleSig::from_public_key(key_pair.public_key()))
         .with_component(BasicWallet)
         .build()
         .unwrap();
 
     client.add_account(&alice_account, false).await?;
-    keystore.add_key(&key_pair, alice_account.id()).await.unwrap();
+    keystore
+        .add_key(&key_pair, alice_account.id())
+        .await
+        .unwrap();
+    fund_account_for_fees(&mut client, alice_account.id(), &fee_config).await?;
 
     // -------------------------------------------------------------------------
     // Set up the delegated (remote) tx prover
     // -------------------------------------------------------------------------
     // Delegated proving outsources ZK proof generation to a remote service. This is
-    // the public Miden testnet prover; run your own
+    // the public prover for the selected network; run your own
     // (https://crates.io/crates/miden-remote-prover) and swap the URL to use it.
-    // The constant `miden_client::grpc_support::TESTNET_PROVER_ENDPOINT` holds this
-    // same URL.
-    let remote_tx_prover = RemoteTransactionProver::new("https://tx-prover.testnet.miden.io");
+    // The upstream constant keeps this URL synchronized with the selected network.
+    let remote_tx_prover = RemoteTransactionProver::new(network.remote_prover_url());
     let tx_prover: Arc<dyn TransactionProver> = Arc::new(remote_tx_prover);
 
     // We use a dummy transaction request to showcase delegated proving.
-    // The only effect of this tx should be increasing Alice's nonce.
-    println!("Alice nonce initial: {:?}", alice_account.nonce());
-    let script_code = "begin push.1 drop end";
+    // In addition to paying the network fee, this transaction increments Alice's nonce.
+    let initial_nonce = client
+        .get_account(alice_account.id())
+        .await?
+        .expect("Alice exists")
+        .nonce();
+    println!("Alice nonce initial: {:?}", initial_nonce);
+    let script_code = "@transaction_script pub proc main push.1 drop end";
     let tx_script = client
         .code_builder()
         .compile_tx_script(script_code)
@@ -145,6 +164,7 @@ async fn main() -> Result<(), ClientError> {
 
     // Step 1: Execute the transaction locally
     println!("Executing transaction...");
+    client.sync_state().await?;
     let tx_result = client
         .execute_transaction(alice_account.id(), transaction_request)
         .await?;
@@ -163,6 +183,7 @@ async fn main() -> Result<(), ClientError> {
     client
         .apply_transaction(&tx_result, submission_height)
         .await?;
+    rust_client::wait_for_transaction(&mut client, tx_result.id()).await?;
 
     println!("Transaction submitted successfully using the delegated prover!");
 
@@ -175,6 +196,7 @@ async fn main() -> Result<(), ClientError> {
         .expect("alice account not found");
 
     println!("Alice nonce has increased: {:?}", account.nonce());
+    assert_eq!(account.nonce(), initial_nonce + miden_client::Felt::ONE);
 
     Ok(())
 }
@@ -183,28 +205,29 @@ async fn main() -> Result<(), ClientError> {
 Now let's run the `src/main.rs` program:
 
 ```bash
-cargo run --release
+TUTORIAL_NETWORK=testnet cargo run --release
 ```
 
-The output will look like this:
+The following is an abbreviated output. The funding transaction has already increased Alice's nonce from 0 to 1; the delegated transaction then increases it to 2:
 
 ```text
-Latest block: 488706
-Alice nonce initial: 0
+Latest block: <current_block_number>
+Alice nonce initial: 1
 Executing transaction...
 Proving transaction with the delegated prover...
 Submitting proven transaction...
+Transaction committed: <transaction_id>
 Transaction submitted successfully using the delegated prover!
-Alice nonce has increased: 1
+Alice nonce has increased: 2
 ```
 
 ### Running the example
 
-To run a full working example navigate to the `rust-client` directory in the [miden-tutorials](https://github.com/0xMiden/miden-tutorials/) repository and run this command:
+From the root of your `tutorials` clone, run the checked-in example:
 
 ```bash
 cd rust-client
-cargo run --release --bin delegated_prover
+TUTORIAL_NETWORK=testnet cargo run --release --bin delegated_prover
 ```
 
 ### Continue learning

--- a/docs/src/rust-client/foreign_procedure_invocation_tutorial.md
+++ b/docs/src/rust-client/foreign_procedure_invocation_tutorial.md
@@ -7,6 +7,8 @@ sidebar_position: 7
 
 _Using foreign procedure invocation to craft read-only cross-contract calls in the Miden VM_
 
+For toolchain requirements and shared fee helpers, see the [Rust client setup](./index.md#running-the-v016-examples).
+
 ## Overview
 
 In previous tutorials we deployed a public counter contract and incremented the count from a different client instance.
@@ -32,43 +34,91 @@ The diagram above depicts the "count copy" smart contract using foreign procedur
 
 ## Prerequisites
 
-This tutorial assumes you have a basic understanding of Miden assembly and completed the previous tutorial on deploying the counter contract. We will be working within the same `miden-counter-contract` repository that we created in the [Interacting with Public Smart Contracts](./public_account_interaction_tutorial.md) tutorial.
+This tutorial assumes you have a basic understanding of Miden assembly and a counter deployed using the [counter contract tutorial](./counter_contract_tutorial.md). Keep its printed `mtst1...` account ID. The reader runs in a separate Cargo project and reads that counter's public state.
 
 ## Step 1: Set up your repository
 
-We will be using the same repository used in the "Interacting with Public Smart Contracts" tutorial. To set up your repository for this tutorial, first follow up until step two [here](./public_account_interaction_tutorial.md).
+From the parent directory of your `tutorials` clone, create a sibling Cargo project:
+
+```bash
+cargo new miden-fpi
+cd miden-fpi
+rustup override set 1.98.1
+cp ../tutorials/rust-client/Cargo.lock Cargo.lock
+```
+
+Add these dependencies and the development profile to your `Cargo.toml`:
+
+```toml
+[dependencies]
+rust-client = { path = "../tutorials/rust-client" }
+miden-client = { version = "=0.16.0", features = ["testing", "tonic"] }
+miden-client-sqlite-store = { version = "=0.16.0", package = "miden-client-sqlite-store" }
+miden-protocol = { version = "=0.16.0" }
+rand = { version = "0.10" }
+tokio = { version = "1.48", features = ["rt-multi-thread", "net", "macros", "fs"] }
+
+[profile.dev]
+opt-level = 2
+```
 
 ## Step 2: Set up the "count reader" contract
 
-Inside of the `masm/accounts/` directory, create the `count_reader.masm` file. This is the smart contract that will read the "count" value from the counter contract.
+The reader contract in `masm/accounts/count_reader.masm` reads the counter’s value through FPI.
 
 `masm/accounts/count_reader.masm`:
 
 ```masm
-use miden::protocol::active_account
 use miden::protocol::native_account
 use miden::protocol::tx
-use miden::core::word
 use miden::core::sys
+use {AccountId, AccountProcedureRoot} from miden::protocol::types
+
+# CONSTANTS
+# =================================================================================================
 
 const COUNT_READER_SLOT = word("miden::tutorials::count_reader")
 
-# => [account_id_suffix, account_id_prefix, PROC_HASH(4), foreign_procedure_inputs(16)]
-pub proc copy_count
+# PUBLIC INTERFACE
+# =================================================================================================
+
+#! Copies the count returned by the foreign counter into this account's storage.
+#!
+#! Inputs:  [foreign_account_id_{suffix,prefix}, FOREIGN_PROC_ROOT, pad(10)]
+#! Outputs: [pad(16)]
+#!
+#! Where:
+#! - foreign_account_id_{suffix,prefix} identifies the public counter account.
+#! - FOREIGN_PROC_ROOT is the root of its get_count procedure.
+#!
+#! Invocation: call
+@account_procedure
+@locals(6)
+pub proc copy_count(foreign_account_id: AccountId, foreign_proc_root: AccountProcedureRoot)
+    # save the foreign target while preparing its sixteen zero inputs
+    loc_store.4 loc_store.5 loc_storew_le.0 dropw
+    # => [pad(16)]
+
+    padw padw padw padw
+    # => [foreign_procedure_inputs(16), pad(16)]
+
+    padw loc_loadw_le.0 loc_load.5 loc_load.4
+    # => [foreign_account_id_suffix, foreign_account_id_prefix, FOREIGN_PROC_ROOT, foreign_procedure_inputs(16), pad(16)]
+
     exec.tx::execute_foreign_procedure
-    # => [count, pad(12)]
+    # => [[count, 0, 0, 0], pad(28)]
 
     push.COUNT_READER_SLOT[0..2]
-    # [slot_id_prefix, slot_id_suffix, count, pad(12)]
+    # => [slot_id_suffix, slot_id_prefix, [count, 0, 0, 0], pad(28)]
 
     exec.native_account::set_item
-    # => [OLD_VALUE, pad(12)]
+    # => [OLD_VALUE, pad(28)]
 
-    dropw dropw dropw dropw
-    # => []
+    dropw
+    # => [pad(28)]
 
     exec.sys::truncate_stack
-    # => []
+    # => [pad(16)]
 end
 ```
 
@@ -84,22 +134,33 @@ This is what the stack state should look like before we call `tx::execute_foreig
 
 `execute_foreign_procedure` always requires exactly 16 `foreign_procedure_inputs` on the stack
 below the procedure hash and account ID. Since `get_count` takes no arguments, we pass 16 zero
-words (`padw padw padw padw`) as the inputs. After the call, the procedure returns 16 output
-elements; the count word sits at the top and we clean up the rest with `dropw dropw dropw dropw`.
+felts (`padw padw padw padw`, four words) as the inputs. The reader prepares these
+inputs internally after saving the account ID and procedure root in local memory. The
+caller therefore passes only those six identifying felts. After the foreign call,
+the count is the first of 16 output elements; the reader stores its word, discards
+the previous storage value, and truncates the remaining padding.
 
 After calling the `get_count` procedure in the counter contract, we save the count into the
 `miden::tutorials::count_reader` storage slot.
 
-**Note**: _The bracket symbols used in the count copy contract are not valid MASM syntax. These are simply placeholder elements that we will replace with the actual values before compilation._
-
-Inside the `masm/scripts/` directory, create the `reader_script.masm` file:
+The transaction script is defined in `masm/scripts/reader_script.masm`:
 
 ```masm
 use external_contract::count_reader_contract
 use miden::core::sys
 
-begin
-    padw padw padw padw
+#! Copies a public counter through the reader account.
+#!
+#! Inputs:  [ARGS, pad(12)]
+#! Outputs: [pad(16)]
+#!
+#! Where:
+#! - ARGS contains unused transaction script arguments.
+#!
+#! Invocation: dyncall
+@transaction_script
+pub proc main(args: word)
+    dropw
     # => [pad(16)]
 
     push.{get_count_proc_hash}
@@ -112,43 +173,49 @@ begin
     # => [account_id_suffix, account_id_prefix, GET_COUNT_HASH, pad(16)]
 
     call.count_reader_contract::copy_count
-    # => []
+    # => [pad(22)]
 
     exec.sys::truncate_stack
-    # => []
+    # => [pad(16)]
 end
 ```
 
-**Note**: _`push.{get_count_proc_hash}` is not valid MASM, we will format the string with the value get_count_proc_hash before passing this script code to the assembler._
+The braces mark template values, not valid MASM operands. The Rust code replaces the procedure root and both account ID elements before assembling the script.
 
-### Step 3: Set up your `src/main.rs` file:
+## Step 3: Set up your `src/main.rs` file
 
 ```rust no_run
-use rand::RngCore;
+use rand::Rng;
+use rust_client::TutorialClientExt;
 use std::{path::PathBuf, sync::Arc, time::Duration};
 use tokio::time::sleep;
 
 use miden_client::{
+    ClientError, Word,
     account::{
-        component::AccountComponentMetadata, AccountBuilder, AccountComponent, AccountId,
-        AccountType, StorageSlot, StorageSlotName,
+        AccountBuilder, AccountComponent, AccountId, AccountType, StorageSlot, StorageSlotName,
+        component::{AccountComponentMetadata, BasicWallet},
     },
     auth::NoAuth,
     builder::ClientBuilder,
     keystore::FilesystemKeyStore,
-    rpc::{domain::account::AccountStorageRequirements, Endpoint, GrpcClient},
+    rpc::{GrpcClient, VerifyingRpcClient, domain::account::AccountStorageRequirements},
     transaction::{ForeignAccount, TransactionRequestBuilder},
-    ClientError, Word,
 };
 use miden_client_sqlite_store::ClientBuilderSqliteExt;
+use rust_client::{FeeConfig, TutorialNetwork, fund_account_for_fees};
 
 #[tokio::main]
 async fn main() -> Result<(), ClientError> {
     // Initialize client
-    let endpoint = Endpoint::testnet();
+    let network = TutorialNetwork::from_env()?;
+    let endpoint = network.endpoint();
     let timeout_ms = 10_000;
-    let rpc_client = Arc::new(GrpcClient::new(&endpoint, timeout_ms));
+    let rpc_client = Arc::new(VerifyingRpcClient::new(GrpcClient::new(
+        &endpoint, timeout_ms,
+    )));
 
+    // Initialize keystore
     let keystore_path = PathBuf::from("./keystore");
     let keystore = Arc::new(FilesystemKeyStore::new(keystore_path).unwrap());
 
@@ -158,27 +225,30 @@ async fn main() -> Result<(), ClientError> {
         .rpc(rpc_client)
         .sqlite_store(store_path)
         .authenticator(keystore.clone())
-        .in_debug_mode(true.into())
         .build()
         .await?;
 
     let sync_summary = client.sync_state().await.unwrap();
     println!("Latest block: {}", sync_summary.block_num);
+    let fee_config = FeeConfig::from_client(&client, network).await?;
 
     // -------------------------------------------------------------------------
     // STEP 1: Create the Count Reader Contract
     // -------------------------------------------------------------------------
     println!("\n[STEP 1] Creating count reader contract.");
 
-    // `include_str!` resolves at compile time relative to this source file,
-    // so the binary is independent of the working directory it is run from.
-    let count_reader_code = include_str!("../masm/accounts/count_reader.masm");
+    // Read the MASM source from the tutorials repository.
+    let count_reader_code =
+        std::fs::read_to_string("../tutorials/masm/accounts/count_reader.masm").unwrap();
 
     let count_reader_slot_name =
         StorageSlotName::new("miden::tutorials::count_reader").expect("valid slot name");
     let count_reader_component_code = client
         .code_builder()
-        .compile_component_code("external_contract::count_reader_contract", count_reader_code)
+        .compile_component_code(
+            "external_contract::count_reader_contract",
+            &count_reader_code,
+        )
         .unwrap();
     let count_reader_component = AccountComponent::new(
         count_reader_component_code,
@@ -196,7 +266,8 @@ async fn main() -> Result<(), ClientError> {
     let count_reader_contract = AccountBuilder::new(init_seed)
         .account_type(AccountType::Public)
         .with_component(count_reader_component.clone())
-        .with_auth_component(NoAuth)
+        .with_component(BasicWallet)
+        .with_component(NoAuth)
         .build()
         .unwrap();
 
@@ -204,12 +275,13 @@ async fn main() -> Result<(), ClientError> {
         "count_reader hash: {:?}",
         count_reader_contract.to_commitment()
     );
-    println!("contract id: {:?}", count_reader_contract.id());
+    println!("count_reader id: {:?}", count_reader_contract.id());
 
     client
         .add_account(&count_reader_contract, false)
         .await
         .unwrap();
+    fund_account_for_fees(&mut client, count_reader_contract.id(), &fee_config).await?;
 
     Ok(())
 }
@@ -218,22 +290,24 @@ async fn main() -> Result<(), ClientError> {
 Run the following command to execute src/main.rs:
 
 ```bash
-cargo run --release
+TUTORIAL_NETWORK=testnet cargo run --release
 ```
 
-The output of our program will look something like this:
+The output includes the reader's initial commitment and ID (abridged; values vary):
 
 ```text
-Latest block: 226976
+Latest block: <block_number>
 
 [STEP 1] Creating count reader contract.
-count_reader hash: RpoDigest([15888177100833057221, 15548657445961063290, 5580812380698193124, 9604096693288041818])
-contract id: "<testnet_account_id>"
+count_reader hash: Word([...])
+count_reader id: V1(AccountIdV1 { suffix: ..., prefix: ... })
 ```
 
 ## Step 4: Import the pre-deployed counter contract
 
-The FPI call needs a counter contract already deployed on-chain. We import the counter contract that was deployed in the [counter contract tutorial](./counter_contract_tutorial.md) by its testnet address:
+The FPI call needs a counter contract already deployed on-chain. Copy its `mtst1...` testnet account ID into the `MIDEN_COUNTER_ACCOUNT_ID` environment variable. Using an input avoids baking in an address that becomes invalid after a testnet reset.
+
+Insert this fragment inside `main`, immediately before its final `Ok(())`:
 
 ```rust ignore
 // -------------------------------------------------------------------------
@@ -241,9 +315,19 @@ The FPI call needs a counter contract already deployed on-chain. We import the c
 // -------------------------------------------------------------------------
 println!("\n[STEP 2] Building counter contract from public state");
 
-// Define the Counter Contract account id from counter contract deploy
-let (_, counter_contract_id) =
-    AccountId::from_bech32("mtst1apcqs7aj3a2cf5t6pnsfy0p4ns7wl7sp").unwrap();
+// Pass the account ID printed by `counter_contract_deploy` as the first argument, or via
+// `MIDEN_COUNTER_ACCOUNT_ID`.
+let counter_contract_bech32 = std::env::args()
+    .nth(1)
+    .or_else(|| std::env::var("MIDEN_COUNTER_ACCOUNT_ID").ok())
+    .expect("pass the counter account ID from counter_contract_deploy");
+let (account_network, counter_contract_id) =
+    AccountId::from_bech32(&counter_contract_bech32).expect("invalid counter account ID");
+assert_eq!(
+    account_network,
+    network.network_id(),
+    "counter account must match the selected tutorial network"
+);
 
 println!("counter contract id: {:?}", counter_contract_id);
 
@@ -265,7 +349,7 @@ println!(
 
 ## Step 5: Call the counter contract via foreign procedure invocation
 
-Add this snippet to the end of your file in the `main()` function:
+Insert this fragment after the import step, inside `main` and before `Ok(())`:
 
 ```rust ignore
 // -------------------------------------------------------------------------
@@ -273,14 +357,17 @@ Add this snippet to the end of your file in the `main()` function:
 // -------------------------------------------------------------------------
 println!("\n[STEP 3] Call counter contract with FPI from count reader contract");
 
-// Derive the get_count procedure hash from the locally compiled counter library.
-let counter_contract_code = include_str!("../masm/accounts/counter.masm");
+let counter_contract_code =
+    std::fs::read_to_string("../tutorials/masm/accounts/counter.masm").unwrap();
 
 // Compile the counter as a component (same path as the deploy binary) to get
 // the correct procedure root that matches the on-chain MAST.
 let counter_component_code = client
     .code_builder()
-    .compile_component_code("external_contract::counter_contract", counter_contract_code)
+    .compile_component_code(
+        "external_contract::counter_contract",
+        &counter_contract_code,
+    )
     .unwrap();
 let counter_component = AccountComponent::new(
     counter_component_code,
@@ -291,7 +378,6 @@ let counter_component = AccountComponent::new(
 
 let get_count_root = counter_component
     .component_code()
-    .as_library()
     .get_procedure_root_by_path("external_contract::counter_contract::get_count")
     .expect("get_count export not found");
 let get_count_hash = format!("{}", get_count_root);
@@ -300,7 +386,8 @@ println!("get_count hash: {:?}", get_count_hash);
 println!("counter id prefix: {:?}", counter_contract_id.prefix());
 println!("counter id suffix: {:?}", counter_contract_id.suffix());
 
-let script_code = include_str!("../masm/scripts/reader_script.masm")
+let script_code = std::fs::read_to_string("../tutorials/masm/scripts/reader_script.masm")
+    .unwrap()
     .replace("{get_count_proc_hash}", &get_count_hash)
     .replace(
         "{account_id_suffix}",
@@ -315,7 +402,10 @@ let script_code = include_str!("../masm/scripts/reader_script.masm")
 // that compiles the script.
 let tx_script = client
     .code_builder()
-    .with_linked_module("external_contract::count_reader_contract", count_reader_code)
+    .with_linked_module(
+        "external_contract::count_reader_contract",
+        &count_reader_code,
+    )
     .unwrap()
     .compile_tx_script(script_code.as_str())
     .unwrap();
@@ -330,12 +420,13 @@ let tx_request = TransactionRequestBuilder::new()
     .unwrap();
 
 let tx_id = client
-    .submit_new_transaction(count_reader_contract.id(), tx_request)
+    .submit_tutorial_transaction(count_reader_contract.id(), tx_request)
     .await
     .unwrap();
 
 println!(
-    "View transaction on MidenScan: https://testnet.midenscan.com/tx/{:?}",
+    "View transaction on MidenScan: {}/tx/{:?}",
+    network.explorer_url(),
     tx_id
 );
 
@@ -365,42 +456,56 @@ println!(
     "count reader contract storage: {:?}",
     account_2.storage().get_item(&count_reader_slot_name)
 );
+assert_eq!(
+    account_2
+        .storage()
+        .get_item(&count_reader_slot_name)
+        .unwrap(),
+    account_1.storage().get_item(&counter_slot_name).unwrap(),
+    "FPI must copy the current counter value",
+);
 ```
 
-The key here is the use of the `.foreign_accounts()` method on the `TransactionRequestBuilder`. Using this method, it is possible to create transactions with multiple foreign procedure calls.
+The `.foreign_accounts()` method declares the foreign state that the client must fetch and prove. `AccountStorageRequirements::default()` suffices here because `get_count` reads a value slot. A procedure that reads map entries must also request proofs for the specific map keys it uses. The MASM script performs the actual foreign call.
 
 ## Summary
 
-In this tutorial created a smart contract that calls the `get_count` procedure in the counter contract using foreign procedure invocation, and then saves the returned value to its local storage.
+In this tutorial, we created a smart contract that calls the counter's `get_count` procedure through FPI and saves the returned value in its own storage. The reader account pays for this transaction; the foreign counter is read-only and is not charged or modified.
 
 The final `src/main.rs` file should look like this:
 
 ```rust no_run
-use rand::RngCore;
+use rand::Rng;
+use rust_client::TutorialClientExt;
 use std::{path::PathBuf, sync::Arc, time::Duration};
 use tokio::time::sleep;
 
 use miden_client::{
+    ClientError, Word,
     account::{
-        component::AccountComponentMetadata, AccountBuilder, AccountComponent, AccountId,
-        AccountType, StorageSlot, StorageSlotName,
+        AccountBuilder, AccountComponent, AccountId, AccountType, StorageSlot, StorageSlotName,
+        component::{AccountComponentMetadata, BasicWallet},
     },
     auth::NoAuth,
     builder::ClientBuilder,
     keystore::FilesystemKeyStore,
-    rpc::{domain::account::AccountStorageRequirements, Endpoint, GrpcClient},
+    rpc::{GrpcClient, VerifyingRpcClient, domain::account::AccountStorageRequirements},
     transaction::{ForeignAccount, TransactionRequestBuilder},
-    ClientError, Word,
 };
 use miden_client_sqlite_store::ClientBuilderSqliteExt;
+use rust_client::{FeeConfig, TutorialNetwork, fund_account_for_fees};
 
 #[tokio::main]
 async fn main() -> Result<(), ClientError> {
     // Initialize client
-    let endpoint = Endpoint::testnet();
+    let network = TutorialNetwork::from_env()?;
+    let endpoint = network.endpoint();
     let timeout_ms = 10_000;
-    let rpc_client = Arc::new(GrpcClient::new(&endpoint, timeout_ms));
+    let rpc_client = Arc::new(VerifyingRpcClient::new(GrpcClient::new(
+        &endpoint, timeout_ms,
+    )));
 
+    // Initialize keystore
     let keystore_path = PathBuf::from("./keystore");
     let keystore = Arc::new(FilesystemKeyStore::new(keystore_path).unwrap());
 
@@ -410,21 +515,21 @@ async fn main() -> Result<(), ClientError> {
         .rpc(rpc_client)
         .sqlite_store(store_path)
         .authenticator(keystore.clone())
-        .in_debug_mode(true.into())
         .build()
         .await?;
 
     let sync_summary = client.sync_state().await.unwrap();
     println!("Latest block: {}", sync_summary.block_num);
+    let fee_config = FeeConfig::from_client(&client, network).await?;
 
     // -------------------------------------------------------------------------
     // STEP 1: Create the Count Reader Contract
     // -------------------------------------------------------------------------
     println!("\n[STEP 1] Creating count reader contract.");
 
-    // `include_str!` resolves at compile time relative to this source file,
-    // so the binary is independent of the working directory it is run from.
-    let count_reader_code = include_str!("../masm/accounts/count_reader.masm");
+    // Read the MASM source from the tutorials repository.
+    let count_reader_code =
+        std::fs::read_to_string("../tutorials/masm/accounts/count_reader.masm").unwrap();
 
     let count_reader_slot_name =
         StorageSlotName::new("miden::tutorials::count_reader").expect("valid slot name");
@@ -432,7 +537,7 @@ async fn main() -> Result<(), ClientError> {
         .code_builder()
         .compile_component_code(
             "external_contract::count_reader_contract",
-            count_reader_code,
+            &count_reader_code,
         )
         .unwrap();
     let count_reader_component = AccountComponent::new(
@@ -451,7 +556,8 @@ async fn main() -> Result<(), ClientError> {
     let count_reader_contract = AccountBuilder::new(init_seed)
         .account_type(AccountType::Public)
         .with_component(count_reader_component.clone())
-        .with_auth_component(NoAuth)
+        .with_component(BasicWallet)
+        .with_component(NoAuth)
         .build()
         .unwrap();
 
@@ -465,15 +571,26 @@ async fn main() -> Result<(), ClientError> {
         .add_account(&count_reader_contract, false)
         .await
         .unwrap();
+    fund_account_for_fees(&mut client, count_reader_contract.id(), &fee_config).await?;
 
     // -------------------------------------------------------------------------
     // STEP 2: Build & Get State of the Counter Contract
     // -------------------------------------------------------------------------
     println!("\n[STEP 2] Building counter contract from public state");
 
-    // Define the Counter Contract account id from counter contract deploy
-    let (_, counter_contract_id) =
-        AccountId::from_bech32("mtst1apcqs7aj3a2cf5t6pnsfy0p4ns7wl7sp").unwrap();
+    // Pass the account ID printed by `counter_contract_deploy` as the first argument, or via
+    // `MIDEN_COUNTER_ACCOUNT_ID`.
+    let counter_contract_bech32 = std::env::args()
+        .nth(1)
+        .or_else(|| std::env::var("MIDEN_COUNTER_ACCOUNT_ID").ok())
+        .expect("pass the counter account ID from counter_contract_deploy");
+    let (account_network, counter_contract_id) =
+        AccountId::from_bech32(&counter_contract_bech32).expect("invalid counter account ID");
+    assert_eq!(
+        account_network,
+        network.network_id(),
+        "counter account must match the selected tutorial network"
+    );
 
     println!("counter contract id: {:?}", counter_contract_id);
 
@@ -497,13 +614,17 @@ async fn main() -> Result<(), ClientError> {
     // -------------------------------------------------------------------------
     println!("\n[STEP 3] Call counter contract with FPI from count reader contract");
 
-    let counter_contract_code = include_str!("../masm/accounts/counter.masm");
+    let counter_contract_code =
+        std::fs::read_to_string("../tutorials/masm/accounts/counter.masm").unwrap();
 
     // Compile the counter as a component (same path as the deploy binary) to get
     // the correct procedure root that matches the on-chain MAST.
     let counter_component_code = client
         .code_builder()
-        .compile_component_code("external_contract::counter_contract", counter_contract_code)
+        .compile_component_code(
+            "external_contract::counter_contract",
+            &counter_contract_code,
+        )
         .unwrap();
     let counter_component = AccountComponent::new(
         counter_component_code,
@@ -514,7 +635,6 @@ async fn main() -> Result<(), ClientError> {
 
     let get_count_root = counter_component
         .component_code()
-        .as_library()
         .get_procedure_root_by_path("external_contract::counter_contract::get_count")
         .expect("get_count export not found");
     let get_count_hash = format!("{}", get_count_root);
@@ -523,7 +643,8 @@ async fn main() -> Result<(), ClientError> {
     println!("counter id prefix: {:?}", counter_contract_id.prefix());
     println!("counter id suffix: {:?}", counter_contract_id.suffix());
 
-    let script_code = include_str!("../masm/scripts/reader_script.masm")
+    let script_code = std::fs::read_to_string("../tutorials/masm/scripts/reader_script.masm")
+        .unwrap()
         .replace("{get_count_proc_hash}", &get_count_hash)
         .replace(
             "{account_id_suffix}",
@@ -538,14 +659,16 @@ async fn main() -> Result<(), ClientError> {
     // that compiles the script.
     let tx_script = client
         .code_builder()
-        .with_linked_module("external_contract::count_reader_contract", count_reader_code)
+        .with_linked_module(
+            "external_contract::count_reader_contract",
+            &count_reader_code,
+        )
         .unwrap()
         .compile_tx_script(script_code.as_str())
         .unwrap();
 
     let foreign_account =
-        ForeignAccount::public(counter_contract_id, AccountStorageRequirements::default())
-            .unwrap();
+        ForeignAccount::public(counter_contract_id, AccountStorageRequirements::default()).unwrap();
 
     let tx_request = TransactionRequestBuilder::new()
         .foreign_accounts([foreign_account])
@@ -554,12 +677,13 @@ async fn main() -> Result<(), ClientError> {
         .unwrap();
 
     let tx_id = client
-        .submit_new_transaction(count_reader_contract.id(), tx_request)
+        .submit_tutorial_transaction(count_reader_contract.id(), tx_request)
         .await
         .unwrap();
 
     println!(
-        "View transaction on MidenScan: https://testnet.midenscan.com/tx/{:?}",
+        "View transaction on MidenScan: {}/tx/{:?}",
+        network.explorer_url(),
         tx_id
     );
 
@@ -589,21 +713,31 @@ async fn main() -> Result<(), ClientError> {
         "count reader contract storage: {:?}",
         account_2.storage().get_item(&count_reader_slot_name)
     );
+    assert_eq!(
+        account_2
+            .storage()
+            .get_item(&count_reader_slot_name)
+            .unwrap(),
+        account_1.storage().get_item(&counter_slot_name).unwrap(),
+        "FPI must copy the current counter value",
+    );
 
     Ok(())
 }
 ```
 
-The output will show the count reader contract being created, the counter contract being imported from testnet, and finally both storage slots reflecting the same count value after the FPI transaction is confirmed.
+Run the standalone project with `TUTORIAL_NETWORK=testnet cargo run --release`. With `MIDEN_COUNTER_ACCOUNT_ID` set, the output shows the reader being created, the counter imported from testnet, and both storage slots containing the same count after the FPI transaction is confirmed. The final assertion assumes the counter is not concurrently incremented while the example runs; use a fresh counter for this check.
 
 ### Running the example
 
-To run the full example, navigate to the `rust-client` directory in the [miden-tutorials](https://github.com/0xMiden/miden-tutorials/) repository and run this command:
+To run the checked-in example, return to the root of the [tutorials repository](https://github.com/0xMiden/tutorials/) and run:
 
 ```bash
 cd rust-client
-cargo run --release --bin counter_contract_fpi
+TUTORIAL_NETWORK=testnet cargo run --release --bin counter_contract_fpi -- "$MIDEN_COUNTER_ACCOUNT_ID"
 ```
+
+If `MIDEN_COUNTER_ACCOUNT_ID` is exported in your shell, you can omit `--` and the final argument.
 
 ### Continue learning
 

--- a/docs/src/rust-client/index.md
+++ b/docs/src/rust-client/index.md
@@ -15,4 +15,38 @@ The Miden Rust client can be used for a variety of things, including:
 
 This section of the docs is an overview of the different things one can achieve using the Rust client, and how to implement them.
 
+## Running the v0.16 examples
+
+The examples use Rust 1.98.1 and Miden v0.16. The repository includes the
+required toolchain configuration and dependency lockfiles.
+
+From the repository root, run the Rust tutorials on testnet with Node.js and Yarn:
+
+```bash
+yarn tutorials --rust
+```
+
+For devnet validation, run `TUTORIAL_NETWORK=devnet yarn tutorials --rust` instead.
+
+The runner uses a fresh store for each example and deploys a counter before the
+FPI and public-account interaction examples. The [oracle tutorial](./oracle_tutorial.md)
+requires an external deployment and is excluded from the default run.
+
+Testnet transactions pay fees in the native asset. The shared
+[`rust-client` helpers](https://github.com/0xMiden/tutorials/blob/next/rust-client/src/lib.rs)
+fund each executing account, synchronize before submission, and wait for confirmation.
+They also filter `TX_FEE` notes when selecting tutorial notes. Set
+`MIDEN_FAUCET_URL` if you need to override the network's public faucet API.
+
+To follow a tutorial in a standalone project, clone this repository as `tutorials`
+and create the project alongside it. The tutorial's `Cargo.toml` includes the
+local `rust-client` dependency and development optimization profile. Follow its
+commands to select the Rust toolchain and copy the repository's `Cargo.lock`.
+Run the first build without `--locked` so Cargo can add the new project's package
+entry to the lockfile.
+
+Run standalone programs from their Cargo project directory. They load the shared
+MASM files from `../tutorials/masm/`; the corresponding tutorial shows and explains
+those sources. No additional MASM files need to be copied into the new project.
+
 Keep in mind that both the Rust client and the documentation are works-in-progress!

--- a/docs/src/rust-client/mappings_in_masm_how_to.md
+++ b/docs/src/rust-client/mappings_in_masm_how_to.md
@@ -7,6 +7,8 @@ sidebar_position: 10
 
 _Using mappings in Miden assembly for storing key value pairs_
 
+For toolchain requirements and shared fee helpers, see the [Rust client setup](./index.md#running-the-v016-examples).
+
 ## Overview
 
 In this example, we will explore how to use mappings in Miden Assembly. Mappings are essential data structures that store key-value pairs. We will demonstrate how to create an account that contains a mapping and then call a procedure in that account to update the mapping.
@@ -16,8 +18,7 @@ At a high level, this example involves:
 - Setting up an account with a mapping stored in one of its storage slots.
 - Writing a smart contract in Miden Assembly that includes procedures to read from and write to the mapping.
 - Creating a transaction script that calls these procedures.
-- Using Rust code to deploy the account and submit a transaction that updates the mapping.  
-  After the Miden Assembly snippets, we explain that the transaction script calls a procedure in the account. This procedure then updates the mapping by modifying the mapping stored in the account's storage slot.
+- Using Rust code to deploy the account and submit a transaction that updates the mapping.
 
 ## What we'll cover
 
@@ -42,46 +43,67 @@ At a high level, this example involves:
 ```masm
 use miden::protocol::active_account
 use miden::protocol::native_account
-use miden::core::word
 use miden::core::sys
+use {StorageMapKey} from miden::protocol::types
+
+# CONSTANTS
+# =================================================================================================
 
 const MAP_SLOT = word("miden::tutorials::mapping::map")
 
-# Inputs: [KEY, VALUE]
-# Outputs: []
-pub proc write_to_map
-    # The storage map is in the mapping slot.
-    push.MAP_SLOT[0..2]
-    # => [slot_id_prefix, slot_id_suffix, KEY, VALUE]
+# PUBLIC INTERFACE
+# =================================================================================================
 
-    # Setting the key value pair in the map
+#! Stores VALUE under KEY in the mapping.
+#!
+#! Inputs:  [KEY, VALUE, pad(8)]
+#! Outputs: [pad(16)]
+#!
+#! Invocation: call
+@account_procedure
+pub proc write_to_map(key: StorageMapKey, value: word)
+    # the storage map is in the mapping slot
+    push.MAP_SLOT[0..2]
+    # => [slot_id_suffix, slot_id_prefix, KEY, VALUE, pad(8)]
+
+    # set the key-value pair in the map
     exec.native_account::set_map_item
-    # => [OLD_VALUE]
+    # => [OLD_VALUE, pad(12)]
 
     dropw
-    # => []
+    # => [pad(16)]
 end
 
-# Inputs: [KEY]
-# Outputs: [VALUE]
-pub proc get_value_in_map
-    # The storage map is in the mapping slot.
+#! Returns the VALUE stored under KEY in the mapping.
+#!
+#! Inputs:  [KEY, pad(12)]
+#! Outputs: [VALUE, pad(12)]
+#!
+#! Invocation: call
+@account_procedure
+pub proc get_value_in_map(key: StorageMapKey) -> word
+    # the storage map is in the mapping slot
     push.MAP_SLOT[0..2]
-    # => [slot_id_prefix, slot_id_suffix, KEY]
+    # => [slot_id_suffix, slot_id_prefix, KEY, pad(12)]
 
     exec.active_account::get_map_item
-    # => [VALUE]
+    # => [VALUE, pad(12)]
 end
 
-# Inputs: []
-# Outputs: [CURRENT_ROOT]
-pub proc get_current_map_root
-    # Getting the current root from the mapping slot.
+#! Returns the CURRENT_ROOT of the mapping.
+#!
+#! Inputs:  [pad(16)]
+#! Outputs: [CURRENT_ROOT, pad(12)]
+#!
+#! Invocation: call
+@account_procedure
+pub proc get_current_map_root() -> word
+    # get the current root from the mapping slot
     push.MAP_SLOT[0..2] exec.active_account::get_item
-    # => [CURRENT_ROOT]
+    # => [CURRENT_ROOT, pad(16)]
 
     exec.sys::truncate_stack
-    # => [CURRENT_ROOT]
+    # => [CURRENT_ROOT, pad(12)]
 end
 ```
 
@@ -95,7 +117,7 @@ end
 - **get_current_map_root:**  
   This procedure retrieves the current root of the mapping by calling `get_item` with the mapping slot ID and then truncating the stack to leave only the mapping root.
 
-**Security Note**: The procedure `write_to_map` calls the account procedure `incr_nonce`. This allows any external account to be able to write to the storage map of the account. Smart contract developers should know that procedures that call the `account::incr_nonce` procedure allow anyone to call the procedure and modify the state of the account.
+The Rust account below uses `NoAuth`, so anyone can import its public state and submit a mapping update without a signature. `NoAuth` handles fee payment and nonce changes; incrementing a nonce does not itself grant authorization. Use an appropriate authentication component when writes should be restricted.
 
 ### Transaction script that calls the smart contract
 
@@ -103,27 +125,42 @@ end
 use miden_by_example::mapping_example_contract
 use miden::core::sys
 
-begin
+#! Writes a mapping entry, reads it, and returns the current map root.
+#!
+#! Inputs:  [ARGS, pad(12)]
+#! Outputs: [CURRENT_ROOT, pad(12)]
+#!
+#! Where:
+#! - ARGS contains unused transaction script arguments.
+#! - CURRENT_ROOT is the mapping's Merkle root after the write.
+#!
+#! Invocation: dyncall
+@transaction_script
+pub proc main(args: word) -> word
+    dropw
+    # => [pad(16)]
+
     push.1.2.3.4
     push.0.0.0.0
-    # => [KEY, VALUE]
+    # => [KEY, VALUE, pad(16)]
 
     call.mapping_example_contract::write_to_map
-    # => []
+    # => [pad(24)]
 
     push.0.0.0.0
-    # => [KEY]
+    # => [KEY, pad(24)]
 
     call.mapping_example_contract::get_value_in_map
-    # => [VALUE]
+    # => [VALUE, pad(24)]
 
     dropw
-    # => []
+    # => [pad(24)]
 
     call.mapping_example_contract::get_current_map_root
-    # => [CURRENT_ROOT]
+    # => [CURRENT_ROOT, pad(20)]
 
     exec.sys::truncate_stack
+    # => [CURRENT_ROOT, pad(12)]
 end
 ```
 
@@ -131,7 +168,7 @@ end
 
 The transaction script does the following:
 
-- It pushes a key (`[0.0.0.0]`) and a value (`[1.2.3.4]`) onto the stack.
+- It pushes the value with `push.1.2.3.4`, then the key with `push.0.0.0.0`. The last pushed element is on top, so the stored value is `[4, 3, 2, 1]` and the key is `[0, 0, 0, 0]`.
 - It calls the `write_to_map` procedure, which is defined in the account’s smart contract. This updates the mapping in the account.
 - It then pushes the key again and calls `get_value_in_map` to retrieve the value associated with the key.
 - Finally, it calls `get_current_map_root` to get the current state (root) of the mapping.
@@ -142,32 +179,62 @@ The script calls the `write_to_map` procedure in the account which writes the ke
 
 ### Rust code that sets everything up
 
+From the parent directory of your `tutorials` clone, create a sibling Cargo project:
+
+```bash
+cargo new miden-mappings
+cd miden-mappings
+rustup override set 1.98.1
+cp ../tutorials/rust-client/Cargo.lock Cargo.lock
+```
+
+Add these dependencies and the development profile to your `Cargo.toml`:
+
+```toml
+[dependencies]
+rust-client = { path = "../tutorials/rust-client" }
+miden-client = { version = "=0.16.0", features = ["testing", "tonic"] }
+miden-client-sqlite-store = { version = "=0.16.0", package = "miden-client-sqlite-store" }
+miden-protocol = { version = "=0.16.0" }
+rand = { version = "0.10" }
+tokio = { version = "1.48", features = ["rt-multi-thread", "net", "macros", "fs"] }
+
+[profile.dev]
+opt-level = 2
+```
+
 Below is the Rust code that deploys the smart contract, creates the transaction script, and submits a transaction to update the mapping in the account:
 
 ```rust no_run
-use rand::RngCore;
+use rand::Rng;
+use rust_client::TutorialClientExt;
 use std::{path::PathBuf, sync::Arc};
 
 use miden_client::{
+    ClientError,
     account::{
-        component::AccountComponentMetadata, AccountBuilder, AccountComponent,
-        AccountType, StorageMap, StorageSlot, StorageSlotName,
+        AccountBuilder, AccountComponent, AccountType, StorageMap, StorageMapKey, StorageSlot,
+        StorageSlotName,
+        component::{AccountComponentMetadata, BasicWallet},
     },
     auth::NoAuth,
     builder::ClientBuilder,
     keystore::FilesystemKeyStore,
-    rpc::{Endpoint, GrpcClient},
+    rpc::{GrpcClient, VerifyingRpcClient},
     transaction::TransactionRequestBuilder,
-    ClientError, Felt, Word,
 };
 use miden_client_sqlite_store::ClientBuilderSqliteExt;
+use rust_client::{FeeConfig, TutorialNetwork, fund_account_for_fees};
 
 #[tokio::main]
 async fn main() -> Result<(), ClientError> {
     // Initialize client
-    let endpoint = Endpoint::testnet();
+    let network = TutorialNetwork::from_env()?;
+    let endpoint = network.endpoint();
     let timeout_ms = 10_000;
-    let rpc_client = Arc::new(GrpcClient::new(&endpoint, timeout_ms));
+    let rpc_client = Arc::new(VerifyingRpcClient::new(GrpcClient::new(
+        &endpoint, timeout_ms,
+    )));
 
     // Initialize keystore
     let keystore_path = PathBuf::from("./keystore");
@@ -179,29 +246,24 @@ async fn main() -> Result<(), ClientError> {
         .rpc(rpc_client)
         .sqlite_store(store_path)
         .authenticator(keystore.clone())
-        .in_debug_mode(true.into())
         .build()
         .await?;
 
     let sync_summary = client.sync_state().await.unwrap();
     println!("Latest block: {}", sync_summary.block_num);
+    let fee_config = FeeConfig::from_client(&client, network).await?;
 
     // -------------------------------------------------------------------------
     // STEP 1: Deploy a smart contract with a mapping
     // -------------------------------------------------------------------------
     println!("\n[STEP 1] Deploy a smart contract with a mapping");
 
-    // Load the MASM file for the counter contract. `include_str!` resolves at
-    // compile time relative to this source file.
-    let account_code = include_str!("../masm/accounts/mapping_example_contract.masm");
+    // Read the MASM source from the tutorials repository.
+    let account_code =
+        std::fs::read_to_string("../tutorials/masm/accounts/mapping_example_contract.masm")
+            .unwrap();
 
-    // Using an empty storage value in slot 0 since this is usually reserved
-    // for the account pub_key and metadata
-    let empty_slot_name =
-        StorageSlotName::new("miden::tutorials::mapping::value").expect("valid slot name");
-    let empty_storage_slot = StorageSlot::with_value(empty_slot_name.clone(), Word::default());
-
-    // initialize storage map
+    // Storage slots are named in v0.16; the component only needs its mapping slot.
     let storage_map = StorageMap::new();
     let map_slot_name =
         StorageSlotName::new("miden::tutorials::mapping::map").expect("valid slot name");
@@ -210,16 +272,16 @@ async fn main() -> Result<(), ClientError> {
     // Compile the account code into `AccountComponent` with one storage slot
     let component_code = client
         .code_builder()
-        .compile_component_code("miden_by_example::mapping_example_contract", account_code)
+        .compile_component_code("miden_by_example::mapping_example_contract", &account_code)
         .unwrap();
     let mapping_contract_component = AccountComponent::new(
         component_code,
-        vec![empty_storage_slot, storage_slot_map],
+        vec![storage_slot_map],
         AccountComponentMetadata::new("miden_by_example::mapping_example_contract"),
     )
     .unwrap();
 
-    // Init seed for the counter contract
+    // Init seed for the mapping contract
     let mut init_seed = [0_u8; 32];
     client.rng().fill_bytes(&mut init_seed);
 
@@ -227,7 +289,8 @@ async fn main() -> Result<(), ClientError> {
     let mapping_example_contract = AccountBuilder::new(init_seed)
         .account_type(AccountType::Public)
         .with_component(mapping_contract_component.clone())
-        .with_auth_component(NoAuth)
+        .with_component(BasicWallet)
+        .with_component(NoAuth)
         .build()
         .unwrap();
 
@@ -235,21 +298,23 @@ async fn main() -> Result<(), ClientError> {
         .add_account(&mapping_example_contract, false)
         .await
         .unwrap();
+    fund_account_for_fees(&mut client, mapping_example_contract.id(), &fee_config).await?;
 
     // -------------------------------------------------------------------------
     // STEP 2: Call the Mapping Contract with a Script
     // -------------------------------------------------------------------------
     println!("\n[STEP 2] Call Mapping Contract With Script");
 
-    let script_code = include_str!("../masm/scripts/mapping_example_script.masm");
+    let script_code =
+        std::fs::read_to_string("../tutorials/masm/scripts/mapping_example_script.masm").unwrap();
 
     // Compile the transaction script with the account code linked as a
     // module on the same `CodeBuilder` chain.
     let tx_script = client
         .code_builder()
-        .with_linked_module("miden_by_example::mapping_example_contract", account_code)
+        .with_linked_module("miden_by_example::mapping_example_contract", &account_code)
         .unwrap()
-        .compile_tx_script(script_code)
+        .compile_tx_script(&script_code)
         .unwrap();
 
     // Build a transaction request with the custom script
@@ -260,12 +325,13 @@ async fn main() -> Result<(), ClientError> {
 
     // Execute and submit the transaction
     let tx_id = client
-        .submit_new_transaction(mapping_example_contract.id(), tx_increment_request)
+        .submit_tutorial_transaction(mapping_example_contract.id(), tx_increment_request)
         .await
         .unwrap();
 
     println!(
-        "View transaction on MidenScan: https://testnet.midenscan.com/tx/{:?}",
+        "View transaction on MidenScan: {}/tx/{:?}",
+        network.explorer_url(),
         tx_id
     );
 
@@ -276,18 +342,21 @@ async fn main() -> Result<(), ClientError> {
         .await
         .unwrap()
         .expect("mapping contract not found");
-    let key = [
-        Felt::new_unchecked(0),
-        Felt::new_unchecked(0),
-        Felt::new_unchecked(0),
-        Felt::new_unchecked(0),
-    ]
-    .into();
+    let key = StorageMapKey::empty();
     println!(
         "Mapping state\n Index: {:?}\n Key: {:?}\n Value: {:?}",
         map_slot_name,
         key,
         account.storage().get_map_item(&map_slot_name, key)
+    );
+    let value = account.storage().get_map_item(&map_slot_name, key).unwrap();
+    assert_eq!(
+        value
+            .iter()
+            .map(|felt| felt.as_canonical_u64())
+            .collect::<Vec<_>>(),
+        vec![4, 3, 2, 1],
+        "the mapping must store the value written by the transaction script",
     );
 
     Ok(())
@@ -297,10 +366,10 @@ async fn main() -> Result<(), ClientError> {
 ### What the Rust code does
 
 - **Client Initialization:**  
-  The client is initialized with a connection to the Miden Testnet and a SQLite store. This sets up the environment to deploy and interact with accounts.
+  The client connects to Miden testnet and uses a SQLite store to track accounts, notes, and transactions.
 
 - **Deploying the Smart Contract:**  
-  The account containing the mapping is created by reading the MASM smart contract from a file, compiling it into an `AccountComponent`, and deploying it using an `AccountBuilder`.
+  The account MASM is compiled into an `AccountComponent` with a named map slot. `AccountBuilder` creates the account locally; consuming its native-asset funding note publishes it on-chain.
 
 - **Creating and Executing a Transaction Script:**  
   A separate MASM script is compiled into a `TransactionScript`. This script calls the smart contract's procedures to write to and then read from the mapping.
@@ -312,11 +381,13 @@ async fn main() -> Result<(), ClientError> {
 
 ### Running the example
 
-To run the full example, navigate to the `rust-client` directory in the [miden-tutorials](https://github.com/0xMiden/miden-tutorials/) repository and run this command:
+For the standalone Cargo project, save the Rust code as `src/main.rs` and run `TUTORIAL_NETWORK=testnet cargo run --release`.
+
+To run the checked-in example, return to the root of the [tutorials repository](https://github.com/0xMiden/tutorials/) and run:
 
 ```bash
 cd rust-client
-cargo run --release --bin mapping_example
+TUTORIAL_NETWORK=testnet cargo run --release --bin mapping_example
 ```
 
 This example shows how the script calls the procedure in the account, which then updates the mapping stored within the account. The mapping update is verified by reading the mapping’s key-value pair after the transaction completes.

--- a/docs/src/rust-client/mint_consume_create_tutorial.md
+++ b/docs/src/rust-client/mint_consume_create_tutorial.md
@@ -7,6 +7,8 @@ sidebar_position: 3
 
 _Using the Miden client in Rust to mint, consume, and create notes_
 
+For toolchain requirements and shared fee helpers, see the [Rust client setup](./index.md#running-the-v016-examples).
+
 ## Overview
 
 In the previous section, we initialized our repository and covered how to create an account and deploy a faucet. In this section, we will mint tokens from the faucet for _Alice_, consume the newly created notes, and demonstrate how to send assets to other accounts.
@@ -19,13 +21,13 @@ In the previous section, we initialized our repository and covered how to create
 
 ## Step 1: Minting tokens from the faucet
 
-To mint notes with tokens from the faucet we created, Alice needs to call the faucet with a mint transaction request.
+To mint notes with tokens from the faucet we created, the client submits a mint transaction signed by the faucet's key. The faucet executes the transaction and creates a note for Alice; Alice later signs a separate transaction to consume it.
 
 _In essence, a transaction request is a structured template that outlines the data required to generate a zero-knowledge proof of a state change of an account. It specifies which input notes (if any) will be consumed, includes an optional transaction script to execute, and enumerates the set of notes expected to be created (if any)._
 
-Below is an example of a transaction request minting tokens from the faucet for Alice. This code snippet will create 5 transaction mint transaction requests.
+Below is an example of a transaction request minting tokens from the faucet for Alice. This code snippet creates and confirms five mint transactions, each producing one note containing 100 raw units of the tutorial asset. Transaction fees are paid in the separate native fee asset.
 
-Add this snippet to the end of your file in the `main()` function that we created in the previous chapter:
+Continue the same project from [Creating Accounts and Faucets](./create_deploy_tutorial.md), keeping its `Cargo.toml` and seeded `Cargo.lock`. Insert this snippet inside `main()`, after the previous steps and immediately before its final `Ok(())`:
 
 ```rust ignore
 //------------------------------------------------------------
@@ -36,6 +38,7 @@ println!("\n[STEP 3] Minting 5 notes of 100 tokens each for Alice.");
 let amount: u64 = 100;
 let fungible_asset = FungibleAsset::new(faucet_account.id(), amount).unwrap();
 
+let mut minted_note_ids = Vec::new();
 for i in 1..=5 {
     let transaction_request = TransactionRequestBuilder::new()
         .build_mint_fungible_asset(
@@ -46,10 +49,16 @@ for i in 1..=5 {
         )
         .unwrap();
 
+    minted_note_ids.extend(
+        transaction_request
+            .expected_output_own_notes()
+            .iter()
+            .map(Note::id),
+    );
     println!("tx request built");
 
     let tx_id = client
-        .submit_new_transaction(faucet_account.id(), transaction_request)
+        .submit_tutorial_transaction(faucet_account.id(), transaction_request)
         .await?;
     println!(
         "Minted note #{} of {} tokens for Alice. TX: {:?}",
@@ -68,14 +77,16 @@ Once Alice has minted a note from the faucet, she will eventually want to spend 
 
 Minting a note from a faucet on Miden means a faucet account creates a new note targeted to the requesting account. The requesting account needs to consume this new note to have the assets appear in their account.
 
-To identify consumable notes, the Miden client provides the `get_consumable_notes` function. Before calling it, ensure that the client state is synced.
+To identify consumable notes, the Miden client provides `get_consumable_notes`. The `TutorialClientExt::get_consumable_tutorial_notes` wrapper used below filters out `TX_FEE` notes. Call it after syncing the client state.
 
-_Tip: If you know how many notes to expect after a transaction, use an await or loop condition to check how many notes of the type you expect are available for consumption instead of using a set timeout before calling `get_consumable_notes`. This ensures your application isn't idle for longer than necessary._
+Track the output note IDs from each mint request and wait for those notes to be committed. Do not wait for the total consumable-note count to equal five: `TX_FEE` notes can also be consumable and make that condition impossible. The `wait_for_notes_by_id` helper in Step 3 polls for the specific minted notes with a timeout.
 
 #### Identifying which notes are available:
 
 ```rust ignore
-let consumable_notes = client.get_consumable_notes(Some(alice_account.id())).await?;
+let consumable_notes = client
+    .get_consumable_tutorial_notes(Some(alice_account.id()))
+    .await?;
 ```
 
 ## Step 3: Consuming multiple notes in a single transaction:
@@ -84,7 +95,7 @@ Now that we know how to identify notes ready to consume, let's consume the notes
 
 The following code snippet identifies consumable notes and consumes them in a single transaction.
 
-Add this snippet to the end of your file in the `main()` function:
+Insert this snippet after the preceding steps inside `main()`, immediately before its final `Ok(())`:
 
 ```rust ignore
 //------------------------------------------------------------
@@ -92,41 +103,17 @@ Add this snippet to the end of your file in the `main()` function:
 //------------------------------------------------------------
 println!("\n[STEP 4] Alice will now consume all of her notes to consolidate them.");
 
-// Consume all minted notes in a single transaction
-loop {
-    // Resync to get the latest data
-    client.sync_state().await?;
-
-    let consumable_notes = client
-        .get_consumable_notes(Some(alice_account.id()))
-        .await?;
-    let notes = consumable_notes
-        .iter()
-        .map(|(note, _)| note.clone().try_into())
-        .collect::<Result<Vec<_>, _>>()?;
-
-    if notes.len() == 5 {
-        println!("Found 5 consumable notes for Alice. Consuming them now...");
-        let transaction_request = TransactionRequestBuilder::new()
-            .build_consume_notes(notes)
-            .unwrap();
-
-        let tx_id = client
-            .submit_new_transaction(alice_account.id(), transaction_request)
-            .await?;
-        println!(
-            "All of Alice's notes consumed successfully. TX: {:?}",
-            tx_id
-        );
-        break;
-    } else {
-        println!(
-            "Currently, Alice has {} consumable notes. Waiting...",
-            notes.len()
-        );
-        tokio::time::sleep(Duration::from_secs(3)).await;
-    }
-}
+// TX_FEE notes are also consumable. Select only the five P2ID notes we minted.
+let notes = rust_client::wait_for_notes_by_id(&mut client, &minted_note_ids).await?;
+assert_eq!(notes.len(), 5);
+let transaction_request = TransactionRequestBuilder::new().build_consume_notes(notes)?;
+let tx_id = client
+    .submit_tutorial_transaction(alice_account.id(), transaction_request)
+    .await?;
+println!(
+    "All of Alice's notes consumed successfully. TX: {:?}",
+    tx_id
+);
 ```
 
 ## Step 4: Sending tokens to other accounts
@@ -143,9 +130,9 @@ For the sake of the example, the first four P2ID transfers are handled in a sing
 
 To output multiple notes in a single transaction we need to create a list of our expected output notes. The expected output notes are the notes that we expect to create in our transaction request.
 
-In the snippet below, we create an empty vector to store five P2ID output notes, loop over five iterations `(using 0..=4)` to create five unique dummy account IDs, build a P2ID note for each one, and push each note onto the vector. Finally, we build a transaction request using `.own_output_notes()`—passing in all five notes—and submit it to the node.
+In the snippet below, we create an empty vector, loop over four iterations using `1..=4`, build a P2ID note for each generated dummy account ID, and push each note onto the vector. We pass all four notes to `.own_output_notes()` and submit one transaction. The following step sends the fifth note.
 
-Add this snippet to the end of your file in the `main()` function:
+Insert this snippet after the preceding steps inside `main()`, immediately before its final `Ok(())`:
 
 ```rust ignore
 //------------------------------------------------------------
@@ -168,30 +155,32 @@ for _ in 1..=4 {
         init_seed,
         AccountIdVersion::Version1,
         AccountType::Public,
+        AssetCallbackFlag::Disabled,
     );
 
     let send_amount = 50;
     let fungible_asset = FungibleAsset::new(faucet_account.id(), send_amount).unwrap();
 
-    let p2id_note = P2idNote::create(
-        alice_account.id(),
-        target_account_id,
-        vec![fungible_asset.into()],
-        NoteType::Public,
-        NoteAttachments::empty(),
-        client.rng(),
-    )?;
+    let p2id_note: Note = P2idNote::builder()
+        .sender(alice_account.id())
+        .target(target_account_id)
+        .asset(fungible_asset)
+        .note_type(NoteType::Public)
+        .generate_serial_number(client.rng())
+        .build()?
+        .into();
     p2id_notes.push(p2id_note);
 }
 
 // Specifying output notes and creating a tx request to create them
+let output_notes = p2id_notes;
 let transaction_request = TransactionRequestBuilder::new()
-    .own_output_notes(p2id_notes)
+    .own_output_notes(output_notes)
     .build()
     .unwrap();
 
 let tx_id = client
-    .submit_new_transaction(alice_account.id(), transaction_request)
+    .submit_tutorial_transaction(alice_account.id(), transaction_request)
     .await?;
 
 println!("Submitted a transaction with 4 P2ID notes. TX: {:?}", tx_id);
@@ -199,9 +188,9 @@ println!("Submitted a transaction with 4 P2ID notes. TX: {:?}", tx_id);
 
 ### Basic P2ID transfer
 
-Now as an example, Alice will send some tokens to an account in a single transaction.
+`build_pay_to_id` creates the P2ID note and transaction request for a single transfer. Alice will use it to send tokens to one more account.
 
-Add this snippet to the end of your file in the `main()` function:
+Insert this snippet after the preceding steps inside `main()`, immediately before its final `Ok(())`:
 
 ```rust ignore
 println!("Submitting one more single P2ID transaction...");
@@ -214,70 +203,85 @@ let target_account_id = AccountId::dummy(
     init_seed,
     AccountIdVersion::Version1,
     AccountType::Public,
+    AssetCallbackFlag::Disabled,
 );
 
 let send_amount = 50;
 let fungible_asset = FungibleAsset::new(faucet_account.id(), send_amount).unwrap();
 
-let p2id_note = P2idNote::create(
+let payment = PaymentNoteDescription::new(
+    vec![fungible_asset.into()],
     alice_account.id(),
     target_account_id,
-    vec![fungible_asset.into()],
+);
+let transaction_request = TransactionRequestBuilder::new().build_pay_to_id(
+    payment,
     NoteType::Public,
-    NoteAttachments::empty(),
     client.rng(),
 )?;
 
-let transaction_request = TransactionRequestBuilder::new()
-    .own_output_notes(vec![p2id_note])
-    .build()
-    .unwrap();
-
 let tx_id = client
-    .submit_new_transaction(alice_account.id(), transaction_request)
+    .submit_tutorial_transaction(alice_account.id(), transaction_request)
     .await?;
 
 println!("Submitted final P2ID transaction. TX: {:?}", tx_id);
+let alice = client
+    .get_account(alice_account.id())
+    .await?
+    .expect("Alice exists");
+let balance = alice
+    .vault()
+    .get_balance(AssetId::new_fungible(faucet_account.id()))?;
+assert_eq!(balance.as_u64(), 250, "Alice should retain 500 - 250 MID");
+
+println!("\nAll steps completed successfully!");
+println!("Alice created a wallet, a faucet was deployed,");
+println!("5 notes of 100 tokens were minted to Alice, those notes were consumed,");
+println!("and then Alice sent 5 separate 50-token notes to 5 different users.");
 ```
 
-Note: _In a production environment do not use `AccountId::dummy()`, this is simply for the sake of the tutorial example._
+Note: _`AccountId::dummy()` generates example IDs without deployable accounts or keys. These notes demonstrate creation and cannot be consumed by real recipients. Use actual recipient IDs when transferring useful assets._
 
 ## Summary
 
 Your `src/main.rs` function should now look like this:
 
 ```rust no_run
-use rand::RngCore;
+use rand::Rng;
+use rust_client::TutorialClientExt;
 use std::{path::PathBuf, sync::Arc};
 use tokio::time::Duration;
 
 use miden_client::{
+    ClientError,
     account::{
-        component::{
-            BasicWallet, BurnPolicyConfig, FungibleFaucet, MintPolicyConfig, PolicyRegistration,
-            TokenName, TokenPolicyManager,
-        },
         AccountBuilder, AccountId, AccountType,
+        component::{
+            create_singlesig_user_fungible_faucet, BasicWallet, BurnPolicy, FungibleFaucet,
+            MintPolicy, TokenName, TokenPolicyManager,
+        },
     },
-    address::NetworkId,
-    asset::{AssetAmount, FungibleAsset, TokenSymbol},
-    auth::{AuthSchemeId, AuthSecretKey, AuthSingleSig},
+    asset::{AssetAmount, AssetCallbackFlag, AssetId, FungibleAsset, TokenSymbol},
+    auth::{AuthSecretKey, AuthSingleSig},
     builder::ClientBuilder,
     keystore::{FilesystemKeyStore, Keystore},
-    note::{NoteAttachments, NoteType, P2idNote},
-    rpc::{Endpoint, GrpcClient},
-    transaction::TransactionRequestBuilder,
-    ClientError,
+    note::{Note, NoteType, P2idNote},
+    rpc::{GrpcClient, VerifyingRpcClient},
+    transaction::{PaymentNoteDescription, TransactionRequestBuilder},
 };
 use miden_client_sqlite_store::ClientBuilderSqliteExt;
 use miden_protocol::account::AccountIdVersion;
+use rust_client::{FeeConfig, TutorialNetwork, fund_account_for_fees};
 
 #[tokio::main]
 async fn main() -> Result<(), ClientError> {
     // Initialize client
-    let endpoint = Endpoint::testnet();
+    let network = TutorialNetwork::from_env()?;
+    let endpoint = network.endpoint();
     let timeout_ms = 10_000;
-    let rpc_client = Arc::new(GrpcClient::new(&endpoint, timeout_ms));
+    let rpc_client = Arc::new(VerifyingRpcClient::new(GrpcClient::new(
+        &endpoint, timeout_ms,
+    )));
 
     // Initialize keystore
     let keystore_path = PathBuf::from("./keystore");
@@ -289,12 +293,12 @@ async fn main() -> Result<(), ClientError> {
         .rpc(rpc_client)
         .sqlite_store(store_path)
         .authenticator(keystore.clone())
-        .in_debug_mode(true.into())
         .build()
         .await?;
 
     let sync_summary = client.sync_state().await.unwrap();
     println!("Latest block: {}", sync_summary.block_num);
+    let fee_config = FeeConfig::from_client(&client, network).await?;
 
     //------------------------------------------------------------
     // STEP 1: Create a basic wallet for Alice
@@ -310,7 +314,7 @@ async fn main() -> Result<(), ClientError> {
     // Build the account
     let alice_account = AccountBuilder::new(init_seed)
         .account_type(AccountType::Public)
-        .with_auth_component(AuthSingleSig::new(key_pair.public_key().to_commitment(), AuthSchemeId::Falcon512Poseidon2))
+        .with_component(AuthSingleSig::from_public_key(key_pair.public_key()))
         .with_component(BasicWallet)
         .build()
         .unwrap();
@@ -319,10 +323,15 @@ async fn main() -> Result<(), ClientError> {
     client.add_account(&alice_account, false).await?;
 
     // Add the key pair to the keystore
-    keystore.add_key(&key_pair, alice_account.id()).await.unwrap();
+    keystore
+        .add_key(&key_pair, alice_account.id())
+        .await
+        .unwrap();
 
-    let alice_account_id_bech32 = alice_account.id().to_bech32(NetworkId::Testnet);
+    let alice_account_id_bech32 = alice_account.id().to_bech32(network.network_id());
     println!("Alice's account ID: {:?}", alice_account_id_bech32);
+
+    fund_account_for_fees(&mut client, alice_account.id(), &fee_config).await?;
 
     //------------------------------------------------------------
     // STEP 2: Deploy a fungible faucet
@@ -342,39 +351,43 @@ async fn main() -> Result<(), ClientError> {
     let key_pair = AuthSecretKey::new_falcon512_poseidon2_with_rng(client.rng());
 
     // Build the faucet account.
-    // In v0.15 the faucet is a `FungibleFaucet` component plus a `TokenPolicyManager`
+    // The faucet is a `FungibleFaucet` component plus a `TokenPolicyManager`
     // that registers an "allow all" mint (and burn) policy; minting is rejected
     // unless an active mint policy is present.
-    let faucet_account = AccountBuilder::new(init_seed)
-        .account_type(AccountType::Public)
-        .with_auth_component(AuthSingleSig::new(key_pair.public_key().to_commitment(), AuthSchemeId::Falcon512Poseidon2))
-        .with_component(
-            FungibleFaucet::builder()
-                .name(TokenName::new("MID").unwrap())
-                .symbol(symbol)
-                .decimals(decimals)
-                .max_supply(max_supply)
-                .build()
-                .unwrap(),
-        )
-        .with_components(
-            TokenPolicyManager::new()
-                .with_mint_policy(MintPolicyConfig::AllowAll, PolicyRegistration::Active)
-                .unwrap()
-                .with_burn_policy(BurnPolicyConfig::AllowAll, PolicyRegistration::Active)
-                .unwrap(),
-        )
+    let faucet = FungibleFaucet::builder()
+        .name(TokenName::new("MID").unwrap())
+        .symbol(symbol)
+        .decimals(decimals)
+        .max_supply(max_supply)
         .build()
         .unwrap();
+    let policies = TokenPolicyManager::builder()
+        .active_mint_policy(MintPolicy::allow_all())
+        .active_burn_policy(BurnPolicy::allow_all())
+        .build();
+    // The SDK factory includes BasicWallet so the faucet can receive the native fee asset.
+    let faucet_account = create_singlesig_user_fungible_faucet(
+        init_seed,
+        faucet,
+        AuthSingleSig::from_public_key(key_pair.public_key()),
+        policies,
+        AccountType::Public,
+    )
+    .unwrap();
 
     // Add the faucet to the client
     client.add_account(&faucet_account, false).await?;
 
     // Add the key pair to the keystore
-    keystore.add_key(&key_pair, faucet_account.id()).await.unwrap();
+    keystore
+        .add_key(&key_pair, faucet_account.id())
+        .await
+        .unwrap();
 
-    let faucet_account_id_bech32 = faucet_account.id().to_bech32(NetworkId::Testnet);
+    let faucet_account_id_bech32 = faucet_account.id().to_bech32(network.network_id());
     println!("Faucet account ID: {:?}", faucet_account_id_bech32);
+
+    fund_account_for_fees(&mut client, faucet_account.id(), &fee_config).await?;
 
     // Resync to show newly deployed faucet
     client.sync_state().await?;
@@ -388,6 +401,7 @@ async fn main() -> Result<(), ClientError> {
     let amount: u64 = 100;
     let fungible_asset = FungibleAsset::new(faucet_account.id(), amount).unwrap();
 
+    let mut minted_note_ids = Vec::new();
     for i in 1..=5 {
         let transaction_request = TransactionRequestBuilder::new()
             .build_mint_fungible_asset(
@@ -398,10 +412,16 @@ async fn main() -> Result<(), ClientError> {
             )
             .unwrap();
 
+        minted_note_ids.extend(
+            transaction_request
+                .expected_output_own_notes()
+                .iter()
+                .map(Note::id),
+        );
         println!("tx request built");
 
         let tx_id = client
-            .submit_new_transaction(faucet_account.id(), transaction_request)
+            .submit_tutorial_transaction(faucet_account.id(), transaction_request)
             .await?;
         println!(
             "Minted note #{} of {} tokens for Alice. TX: {:?}",
@@ -418,40 +438,17 @@ async fn main() -> Result<(), ClientError> {
     //------------------------------------------------------------
     println!("\n[STEP 4] Alice will now consume all of her notes to consolidate them.");
 
-    // Consume all minted notes in a single transaction
-    loop {
-        // Resync to get the latest data
-        client.sync_state().await?;
-
-        let consumable_notes = client
-            .get_consumable_notes(Some(alice_account.id()))
-            .await?;
-        let notes = consumable_notes
-            .iter()
-            .map(|(note, _)| note.clone().try_into())
-            .collect::<Result<Vec<_>, _>>()?;
-
-        if notes.len() == 5 {
-            println!("Found 5 consumable notes for Alice. Consuming them now...");
-            let transaction_request =
-                TransactionRequestBuilder::new().build_consume_notes(notes)?;
-
-            let tx_id = client
-                .submit_new_transaction(alice_account.id(), transaction_request)
-                .await?;
-            println!(
-                "All of Alice's notes consumed successfully. TX: {:?}",
-                tx_id
-            );
-            break;
-        } else {
-            println!(
-                "Currently, Alice has {} consumable notes. Waiting...",
-                notes.len()
-            );
-            tokio::time::sleep(Duration::from_secs(3)).await;
-        }
-    }
+    // TX_FEE notes are also consumable. Select only the five P2ID notes we minted.
+    let notes = rust_client::wait_for_notes_by_id(&mut client, &minted_note_ids).await?;
+    assert_eq!(notes.len(), 5);
+    let transaction_request = TransactionRequestBuilder::new().build_consume_notes(notes)?;
+    let tx_id = client
+        .submit_tutorial_transaction(alice_account.id(), transaction_request)
+        .await?;
+    println!(
+        "All of Alice's notes consumed successfully. TX: {:?}",
+        tx_id
+    );
 
     //------------------------------------------------------------
     // STEP 5: Alice sends 5 notes of 50 tokens to 5 users
@@ -473,19 +470,20 @@ async fn main() -> Result<(), ClientError> {
             init_seed,
             AccountIdVersion::Version1,
             AccountType::Public,
+            AssetCallbackFlag::Disabled,
         );
 
         let send_amount = 50;
         let fungible_asset = FungibleAsset::new(faucet_account.id(), send_amount).unwrap();
 
-        let p2id_note = P2idNote::create(
-            alice_account.id(),
-            target_account_id,
-            vec![fungible_asset.into()],
-            NoteType::Public,
-            NoteAttachments::empty(),
-            client.rng(),
-        )?;
+        let p2id_note: Note = P2idNote::builder()
+            .sender(alice_account.id())
+            .target(target_account_id)
+            .asset(fungible_asset)
+            .note_type(NoteType::Public)
+            .generate_serial_number(client.rng())
+            .build()?
+            .into();
         p2id_notes.push(p2id_note);
     }
 
@@ -497,7 +495,7 @@ async fn main() -> Result<(), ClientError> {
         .unwrap();
 
     let tx_id = client
-        .submit_new_transaction(alice_account.id(), transaction_request)
+        .submit_tutorial_transaction(alice_account.id(), transaction_request)
         .await?;
 
     println!("Submitted a transaction with 4 P2ID notes. TX: {:?}", tx_id);
@@ -512,30 +510,36 @@ async fn main() -> Result<(), ClientError> {
         init_seed,
         AccountIdVersion::Version1,
         AccountType::Public,
+        AssetCallbackFlag::Disabled,
     );
 
     let send_amount = 50;
     let fungible_asset = FungibleAsset::new(faucet_account.id(), send_amount).unwrap();
 
-    let p2id_note = P2idNote::create(
+    let payment = PaymentNoteDescription::new(
+        vec![fungible_asset.into()],
         alice_account.id(),
         target_account_id,
-        vec![fungible_asset.into()],
+    );
+    let transaction_request = TransactionRequestBuilder::new().build_pay_to_id(
+        payment,
         NoteType::Public,
-        NoteAttachments::empty(),
         client.rng(),
     )?;
 
-    let transaction_request = TransactionRequestBuilder::new()
-        .own_output_notes(vec![p2id_note])
-        .build()
-        .unwrap();
-
     let tx_id = client
-        .submit_new_transaction(alice_account.id(), transaction_request)
+        .submit_tutorial_transaction(alice_account.id(), transaction_request)
         .await?;
 
     println!("Submitted final P2ID transaction. TX: {:?}", tx_id);
+    let alice = client
+        .get_account(alice_account.id())
+        .await?
+        .expect("Alice exists");
+    let balance = alice
+        .vault()
+        .get_balance(AssetId::new_fungible(faucet_account.id()))?;
+    assert_eq!(balance.as_u64(), 250, "Alice should retain 500 - 250 MID");
 
     println!("\nAll steps completed successfully!");
     println!("Alice created a wallet, a faucet was deployed,");
@@ -549,43 +553,35 @@ async fn main() -> Result<(), ClientError> {
 Let's run the `src/main.rs` program again:
 
 ```bash
-cargo run --release
+TUTORIAL_NETWORK=testnet cargo run --release
 ```
 
-The output will look like this:
+The following is an abbreviated output; IDs vary and the helper also prints funding and transaction confirmations:
 
 ```text
-Latest block: 226896
+Latest block: <current_block_number>
 
 [STEP 1] Creating a new account for Alice
-Alice's account ID: "<testnet_account_id>"
+Alice's account ID: "<alice_testnet_account_id>"
 
 [STEP 2] Deploying a new fungible faucet.
-Faucet account ID: "<testnet_account_id>"
+Faucet account ID: "<faucet_testnet_account_id>"
 
 [STEP 3] Minting 5 notes of 100 tokens each for Alice.
 tx request built
-Minted note #1 of 100 tokens for Alice.
-tx request built
-Minted note #2 of 100 tokens for Alice.
-tx request built
-Minted note #3 of 100 tokens for Alice.
-tx request built
-Minted note #4 of 100 tokens for Alice.
-tx request built
-Minted note #5 of 100 tokens for Alice.
+Minted note #1 of 100 tokens for Alice. TX: <transaction_id>
+...
+Minted note #5 of 100 tokens for Alice. TX: <transaction_id>
 All 5 notes minted for Alice successfully!
 
 [STEP 4] Alice will now consume all of her notes to consolidate them.
-Currently, Alice has 2 consumable notes. Waiting...
-Currently, Alice has 4 consumable notes. Waiting...
-Found 5 consumable notes for Alice. Consuming them now...
-All of Alice's notes consumed successfully.
+All of Alice's notes consumed successfully. TX: <transaction_id>
 
 [STEP 5] Alice sends 5 notes of 50 tokens each to 5 different users.
 Creating multiple P2ID notes for 4 target accounts in one transaction...
-Submitted a transaction with 4 P2ID notes.
+Submitted a transaction with 4 P2ID notes. TX: <transaction_id>
 Submitting one more single P2ID transaction...
+Submitted final P2ID transaction. TX: <transaction_id>
 
 All steps completed successfully!
 Alice created a wallet, a faucet was deployed,
@@ -595,11 +591,11 @@ and then Alice sent 5 separate 50-token notes to 5 different users.
 
 ### Running the example
 
-To run a full working example navigate to the `rust-client` directory in the [miden-tutorials](https://github.com/0xMiden/miden-tutorials/) repository and run this command:
+From the root of your `tutorials` clone, run the checked-in example:
 
 ```bash
 cd rust-client
-cargo run --release --bin create_mint_consume_send
+TUTORIAL_NETWORK=testnet cargo run --release --bin create_mint_consume_send
 ```
 
 ### Continue learning

--- a/docs/src/rust-client/network_transactions_tutorial.md
+++ b/docs/src/rust-client/network_transactions_tutorial.md
@@ -7,17 +7,21 @@ sidebar_position: 6
 
 _Using the Miden client in Rust to deploy and interact with smart contracts using network transactions_
 
+For toolchain requirements and shared fee helpers, see the [Rust client setup](./index.md#running-the-v016-examples).
+
 ## Overview
 
 In this tutorial, we will explore Network Transactions (NTXs) on Miden - a powerful feature that enables autonomous smart contract execution and public shared state management. Unlike local transactions that require users to execute and prove, network transactions are executed and proven by a network transaction builder.
 
-We'll build a network counter smart contract using the same MASM code as the regular counter. In v0.15 there is no separate network storage mode. Instead, an account is a _network account_ — one the network transaction builder executes on a user's behalf — if and only if it is public (`AccountType::Public`) **and** carries the `AuthNetworkAccount` auth component with a non-empty note-script allowlist. The allowed note-script roots and transaction-script roots are pinned at account creation. Attaching a `NetworkAccountTarget` to a note is necessary but not sufficient: without the allowlist the node never classifies the account as a network account, and the note is silently orphaned. See the [account changes migration guide](https://docs.miden.xyz/builder/migration/account-changes).
+We'll build a public network counter using the same MASM code as the regular counter. `AuthNetworkAccount` configures the note scripts that the network transaction builder may execute, and a fee policy prices those notes. The increment note also carries a `NetworkAccountTarget` attachment identifying its target. See the [account changes migration guide](https://docs.miden.xyz/builder/migration/account-changes).
+
+Deployment and subsequent updates are different operations. On a fee-enabled network, consuming the initial native-asset funding note publishes the new network account with count **0**. After publication, the public RPC rejects user-submitted transactions that directly update an existing network account. Alice must publish an increment note from her own account; the network transaction builder consumes it and changes the counter to **1**. This restriction is enforced by the [node's submission handler](https://github.com/0xMiden/node/blob/v0.16.0/crates/rpc/src/server/api/submit_proven_tx.rs#L94).
 
 ## What we'll cover
 
 - Understanding Network Transactions and when to use them
 - Deploying public smart contracts that the network operator can execute
-- Using transaction scripts to initialize network contracts on-chain
+- Publishing a new network account through its initial funding transaction
 - Creating network notes for user interactions
 - Validating network transaction results
 
@@ -29,108 +33,134 @@ This tutorial assumes you have completed the [counter contract tutorial](counter
 
 Network transactions are executed and proven by the Miden operator rather than the client. They are useful for:
 
-- **Public shared state**: Multiple users can interact with the same contract state without race conditions
+- **Public shared state**: Multiple users can publish notes targeting the same contract; the network transaction builder orders their execution
 - **Autonomous execution**: Smart contracts can execute when conditions are met without user intervention
 - **Resource-constrained devices**: Clients that can't generate ZK proofs efficiently
 - **AMM applications**: Using network notes, you can build sophisticated AMMs where trades execute automatically
 
-The main trade-off is reduced privacy since the operator can see transaction inputs.
+The account state and increment notes in this example are public, so the operator can see the transaction inputs.
 
 ## Step 1: Initialize your repository
 
-Create a new Rust repository for your Miden project and navigate to it:
+From the parent directory of your `tutorials` clone, create a sibling Cargo project:
 
 ```bash
 cargo new miden-network-transactions
 cd miden-network-transactions
+rustup override set 1.98.1
+cp ../tutorials/rust-client/Cargo.lock Cargo.lock
 ```
 
 Add the following dependencies to your `Cargo.toml` file:
 
 ```toml
 [dependencies]
-miden-client = { version = "0.15", features = ["testing", "tonic"] }
-miden-client-sqlite-store = { version = "0.15", package = "miden-client-sqlite-store" }
-miden-protocol = { version = "0.15" }
-rand = { version = "0.9" }
-tokio = { version = "1.46", features = ["rt-multi-thread", "net", "macros", "fs"] }
+# Clone tutorials next to this Cargo project (see Rust client setup).
+rust-client = { path = "../tutorials/rust-client" }
+miden-client = { version = "=0.16.0", features = ["testing", "tonic"] }
+miden-client-sqlite-store = { version = "=0.16.0", package = "miden-client-sqlite-store" }
+miden-protocol = { version = "=0.16.0" }
+rand = { version = "0.10" }
+tokio = { version = "1.48", features = ["rt-multi-thread", "net", "macros", "fs"] }
+
+[profile.dev]
+opt-level = 2
 ```
 
 ## Step 2: Set up MASM files
 
-Create the directory structure:
-
-```bash
-mkdir -p masm/accounts masm/scripts masm/notes
-```
+The example reads the counter and note sources from the repository’s `masm/` directory.
 
 ### Counter Contract
 
 We'll use the same counter contract MASM code as the regular counter tutorial. The key difference is in the Rust configuration, not the MASM code.
 
-Create `masm/accounts/counter.masm`:
+The counter is defined in `masm/accounts/counter.masm`:
 
 ```masm
 use miden::protocol::active_account
 use miden::protocol::native_account
-use miden::core::word
 use miden::core::sys
+
+# CONSTANTS
+# =================================================================================================
 
 const COUNTER_SLOT = word("miden::tutorials::counter")
 
-#! Inputs:  []
-#! Outputs: [count]
-pub proc get_count
+# PUBLIC INTERFACE
+# =================================================================================================
+
+#! Returns the current count.
+#!
+#! Inputs:  [pad(16)]
+#! Outputs: [count, pad(15)]
+#!
+#! Invocation: call
+@account_procedure
+pub proc get_count() -> felt
     push.COUNTER_SLOT[0..2] exec.active_account::get_item
-    # => [count]
+    # => [[count, 0, 0, 0], pad(16)]
 
     exec.sys::truncate_stack
-    # => [count]
+    # => [count, pad(15)]
 end
 
-#! Inputs:  []
-#! Outputs: []
-pub proc increment_count
+#! Increments the current count by one.
+#!
+#! Inputs:  [pad(16)]
+#! Outputs: [pad(16)]
+#!
+#! Invocation: call
+@account_procedure
+pub proc increment_count()
     push.COUNTER_SLOT[0..2] exec.active_account::get_item
-    # => [count]
+    # => [[count, 0, 0, 0], pad(16)]
 
     add.1
-    # => [count+1]
+    # => [[count + 1, 0, 0, 0], pad(16)]
 
     push.COUNTER_SLOT[0..2] exec.native_account::set_item
-    # => []
+    # => [OLD_VALUE, pad(16)]
+
+    dropw
+    # => [pad(16)]
 
     exec.sys::truncate_stack
-    # => []
+    # => [pad(16)]
 end
 ```
 
-### Transaction Script for Deployment
+### Initial deployment
 
-Create `masm/scripts/counter_script.masm`:
-
-```masm
-use external_contract::counter_contract
-
-begin
-    call.counter_contract::increment_count
-end
-```
-
-This script executes a function call (increment) that creates a necessary state change for our contract to be deployed and stored on the network on-chain. In Miden, public contracts must have their state modified through a transaction to be properly registered and committed to the blockchain - simply creating the account isn't sufficient.
+Creating an account locally does not publish it. The funding helper below creates
+the new account's first committed transaction by consuming its native-asset note.
+No separate increment transaction script is needed on a fee-enabled network. The
+empty deployment request shown later is only for networks with zero fees, where
+funding does not perform that initial transaction.
 
 ### Network Note for User Interaction
 
-Create `masm/notes/network_increment_note.masm`. Note scripts are compiled as libraries; the `@note_script` attribute marks the entrypoint procedure.
+The increment note is defined in `masm/notes/network_increment_note.masm`. Note scripts are compiled as libraries; the `@note_script` attribute marks the entrypoint procedure.
 
 ```masm
 use external_contract::counter_contract
 
-#! Inputs:  []
-#! Outputs: []
+#! Increments the network counter when this note is consumed.
+#!
+#! Inputs:  [ARGS, pad(12)]
+#! Outputs: [pad(16)]
+#!
+#! Where:
+#! - ARGS contains unused note script arguments.
+#!
+#! Invocation: dyncall
 @note_script
-pub proc main
+pub proc main(args: word)
+    dropw
+    # => [pad(16)]
+
     call.counter_contract::increment_count
+    # => [pad(16)]
 end
 ```
 
@@ -143,69 +173,52 @@ Before deploying the network account and creating network notes, we need to set 
 Copy and paste the following code into your `src/main.rs` file:
 
 ```rust no_run
+use rust_client::TutorialClientExt;
 use std::{collections::BTreeSet, path::PathBuf, sync::Arc};
 
 use miden_client::{
+    Client, ClientError, Felt, Word,
     account::{
-        component::{AccountComponentMetadata, AuthNetworkAccount, BasicWallet}, AccountBuilder, AccountComponent,
-        AccountType, StorageSlot, StorageSlotName,
+        AccountBuilder, AccountComponent, AccountType, StorageSlot, StorageSlotName,
+        component::{
+            AccountComponentMetadata, AuthNetworkAccount, BasicConstantFeePolicy, BasicWallet,
+            FeePolicy, FeePolicyManager,
+        },
     },
-    address::NetworkId,
-    auth::{AuthSchemeId, AuthSecretKey, AuthSingleSig},
+    asset::AssetAmount,
+    auth::{AuthSecretKey, AuthSingleSig},
     builder::ClientBuilder,
     crypto::FeltRng,
     keystore::{FilesystemKeyStore, Keystore},
     note::{
         NetworkAccountTarget, Note, NoteAssets, NoteAttachments, NoteError, NoteExecutionHint,
-        NoteRecipient, NoteStorage, NoteTag, NoteType, PartialNoteMetadata,
+        NoteRecipient, NoteStorage, NoteTag, NoteType, P2idNote, PartialNoteMetadata,
     },
-    rpc::{Endpoint, GrpcClient},
-    store::TransactionFilter,
-    transaction::{TransactionId, TransactionRequestBuilder, TransactionStatus},
-    Client, ClientError, Felt, Word,
+    rpc::{GrpcClient, VerifyingRpcClient},
+    transaction::{ExpirationTransactionScript, TransactionId, TransactionRequestBuilder},
 };
 use miden_client_sqlite_store::ClientBuilderSqliteExt;
-use rand::RngCore;
-use tokio::time::{sleep, Duration};
+use rand::Rng;
+use rust_client::{FeeConfig, TutorialNetwork, fund_account_for_fees};
+use tokio::time::{Duration, sleep};
 
 /// Waits for a specific transaction to be committed.
 async fn wait_for_tx(
     client: &mut Client<FilesystemKeyStore>,
     tx_id: TransactionId,
 ) -> Result<(), ClientError> {
-    loop {
-        client.sync_state().await?;
-
-        // Check transaction status
-        let txs = client
-            .get_transactions(TransactionFilter::Ids(vec![tx_id]))
-            .await?;
-        let tx_committed = if !txs.is_empty() {
-            matches!(txs[0].status, TransactionStatus::Committed { .. })
-        } else {
-            false
-        };
-
-        if tx_committed {
-            println!("✅ transaction {} committed", tx_id.to_hex());
-            break;
-        }
-
-        println!(
-            "Transaction {} not yet committed. Waiting...",
-            tx_id.to_hex()
-        );
-        sleep(Duration::from_secs(2)).await;
-    }
-    Ok(())
+    rust_client::wait_for_transaction(client, tx_id).await
 }
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Initialize client
-    let endpoint = Endpoint::testnet();
+    let network = TutorialNetwork::from_env()?;
+    let endpoint = network.endpoint();
     let timeout_ms = 10_000;
-    let rpc_client = Arc::new(GrpcClient::new(&endpoint, timeout_ms));
+    let rpc_client = Arc::new(VerifyingRpcClient::new(GrpcClient::new(
+        &endpoint, timeout_ms,
+    )));
 
     // Initialize keystore
     let keystore_path = PathBuf::from("./keystore");
@@ -217,12 +230,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .rpc(rpc_client)
         .sqlite_store(store_path)
         .authenticator(keystore.clone())
-        .in_debug_mode(true.into())
         .build()
         .await?;
 
     let sync_summary = client.sync_state().await.unwrap();
     println!("Latest block: {}", sync_summary.block_num);
+    let fee_config = FeeConfig::from_client(&client, network).await?;
+    let fee_faucet_id = fee_config.native_fee_faucet_id();
 
     // -------------------------------------------------------------------------
     // STEP 1: Create Basic User Account
@@ -238,7 +252,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Build the account
     let alice_account = AccountBuilder::new(init_seed)
         .account_type(AccountType::Public)
-        .with_auth_component(AuthSingleSig::new(key_pair.public_key().to_commitment(), AuthSchemeId::Falcon512Poseidon2))
+        .with_component(AuthSingleSig::from_public_key(key_pair.public_key()))
         .with_component(BasicWallet)
         .build()
         .unwrap();
@@ -247,11 +261,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     client.add_account(&alice_account, false).await?;
 
     // Add the key pair to the keystore
-    keystore.add_key(&key_pair, alice_account.id()).await.unwrap();
+    keystore
+        .add_key(&key_pair, alice_account.id())
+        .await
+        .unwrap();
+    fund_account_for_fees(&mut client, alice_account.id(), &fee_config).await?;
 
     println!(
         "Alice's account ID: {:?}",
-        alice_account.id().to_bech32(NetworkId::Testnet)
+        alice_account.id().to_bech32(network.network_id())
     );
 
     Ok(())
@@ -262,9 +280,17 @@ This step initializes the Miden client and creates a basic user account (Alice) 
 
 ## Step 4: Create the network counter smart contract
 
-Now we'll create the network smart contract. In v0.15 what makes an account network-executable is its auth component, not a storage mode: the contract is a public account (`AccountType::Public`) built with the `AuthNetworkAccount` component. Its note-script allowlist is what marks the account as a network account, and its transaction-script allowlist authorizes the deploy script in Step 5. Both allowlists are fixed at account creation, so we compile the note script and the deploy transaction script first and pass their MAST roots in.
+Build a public account with `AuthNetworkAccount`, the counter component, and
+`BasicWallet`. Compile the increment note first so its root can be allowlisted.
+Also allow the P2ID funding note. Use `AuthNetworkAccount::custom` for this minimal
+account and explicitly allow `ExpirationTransactionScript::script_root()`, which
+the network builder uses. No configuration or sponsorship note scripts are
+enabled: this account does not implement their required authority components.
+There is no custom increment transaction script to allowlist. The zero per-note
+policy charge does not remove the network's verification fee: the account pays
+that fee from its funded native-asset balance.
 
-Add this code to your `main()` function:
+Insert this code inside `main`, immediately before its final `Ok(())`:
 
 ```rust ignore
 // -------------------------------------------------------------------------
@@ -272,44 +298,28 @@ Add this code to your `main()` function:
 // -------------------------------------------------------------------------
 println!("\n[STEP 2] Creating a network counter smart contract");
 
-// `include_str!` resolves at compile time relative to this source file,
-// so the binary is independent of the working directory it is run from.
-let counter_code = include_str!("../masm/accounts/counter.masm");
-let script_code = include_str!("../masm/scripts/counter_script.masm");
-let network_note_code = include_str!("../masm/notes/network_increment_note.masm");
+// Read the MASM source from the tutorials repository.
+let counter_code = std::fs::read_to_string("../tutorials/masm/accounts/counter.masm").unwrap();
+let network_note_code =
+    std::fs::read_to_string("../tutorials/masm/notes/network_increment_note.masm").unwrap();
 
-// In protocol v0.15 an account is a *network account* (one the network
+// An account is a *network account* (one the network
 // transaction builder executes on a user's behalf) if and only if it is
 // public AND carries the `AuthNetworkAccount` auth component. That component
-// holds two allowlists, both fixed at account creation:
-//   * the note-script allowlist: its presence is what marks the account as a
-//     network account, and the builder only executes notes whose script root
-//     is listed here;
-//   * the tx-script allowlist: the network auth procedure rejects any custom
-//     tx script whose root is not listed, so the STEP 3 deploy script must be
-//     in it.
-// We therefore compile the note script and the deploy tx script now and feed
-// their MAST roots into the allowlists below. Both compiled scripts are reused
-// as-is in STEP 3 (tx script) and STEP 4 (note script) — nothing is compiled
-// twice.
+// holds an allowlist of note scripts the network builder may execute.
+// Compile the increment note first so its root can be included at creation.
 let note_script = client
     .code_builder()
-    .with_linked_module("external_contract::counter_contract", counter_code)?
-    .compile_note_script(network_note_code)?;
+    .with_linked_module("external_contract::counter_contract", &counter_code)?
+    .compile_note_script(&network_note_code)?;
 let note_script_root = note_script.root();
-
-let tx_script = client
-    .code_builder()
-    .with_linked_module("external_contract::counter_contract", counter_code)?
-    .compile_tx_script(script_code)?;
-let tx_script_root = tx_script.root();
 
 // Compile the counter MASM into an account component
 let counter_slot_name =
     StorageSlotName::new("miden::tutorials::counter").expect("valid slot name");
 let component_code = client
     .code_builder()
-    .compile_component_code("external_contract::counter_contract", counter_code)?;
+    .compile_component_code("external_contract::counter_contract", &counter_code)?;
 let counter_component = AccountComponent::new(
     component_code,
     vec![StorageSlot::with_value(
@@ -323,68 +333,83 @@ let counter_component = AccountComponent::new(
 let mut init_seed = [0_u8; 32];
 client.rng().fill_bytes(&mut init_seed);
 
-// Build the network account: public + `AuthNetworkAccount` with the note-script
-// root allowlisted (this is what makes it a network account) and the deploy
-// tx-script root allowlisted (so the auth procedure accepts the STEP 3 deploy).
-let network_auth = AuthNetworkAccount::with_allowed_notes(BTreeSet::from([note_script_root]))?
-    .with_allowed_tx_scripts(BTreeSet::from([tx_script_root]));
+// Build the public network account with the increment and funding notes allowed.
+let fee_policy: FeePolicy = BasicConstantFeePolicy::new()
+    .with_fees(
+        [note_script_root, P2idNote::script_root()].map(|root| (root, AssetAmount::ZERO)),
+    )
+    .into();
+let fee_policy_manager = FeePolicyManager::builder()
+    .fee_faucet_id(fee_faucet_id)
+    .active_fee_policy(fee_policy)
+    .build();
+// Match the protocol/node counter example: only permit the two note scripts
+// this account implements. Config notes need Authority, which it does not have.
+// The canonical expiration script is required by the network builder.
+let network_auth = AuthNetworkAccount::custom(
+    BTreeSet::from([note_script_root, P2idNote::script_root()]),
+    fee_policy_manager,
+)?
+.with_allowed_tx_scripts([ExpirationTransactionScript::script_root()]);
 let counter_contract = AccountBuilder::new(init_seed)
     .account_type(AccountType::Public)
-    .with_auth_component(network_auth)
+    .with_components(network_auth)
     .with_component(counter_component)
+    .with_component(BasicWallet)
     .build()
     .unwrap();
 
 client.add_account(&counter_contract, false).await.unwrap();
+fund_account_for_fees(&mut client, counter_contract.id(), &fee_config).await?;
 
 println!(
     "contract id: {:?}",
-    counter_contract.id().to_bech32(NetworkId::Testnet)
+    counter_contract.id().to_bech32(network.network_id())
 );
 ```
 
-This step creates a public smart contract (`AccountType::Public`) whose `AuthNetworkAccount` component allowlists the increment note's script root — marking it as a network account the operator will execute — and the deploy transaction script's root, so the Step 5 deploy is authorized.
+This step creates and funds a public network account. On a fee-enabled network,
+the funding transaction also publishes it. Its counter remains zero.
 
-## Step 5: Deploy the network account with a transaction script
+## Step 5: Confirm publication of the network account
 
-We use a transaction script to deploy the network account and ensure it's properly registered on-chain. The script calls the `increment` function, which initializes the counter to 1.
+When fees are active, initial funding has already published the network account. Do not send
+another direct increment transaction from the user client: the node rejects
+user-submitted updates to existing network accounts. Only the zero-fee path needs
+an explicit first deployment transaction here.
 
-Add this code to your `main()` function:
+Insert this code after account creation, inside `main` and before `Ok(())`:
 
 ```rust ignore
 // -------------------------------------------------------------------------
-// STEP 3: Deploy Network Account with Transaction Script
+// STEP 3: Publish the network account
 // -------------------------------------------------------------------------
 println!("\n[STEP 3] Deploy network counter smart contract");
 
-// Reuse the `tx_script` compiled in STEP 2 (its root is allowlisted on the
-// account, so the network auth procedure accepts this deploy transaction).
-let tx_increment_request = TransactionRequestBuilder::new()
-    .custom_script(tx_script)
-    .build()
-    .unwrap();
-
-let tx_id = client
-    .submit_new_transaction(counter_contract.id(), tx_increment_request)
-    .await
-    .unwrap();
-
-println!(
-    "View transaction on MidenScan: https://testnet.midenscan.com/tx/{:?}",
-    tx_id
-);
-
-// Wait for the transaction to be committed
-wait_for_tx(&mut client, tx_id).await.unwrap();
+// On a fee-enabled network, consuming the funding note already published this
+// account. RPC permits users to deploy new network accounts, but rejects
+// user-submitted transactions for existing ones. Subsequent increments must
+// be requested by notes and executed by the network transaction builder.
+if !fee_config.fees_are_active() {
+    let deployment = TransactionRequestBuilder::new().build()?;
+    client
+        .submit_tutorial_transaction(counter_contract.id(), deployment)
+        .await?;
+}
+println!("Network counter deployed; initial count is 0");
 ```
 
-This step uses a transaction script to deploy the network account and ensure it's properly registered on-chain. The script calls the `increment` function, which initializes the counter to 1.
+The initial committed count is zero. All later counter updates go through network
+notes executed by the network transaction builder.
 
 ## Step 6: Create a network note for user interaction
 
-We create a public note that the network operator can consume to execute the increment function. This increments the counter from 1 to 2.
+Alice publishes a public increment note from her own funded account. The network
+transaction builder then consumes that note on the counter's behalf, changing
+the counter from zero to one. Confirmation of Alice's transaction alone is not
+enough; the example also waits for the counter's updated state.
 
-Add this code to your `main()` function:
+Replace the final `Ok(())` in `main` with the following fragment. Its polling loop and final `Err(...)` expressions provide the function's result:
 
 ```rust ignore
 // -------------------------------------------------------------------------
@@ -420,11 +445,12 @@ let note_req = TransactionRequestBuilder::new()
     .build()?;
 
 let note_tx_id = client
-    .submit_new_transaction(alice_account.id(), note_req)
+    .submit_tutorial_transaction(alice_account.id(), note_req)
     .await?;
 
 println!(
-    "View transaction on MidenScan: https://testnet.midenscan.com/tx/{:?}",
+    "View transaction on MidenScan: {}/tx/{:?}",
+    network.explorer_url(),
     note_tx_id
 );
 
@@ -439,7 +465,7 @@ wait_for_tx(&mut client, note_tx_id).await.unwrap();
 sleep(Duration::from_secs(6)).await;
 
 let mut last_val = None;
-for _ in 0..10 {
+for _ in 0..24 {
     client.sync_state().await?;
 
     // Checking updated state
@@ -452,7 +478,7 @@ for _ in 0..10 {
             .unwrap()
             .into();
         let val = count[0].as_canonical_u64();
-        if val >= 2 {
+        if val == 1 {
             println!("🔢 Final counter value: {}", val);
             return Ok(());
         }
@@ -464,12 +490,12 @@ for _ in 0..10 {
 }
 
 // The network note was submitted, but it is executed asynchronously by the
-// network transaction builder. If the counter has not reached 2 within the
+// network transaction builder. If the counter has not reached 1 within the
 // polling window, the tutorial's final state is unconfirmed, so fail rather
 // than claim success.
 if let Some(val) = last_val {
     Err(format!(
-        "Counter did not reach the expected value 2 within the timeout (last observed {}). \
+        "Counter did not reach the expected value 1 within the timeout (last observed {}). \
          The network note was submitted but its execution is still pending on the network \
          transaction builder; re-run or check Midenscan.",
         val
@@ -481,78 +507,57 @@ if let Some(val) = last_val {
 }
 ```
 
-This step creates a public note that the network operator can consume to execute the increment function. This increments the counter from 1 to 2.
+## Complete example
 
-## Summary
-
-Your complete `main()` function should look like this:
+Your complete `src/main.rs` file should look like this:
 
 ```rust no_run
+use rust_client::TutorialClientExt;
 use std::{collections::BTreeSet, path::PathBuf, sync::Arc};
 
 use miden_client::{
+    Client, ClientError, Felt, Word,
     account::{
-        component::{AccountComponentMetadata, AuthNetworkAccount, BasicWallet}, AccountBuilder, AccountComponent,
-        AccountType, StorageSlot, StorageSlotName,
+        AccountBuilder, AccountComponent, AccountType, StorageSlot, StorageSlotName,
+        component::{
+            AccountComponentMetadata, AuthNetworkAccount, BasicConstantFeePolicy, BasicWallet,
+            FeePolicy, FeePolicyManager,
+        },
     },
-    address::NetworkId,
-    auth::{AuthSchemeId, AuthSecretKey, AuthSingleSig},
+    asset::AssetAmount,
+    auth::{AuthSecretKey, AuthSingleSig},
     builder::ClientBuilder,
     crypto::FeltRng,
     keystore::{FilesystemKeyStore, Keystore},
     note::{
         NetworkAccountTarget, Note, NoteAssets, NoteAttachments, NoteError, NoteExecutionHint,
-        NoteRecipient, NoteStorage, NoteTag, NoteType, PartialNoteMetadata,
+        NoteRecipient, NoteStorage, NoteTag, NoteType, P2idNote, PartialNoteMetadata,
     },
-    rpc::{Endpoint, GrpcClient},
-    store::TransactionFilter,
-    transaction::{
-        TransactionId, TransactionRequestBuilder, TransactionStatus,
-    },
-    Client, ClientError, Felt, Word,
+    rpc::{GrpcClient, VerifyingRpcClient},
+    transaction::{ExpirationTransactionScript, TransactionId, TransactionRequestBuilder},
 };
 use miden_client_sqlite_store::ClientBuilderSqliteExt;
-use rand::RngCore;
-use tokio::time::{sleep, Duration};
+use rand::Rng;
+use rust_client::{FeeConfig, TutorialNetwork, fund_account_for_fees};
+use tokio::time::{Duration, sleep};
 
 /// Waits for a specific transaction to be committed.
 async fn wait_for_tx(
     client: &mut Client<FilesystemKeyStore>,
     tx_id: TransactionId,
 ) -> Result<(), ClientError> {
-    loop {
-        client.sync_state().await?;
-
-        // Check transaction status
-        let txs = client
-            .get_transactions(TransactionFilter::Ids(vec![tx_id]))
-            .await?;
-        let tx_committed = if !txs.is_empty() {
-            matches!(txs[0].status, TransactionStatus::Committed { .. })
-        } else {
-            false
-        };
-
-        if tx_committed {
-            println!("✅ transaction {} committed", tx_id.to_hex());
-            break;
-        }
-
-        println!(
-            "Transaction {} not yet committed. Waiting...",
-            tx_id.to_hex()
-        );
-        sleep(Duration::from_secs(2)).await;
-    }
-    Ok(())
+    rust_client::wait_for_transaction(client, tx_id).await
 }
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Initialize client
-    let endpoint = Endpoint::testnet();
+    let network = TutorialNetwork::from_env()?;
+    let endpoint = network.endpoint();
     let timeout_ms = 10_000;
-    let rpc_client = Arc::new(GrpcClient::new(&endpoint, timeout_ms));
+    let rpc_client = Arc::new(VerifyingRpcClient::new(GrpcClient::new(
+        &endpoint, timeout_ms,
+    )));
 
     // Initialize keystore
     let keystore_path = PathBuf::from("./keystore");
@@ -564,12 +569,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .rpc(rpc_client)
         .sqlite_store(store_path)
         .authenticator(keystore.clone())
-        .in_debug_mode(true.into())
         .build()
         .await?;
 
     let sync_summary = client.sync_state().await.unwrap();
     println!("Latest block: {}", sync_summary.block_num);
+    let fee_config = FeeConfig::from_client(&client, network).await?;
+    let fee_faucet_id = fee_config.native_fee_faucet_id();
 
     // -------------------------------------------------------------------------
     // STEP 1: Create Basic User Account
@@ -585,7 +591,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Build the account
     let alice_account = AccountBuilder::new(init_seed)
         .account_type(AccountType::Public)
-        .with_auth_component(AuthSingleSig::new(key_pair.public_key().to_commitment(), AuthSchemeId::Falcon512Poseidon2))
+        .with_component(AuthSingleSig::from_public_key(key_pair.public_key()))
         .with_component(BasicWallet)
         .build()
         .unwrap();
@@ -594,11 +600,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     client.add_account(&alice_account, false).await?;
 
     // Add the key pair to the keystore
-    keystore.add_key(&key_pair, alice_account.id()).await.unwrap();
+    keystore
+        .add_key(&key_pair, alice_account.id())
+        .await
+        .unwrap();
+    fund_account_for_fees(&mut client, alice_account.id(), &fee_config).await?;
 
     println!(
         "Alice's account ID: {:?}",
-        alice_account.id().to_bech32(NetworkId::Testnet)
+        alice_account.id().to_bech32(network.network_id())
     );
 
     // -------------------------------------------------------------------------
@@ -606,44 +616,28 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // -------------------------------------------------------------------------
     println!("\n[STEP 2] Creating a network counter smart contract");
 
-    // `include_str!` resolves at compile time relative to this source file,
-    // so the binary is independent of the working directory it is run from.
-    let counter_code = include_str!("../masm/accounts/counter.masm");
-    let script_code = include_str!("../masm/scripts/counter_script.masm");
-    let network_note_code = include_str!("../masm/notes/network_increment_note.masm");
+    // Read the MASM source from the tutorials repository.
+    let counter_code = std::fs::read_to_string("../tutorials/masm/accounts/counter.masm").unwrap();
+    let network_note_code =
+        std::fs::read_to_string("../tutorials/masm/notes/network_increment_note.masm").unwrap();
 
-    // In protocol v0.15 an account is a *network account* (one the network
+    // An account is a *network account* (one the network
     // transaction builder executes on a user's behalf) if and only if it is
     // public AND carries the `AuthNetworkAccount` auth component. That component
-    // holds two allowlists, both fixed at account creation:
-    //   * the note-script allowlist: its presence is what marks the account as a
-    //     network account, and the builder only executes notes whose script root
-    //     is listed here;
-    //   * the tx-script allowlist: the network auth procedure rejects any custom
-    //     tx script whose root is not listed, so the STEP 3 deploy script must be
-    //     in it.
-    // We therefore compile the note script and the deploy tx script now and feed
-    // their MAST roots into the allowlists below. Both compiled scripts are reused
-    // as-is in STEP 3 (tx script) and STEP 4 (note script) — nothing is compiled
-    // twice.
+    // holds an allowlist of note scripts the network builder may execute.
+    // Compile the increment note first so its root can be included at creation.
     let note_script = client
         .code_builder()
-        .with_linked_module("external_contract::counter_contract", counter_code)?
-        .compile_note_script(network_note_code)?;
+        .with_linked_module("external_contract::counter_contract", &counter_code)?
+        .compile_note_script(&network_note_code)?;
     let note_script_root = note_script.root();
-
-    let tx_script = client
-        .code_builder()
-        .with_linked_module("external_contract::counter_contract", counter_code)?
-        .compile_tx_script(script_code)?;
-    let tx_script_root = tx_script.root();
 
     // Compile the counter MASM into an account component
     let counter_slot_name =
         StorageSlotName::new("miden::tutorials::counter").expect("valid slot name");
     let component_code = client
         .code_builder()
-        .compile_component_code("external_contract::counter_contract", counter_code)?;
+        .compile_component_code("external_contract::counter_contract", &counter_code)?;
     let counter_component = AccountComponent::new(
         component_code,
         vec![StorageSlot::with_value(
@@ -657,49 +651,56 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut init_seed = [0_u8; 32];
     client.rng().fill_bytes(&mut init_seed);
 
-    // Build the network account: public + `AuthNetworkAccount` with the note-script
-    // root allowlisted (this is what makes it a network account) and the deploy
-    // tx-script root allowlisted (so the auth procedure accepts the STEP 3 deploy).
-    let network_auth = AuthNetworkAccount::with_allowed_notes(BTreeSet::from([note_script_root]))?
-        .with_allowed_tx_scripts(BTreeSet::from([tx_script_root]));
+    // Build the public network account with the increment and funding notes allowed.
+    let fee_policy: FeePolicy = BasicConstantFeePolicy::new()
+        .with_fees(
+            [note_script_root, P2idNote::script_root()].map(|root| (root, AssetAmount::ZERO)),
+        )
+        .into();
+    let fee_policy_manager = FeePolicyManager::builder()
+        .fee_faucet_id(fee_faucet_id)
+        .active_fee_policy(fee_policy)
+        .build();
+    // Match the protocol/node counter example: only permit the two note scripts
+    // this account implements. Config notes need Authority, which it does not have.
+    // The canonical expiration script is required by the network builder.
+    let network_auth = AuthNetworkAccount::custom(
+        BTreeSet::from([note_script_root, P2idNote::script_root()]),
+        fee_policy_manager,
+    )?
+    .with_allowed_tx_scripts([ExpirationTransactionScript::script_root()]);
     let counter_contract = AccountBuilder::new(init_seed)
         .account_type(AccountType::Public)
-        .with_auth_component(network_auth)
+        .with_components(network_auth)
         .with_component(counter_component)
+        .with_component(BasicWallet)
         .build()
         .unwrap();
 
     client.add_account(&counter_contract, false).await.unwrap();
+    fund_account_for_fees(&mut client, counter_contract.id(), &fee_config).await?;
 
     println!(
         "contract id: {:?}",
-        counter_contract.id().to_bech32(NetworkId::Testnet)
+        counter_contract.id().to_bech32(network.network_id())
     );
 
     // -------------------------------------------------------------------------
-    // STEP 3: Deploy Network Account with Transaction Script
+    // STEP 3: Publish the network account
     // -------------------------------------------------------------------------
     println!("\n[STEP 3] Deploy network counter smart contract");
 
-    // Reuse the `tx_script` compiled in STEP 2 (its root is allowlisted on the
-    // account, so the network auth procedure accepts this deploy transaction).
-    let tx_increment_request = TransactionRequestBuilder::new()
-        .custom_script(tx_script)
-        .build()
-        .unwrap();
-
-    let tx_id = client
-        .submit_new_transaction(counter_contract.id(), tx_increment_request)
-        .await
-        .unwrap();
-
-    println!(
-        "View transaction on MidenScan: https://testnet.midenscan.com/tx/{:?}",
-        tx_id
-    );
-
-    // Wait for the transaction to be committed
-    wait_for_tx(&mut client, tx_id).await.unwrap();
+    // On a fee-enabled network, consuming the funding note already published this
+    // account. RPC permits users to deploy new network accounts, but rejects
+    // user-submitted transactions for existing ones. Subsequent increments must
+    // be requested by notes and executed by the network transaction builder.
+    if !fee_config.fees_are_active() {
+        let deployment = TransactionRequestBuilder::new().build()?;
+        client
+            .submit_tutorial_transaction(counter_contract.id(), deployment)
+            .await?;
+    }
+    println!("Network counter deployed; initial count is 0");
 
     // -------------------------------------------------------------------------
     // STEP 4: Prepare & Create the Network Note
@@ -734,11 +735,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .build()?;
 
     let note_tx_id = client
-        .submit_new_transaction(alice_account.id(), note_req)
+        .submit_tutorial_transaction(alice_account.id(), note_req)
         .await?;
 
     println!(
-        "View transaction on MidenScan: https://testnet.midenscan.com/tx/{:?}",
+        "View transaction on MidenScan: {}/tx/{:?}",
+        network.explorer_url(),
         note_tx_id
     );
 
@@ -753,7 +755,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     sleep(Duration::from_secs(6)).await;
 
     let mut last_val = None;
-    for _ in 0..10 {
+    for _ in 0..24 {
         client.sync_state().await?;
 
         // Checking updated state
@@ -766,7 +768,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .unwrap()
                 .into();
             let val = count[0].as_canonical_u64();
-            if val >= 2 {
+            if val == 1 {
                 println!("🔢 Final counter value: {}", val);
                 return Ok(());
             }
@@ -778,12 +780,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     // The network note was submitted, but it is executed asynchronously by the
-    // network transaction builder. If the counter has not reached 2 within the
+    // network transaction builder. If the counter has not reached 1 within the
     // polling window, the tutorial's final state is unconfirmed, so fail rather
     // than claim success.
     if let Some(val) = last_val {
         Err(format!(
-            "Counter did not reach the expected value 2 within the timeout (last observed {}). \
+            "Counter did not reach the expected value 1 within the timeout (last observed {}). \
              The network note was submitted but its execution is still pending on the network \
              transaction builder; re-run or check Midenscan.",
             val
@@ -798,38 +800,33 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 ## Step 7: Running the Example
 
-To run the complete network transaction example:
+For the standalone Cargo project, run `TUTORIAL_NETWORK=testnet cargo run --release` from `miden-network-transactions`.
+
+To run the checked-in example from the repository root:
 
 ```bash
 cd rust-client
-cargo run --release --bin network_notes_counter_contract
+TUTORIAL_NETWORK=testnet cargo run --release --bin network_notes_counter_contract
 ```
 
-Expected output:
+Successful output has this shape (abridged; IDs and block numbers vary):
 
 ```text
-Latest block: 486537
+Latest block: <block_number>
 
 [STEP 1] Creating a new account for Alice
-Alice's account ID: "mtst1aqcmenmxlqkw8ugn005s7r09kq0xpqp9"
+Alice's account ID: "<testnet_account_id>"
 
 [STEP 2] Creating a network counter smart contract
-one or more warnings were emitted
-one or more warnings were emitted
-one or more warnings were emitted
-contract id: "mtst1aqtvag789v45tvtqdaknugytf5d5gxxu"
+contract id: "<testnet_account_id>"
 
 [STEP 3] Deploy network counter smart contract
-View transaction on MidenScan: https://testnet.midenscan.com/tx/0x37c202efb825f0c7a55bd4416858fbe2d30064a5b1e557876a0053ed5307607f
-Transaction 0x37c202efb825f0c7a55bd4416858fbe2d30064a5b1e557876a0053ed5307607f not yet committed. Waiting...
-✅ transaction 0x37c202efb825f0c7a55bd4416858fbe2d30064a5b1e557876a0053ed5307607f committed
+Network counter deployed; initial count is 0
 
 [STEP 4] Creating a network note for network counter contract
-View transaction on MidenScan: https://testnet.midenscan.com/tx/0xa5ec0baa9443a0f5aa056bd4c0e4583c5c3f5a5163aa0536b469a0255b489f75
+View transaction on MidenScan: https://testnet.midenscan.com/tx/<transaction_id>
 network increment note creation tx submitted, waiting for onchain commitment
-Transaction 0xa5ec0baa9443a0f5aa056bd4c0e4583c5c3f5a5163aa0536b469a0255b489f75 not yet committed. Waiting...
-✅ transaction 0xa5ec0baa9443a0f5aa056bd4c0e4583c5c3f5a5163aa0536b469a0255b489f75 committed
-🔢 Final counter value: 2
+🔢 Final counter value: 1
 ```
 
 ## Summary
@@ -837,8 +834,8 @@ Transaction 0xa5ec0baa9443a0f5aa056bd4c0e4583c5c3f5a5163aa0536b469a0255b489f75 n
 Network transactions on Miden enable powerful use cases by allowing the operator to execute transactions on behalf of users. The key steps are:
 
 1. **Create user account**: Standard account creation for interaction
-2. **Create network account**: Build a public account (`AccountType::Public`) with the `AuthNetworkAccount` auth component, allowlisting the note-script root (this is what marks it as a network account) and the deploy transaction-script root
-3. **Deploy with transaction script**: Ensures the contract is registered on-chain
+2. **Create network account**: Build a public account with `AuthNetworkAccount`, allowlisting the increment and funding note scripts
+3. **Publish and fund it**: The initial native-asset consumption transaction registers the new account with count zero
 4. **Interact with network notes**: Users create public notes that the operator executes
 
 The same MASM code works for both regular and network contracts — the difference is purely in the Rust configuration (the `AuthNetworkAccount` auth component and its allowlists). This makes network transactions a powerful tool for building applications like AMMs where multiple users need to interact with shared state efficiently.

--- a/docs/src/rust-client/oracle_tutorial.md
+++ b/docs/src/rust-client/oracle_tutorial.md
@@ -7,18 +7,32 @@ sidebar_position: 13
 
 _Using the Pragma oracle to get on chain price data_
 
+For toolchain requirements and shared fee helpers, see the [Rust client setup](./index.md#running-the-v016-examples).
+
 ## Overview
 
 In this tutorial, we will build a simple “price reader” smart contract that will read Bitcoin price data from the on-chain Pragma oracle.
 
-We will use a script to call the `read_price` function in our "price reader" smart contract, which, in turn, calls the Pragma oracle via foreign procedure invocation (FPI). This tutorial lays the foundation for how you can integrate on-chain price data into your DeFi applications on Miden.
+We will use a script to call the `get_price` procedure in our reader account, which invokes Pragma through foreign procedure invocation (FPI). This example demonstrates the call plumbing and discards the returned price. An application would need to validate and use the result.
 
 ## What we'll cover
 
 - Deploying a smart contract that can read oracle price data
-- Using foreign procedure invocation to get real time on-chain price data
+- Using foreign procedure invocation to query published on-chain price data
 
 ## Prerequisites
+
+:::warning Deployment required
+
+Pragma's [published deployment table](https://github.com/astraly-labs/pragma-miden#deployments)
+lists Miden v0.15 testnet only. Running this example requires a compatible v0.16
+testnet deployment, its account ID, `get_median` procedure root, and pair identifiers.
+
+The reader assumes the named slots `pragma::oracle::next_publisher_index`,
+`pragma::oracle::publishers`, and `pragma::publisher::entries`. Check these slots,
+the publisher ID layout and index range, and the return values against that deployment.
+
+:::
 
 This tutorial assumes you have a basic understanding of Miden assembly, have completed the previous tutorials on using the Rust client, and have completed the tutorial on foreign procedure invocation.
 
@@ -26,53 +40,57 @@ To quickly get up to speed with Miden assembly (MASM), please play around with r
 
 ## Step 1: Initialize your repository
 
-Create a new Rust repository for your Miden project and navigate to it with the following command:
+From the parent directory of your `tutorials` clone, create a sibling Cargo project:
 
 ```bash
 cargo new miden-defi-app
 cd miden-defi-app
+rustup override set 1.98.1
+cp ../tutorials/rust-client/Cargo.lock Cargo.lock
 ```
 
 Add the following dependencies to your `Cargo.toml` file:
 
 ```toml
 [dependencies]
-miden-client = { version = "0.15", features = ["testing", "tonic"] }
-miden-client-sqlite-store = { version = "0.15", package = "miden-client-sqlite-store" }
-miden-protocol = { version = "0.15" }
-rand = { version = "0.9" }
+# Clone tutorials next to this Cargo project (see Rust client setup).
+rust-client = { path = "../tutorials/rust-client" }
+miden-client = { version = "=0.16.0", features = ["testing", "tonic"] }
+miden-client-sqlite-store = { version = "=0.16.0", package = "miden-client-sqlite-store" }
+miden-protocol = { version = "=0.16.0" }
+rand = { version = "0.10" }
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1.0", features = ["raw_value"] }
-tokio = { version = "1.46", features = ["rt-multi-thread", "net", "macros", "fs"] }
-rand_chacha = "0.9.0"
+tokio = { version = "1.48", features = ["rt-multi-thread", "net", "macros", "fs"] }
+
+[profile.dev]
+opt-level = 2
 ```
 
-### Step 1: Set up your `src/main.rs` file
+### Set up your `src/main.rs` file
 
 Copy and paste the following code into your `src/main.rs` file:
 
 ```rust no_run
 use miden_client::{
+    Client, ClientError, Felt, Word, ZERO,
     account::{
-        component::AccountComponentMetadata, AccountBuilder, AccountComponent, AccountId,
-        AccountType, StorageMapKey, StorageSlot, StorageSlotName,
+        AccountBuilder, AccountComponent, AccountId, AccountType, StorageMapKey, StorageSlot,
+        StorageSlotName,
+        component::{AccountComponentMetadata, BasicWallet},
     },
-    assembly::{
-        CodeBuilder, DefaultSourceManager, Module, ModuleKind, Path as AssemblyPath,
-    },
+    assembly::CodeBuilder,
     auth::NoAuth,
     builder::ClientBuilder,
     keystore::FilesystemKeyStore,
-    rpc::{
-        domain::account::AccountStorageRequirements,
-        Endpoint, GrpcClient,
-    },
-    transaction::{ForeignAccount, TransactionKernel, TransactionRequestBuilder},
-    Client, ClientError, Felt, Word, ZERO,
+    rpc::{GrpcClient, VerifyingRpcClient, domain::account::AccountStorageRequirements},
+    transaction::{ForeignAccount, TransactionRequestBuilder},
 };
 use miden_client_sqlite_store::ClientBuilderSqliteExt;
-use rand::RngCore;
-use std::{fs, path::Path, sync::Arc};
+use rand::Rng;
+use rust_client::TutorialClientExt;
+use rust_client::{FeeConfig, TutorialNetwork, fund_account_for_fees};
+use std::sync::Arc;
 
 /// Import the oracle + its publishers and return the ForeignAccount list
 /// Due to Pragma's decentralized oracle architecture, we need to get the
@@ -107,7 +125,7 @@ pub async fn get_oracle_foreign_accounts(
         StorageSlotName::new("pragma::oracle::publishers").expect("valid slot name");
     let publisher_ids: Vec<AccountId> = (2..next_publisher_index)
         .map(|index| {
-            let key: Word = [Felt::new_unchecked(index), ZERO, ZERO, ZERO].into();
+            let key = StorageMapKey::new([Felt::new_unchecked(index), ZERO, ZERO, ZERO].into());
             let publisher_word = storage
                 .get_map_item(&publishers_slot, key)
                 .expect("publisher entry missing from oracle storage");
@@ -118,8 +136,7 @@ pub async fn get_oracle_foreign_accounts(
 
     // Each publisher exposes its price entries in the `entries` map, keyed by
     // the faucet ID word of the trading pair.
-    let entries_slot =
-        StorageSlotName::new("pragma::publisher::entries").expect("valid slot name");
+    let entries_slot = StorageSlotName::new("pragma::publisher::entries").expect("valid slot name");
     let mut foreign_accounts = Vec::with_capacity(publisher_ids.len() + 1);
 
     for publisher_id in publisher_ids {
@@ -149,29 +166,17 @@ pub async fn get_oracle_foreign_accounts(
     Ok(foreign_accounts)
 }
 
-fn create_library(
-    library_path: &str,
-    source_code: &str,
-) -> Result<Arc<miden_client::assembly::Library>, Box<dyn std::error::Error>> {
-    let source_manager = Arc::new(DefaultSourceManager::default());
-    let assembler = TransactionKernel::assembler_with_source_manager(source_manager.clone());
-    let module = Module::parser(ModuleKind::Library).parse_str(
-        AssemblyPath::new(library_path),
-        source_code,
-        source_manager,
-    )?;
-    let library = assembler.assemble_library([module])?;
-    Ok(library)
-}
-
 #[tokio::main]
 async fn main() -> Result<(), ClientError> {
     // -------------------------------------------------------------------------
     // Initialize Client
     // -------------------------------------------------------------------------
-    let endpoint = Endpoint::testnet();
+    let network = TutorialNetwork::from_env()?;
+    let endpoint = network.endpoint();
     let timeout_ms = 10_000;
-    let rpc_client = Arc::new(GrpcClient::new(&endpoint, timeout_ms));
+    let rpc_client = Arc::new(VerifyingRpcClient::new(GrpcClient::new(
+        &endpoint, timeout_ms,
+    )));
 
     let keystore_path = std::path::PathBuf::from("./keystore");
     let keystore = Arc::new(FilesystemKeyStore::new(keystore_path).unwrap());
@@ -182,30 +187,55 @@ async fn main() -> Result<(), ClientError> {
         .rpc(rpc_client)
         .sqlite_store(store_path)
         .authenticator(keystore.clone())
-        .in_debug_mode(true.into())
         .build()
         .await?;
 
     println!("Latest block: {}", client.sync_state().await?.block_num);
+    let fee_config = FeeConfig::from_client(&client, network).await?;
 
     // -------------------------------------------------------------------------
     // Get all foreign accounts for oracle data
     // -------------------------------------------------------------------------
-    // Defaults to Pragma's current Miden v0.15 testnet oracle; pass a different
-    // bech32 id as the first CLI argument to point at another deployment. Pragma's
-    // addresses change between testnet iterations, so check their README
-    // (https://github.com/astraly-labs/pragma-miden) if this feed stops resolving.
+    // Pass a compatible oracle account ID and its `get_median` procedure root as CLI
+    // arguments (or through the matching environment variables). This tutorial remains skipped
+    // by the runner until Pragma publishes a deployment for the current protocol release.
     let oracle_bech32 = std::env::args()
         .nth(1)
-        .unwrap_or_else(|| "mtst1apadf2szkxqkcyt7x2znuggv9qkhccam".to_string());
-    let (_, oracle_account_id) = AccountId::from_bech32(&oracle_bech32).unwrap();
+        .or_else(|| std::env::var("MIDEN_ORACLE_ACCOUNT_ID").ok())
+        .ok_or_else(|| ClientError::Observer(Box::new(std::io::Error::other(
+            "Oracle deployment is required: set MIDEN_ORACLE_ACCOUNT_ID and MIDEN_ORACLE_GET_MEDIAN_ROOT for the selected network. Use a compatible v0.16 deployment on the selected network.",
+        ))))?;
+    let get_median_proc_root = std::env::args()
+        .nth(2)
+        .or_else(|| std::env::var("MIDEN_ORACLE_GET_MEDIAN_ROOT").ok())
+        .ok_or_else(|| {
+            ClientError::Observer(Box::new(std::io::Error::other(
+            "Set MIDEN_ORACLE_GET_MEDIAN_ROOT to the deployed oracle's get_median procedure root",
+        )))
+        })?;
+    let (account_network, oracle_account_id) = AccountId::from_bech32(&oracle_bech32).unwrap();
+    assert_eq!(
+        account_network,
+        network.network_id(),
+        "oracle account must match the selected tutorial network"
+    );
 
-    // BTC/USD is identified by the faucet ID pair `1:0` (prefix 1, suffix 0).
+    // BTC/USD was identified by the faucet ID pair `1:0` in the previous deployment. Override
+    // either value with the optional third and fourth CLI arguments for the selected deployment.
     // The faucet ID word is laid out as [0, 0, suffix, prefix].
-    let pair_prefix: u64 = 1;
-    let pair_suffix: u64 = 0;
-    let btc_usd_pair: Word =
-        [ZERO, ZERO, Felt::new_unchecked(pair_suffix), Felt::new_unchecked(pair_prefix)].into();
+    let pair_prefix: u64 = std::env::args()
+        .nth(3)
+        .map_or(1, |value| value.parse().expect("pair prefix must be a u64"));
+    let pair_suffix: u64 = std::env::args()
+        .nth(4)
+        .map_or(0, |value| value.parse().expect("pair suffix must be a u64"));
+    let btc_usd_pair: Word = [
+        ZERO,
+        ZERO,
+        Felt::new_unchecked(pair_suffix),
+        Felt::new_unchecked(pair_prefix),
+    ]
+    .into();
     let foreign_accounts: Vec<ForeignAccount> =
         get_oracle_foreign_accounts(&mut client, oracle_account_id, btc_usd_pair).await?;
 
@@ -218,8 +248,19 @@ async fn main() -> Result<(), ClientError> {
     // -------------------------------------------------------------------------
     // Create Oracle Reader contract
     // -------------------------------------------------------------------------
-    let contract_code =
-        fs::read_to_string(Path::new("../masm/accounts/oracle_reader.masm")).unwrap();
+    let contract_code = std::fs::read_to_string("../tutorials/masm/accounts/oracle_reader.masm")
+        .unwrap()
+        .replace("{get_median_proc_root}", &get_median_proc_root)
+        .replace(
+            "{oracle_id_prefix}",
+            &oracle_account_id.prefix().to_string(),
+        )
+        .replace(
+            "{oracle_id_suffix}",
+            &oracle_account_id.suffix().to_string(),
+        )
+        .replace("{pair_prefix}", &pair_prefix.to_string())
+        .replace("{pair_suffix}", &pair_suffix.to_string());
 
     let contract_slot_name =
         StorageSlotName::new("miden::tutorials::oracle_reader").expect("valid slot name");
@@ -242,7 +283,8 @@ async fn main() -> Result<(), ClientError> {
     let oracle_reader_contract = AccountBuilder::new(seed)
         .account_type(AccountType::Public)
         .with_component(contract_component.clone())
-        .with_auth_component(NoAuth)
+        .with_component(BasicWallet)
+        .with_component(NoAuth)
         .build()
         .unwrap();
 
@@ -250,20 +292,17 @@ async fn main() -> Result<(), ClientError> {
         .add_account(&oracle_reader_contract, false)
         .await
         .unwrap();
+    fund_account_for_fees(&mut client, oracle_reader_contract.id(), &fee_config).await?;
 
     // -------------------------------------------------------------------------
     // Build the script that calls our `get_price` procedure
     // -------------------------------------------------------------------------
-    let script_path = Path::new("../masm/scripts/oracle_reader_script.masm");
-    let script_code = fs::read_to_string(script_path).unwrap();
-
-    let library_path = "external_contract::oracle_reader";
-    let account_component_lib =
-        create_library(library_path, &contract_code).unwrap();
+    let script_code =
+        std::fs::read_to_string("../tutorials/masm/scripts/oracle_reader_script.masm").unwrap();
 
     let tx_script = client
         .code_builder()
-        .with_dynamically_linked_library(&account_component_lib)
+        .with_linked_module("external_contract::oracle_reader", &contract_code)
         .unwrap()
         .compile_tx_script(&script_code)
         .unwrap();
@@ -275,12 +314,13 @@ async fn main() -> Result<(), ClientError> {
         .unwrap();
 
     let tx_id = client
-        .submit_new_transaction(oracle_reader_contract.id(), tx_increment_request)
+        .submit_tutorial_transaction(oracle_reader_contract.id(), tx_increment_request)
         .await
         .unwrap();
 
     println!(
-        "View transaction on MidenScan: https://testnet.midenscan.com/tx/{:?}",
+        "View transaction on MidenScan: {}/tx/{:?}",
+        network.explorer_url(),
         tx_id
     );
 
@@ -290,168 +330,137 @@ async fn main() -> Result<(), ClientError> {
 }
 ```
 
-_Don't run this code just yet, we still need to create our smart contract that queries the oracle_
+The following section explains the two MASM templates loaded by the Rust example.
 
-In the code above, the Pragma oracle account ID is provided as a command-line argument in bech32 form, and the BTC/USD price feed is identified by the faucet ID pair `1:0` (prefix `1`, suffix `0`). The `get_oracle_foreign_accounts` function returns all of the `ForeignAccount`s that you will need to execute the transaction to get the price data from the oracle. Since Pragma's oracle aggregates data from multiple publishers, this function reads the oracle's on-chain publisher registry and collects every publisher account id required to make a successful FPI call.
-
-:::note
-The oracle account ID, procedure hash, and faucet pair used in this tutorial reference Pragma's testnet deployment. These values are maintained by Pragma and may change if they redeploy their oracle. For the latest values, check the [Pragma Miden repository](https://github.com/astraly-labs/pragma-miden).
-:::
+In the code above, a compatible testnet oracle account ID and `get_median` procedure root are required inputs. The BTC/USD price feed used prefix `1` and suffix `0` in Pragma's earlier deployment; the optional third and fourth arguments let you supply the pair identifiers published for a new deployment. The `get_oracle_foreign_accounts` function returns every `ForeignAccount` needed to execute the transaction. Since Pragma's oracle aggregates data from multiple publishers, the function reads the on-chain publisher registry and requests the storage proofs needed by the nested FPI calls.
 
 ## Step 2: Build the price reader smart contract and script
 
-Just like in previous tutorials, for better code organization we will separate the Miden assembly code from our Rust code.
-
-Create a directory named `masm` at the **root** of your `miden-counter-contract` directory. This will contain our contract and script masm code.
-
-Initialize the `masm` directory:
-
-```bash
-mkdir -p masm/accounts masm/scripts
-```
-
-This will create:
-
-```text
-masm/
-├── accounts/
-└── scripts/
-```
+The reader and transaction script are in the repository’s `masm/` directory.
 
 ### Oracle price reader smart contract
 
 Below is our oracle price reader contract. It has a single exported procedure: `get_price`
 
-The import `miden::tx` contains the `tx::execute_foreign_procedure` which we will use to read the price from the oracle contract.
+The `miden::protocol::tx` module exports `execute_foreign_procedure`, which the reader uses to invoke the oracle.
 
 #### Here's a breakdown of what the `get_price` procedure does:
 
-1. Pushes the 16 foreign procedure inputs that `tx::execute_foreign_procedure` requires. The first four are the arguments to `get_median` — the BTC/USD faucet ID prefix `1`, suffix `0`, an `amount` of `0`, and a trailing `0` — and the remaining twelve are zero padding.
-2. Pushes `0xaa3a12d4e9de2dad37c50dba93809b9c17226d512e642d3d620c77088a85da71` onto the stack, which is the procedure root of the `get_median` procedure in the oracle.
-3. Pushes the Pragma oracle account ID prefix and suffix.
-4. Calls `tx::execute_foreign_procedure`, which invokes the `get_median` procedure via foreign procedure invocation. `get_median` returns `[is_tracked, median_price, amount]` on the stack.
+1. Pushes the 16 foreign procedure inputs that `tx::execute_foreign_procedure` requires. The first four contain the requested pair prefix and suffix, an `amount` of `0`, and a trailing `0`; the remaining twelve are zero padding.
+2. Pushes the supplied `get_median` procedure root.
+3. Pushes the supplied testnet oracle account ID prefix and suffix.
+4. Calls `tx::execute_foreign_procedure`, which invokes `get_median`. The template expects `[is_tracked, median_price, amount]` at the top of the returned stack; confirm this interface against the compatible deployment.
+5. Drops the sixteen foreign output elements, including the price, to restore the caller's stack.
 
-Inside of the `masm/accounts/` directory, create the `oracle_reader.masm` file:
+The reader is defined in `masm/accounts/oracle_reader.masm`:
 
 ```masm
-# The oracle account ID, procedure hash, and pair ID below reference
-# Pragma's Miden v0.15 testnet deployment (https://github.com/astraly-labs/pragma-miden).
-# Pragma's addresses change between testnet iterations (their README is the
-# source of truth), so if the oracle is redeployed these values must be updated:
-# the oracle account id, the `get_median` procedure root, and (if a different
-# feed) the faucet pair id.
+# the Rust runner replaces these placeholders with values from a compatible
+# pragma deployment before compiling this component.
 
 use miden::protocol::tx
 
-# Fetches the current price from the `get_median`
-# procedure from the Pragma oracle
-# => []
-pub proc get_price
+# PUBLIC INTERFACE
+# =================================================================================================
+
+#! Queries the configured Pragma oracle's median price through a foreign procedure.
+#!
+#! Inputs:  [pad(16)]
+#! Outputs: [pad(16)]
+#!
+#! Panics if:
+#! - the configured oracle procedure or its required foreign state is unavailable.
+#!
+#! Invocation: call
+@account_procedure
+pub proc get_price()
     # `execute_foreign_procedure` requires exactly 16 foreign procedure inputs.
     # `get_median` only reads the first four, so the rest are zero padding.
     padw padw padw
-    # => [PAD(12)]
+    # => [pad(28)]
 
-    # BTC/USD pair: faucet id prefix `1`, suffix `0`, amount `0`
-    push.0.0.0.1
-    # => [pair_prefix, pair_suffix, amount, 0, PAD(12)]
+    # requested pair: faucet ID prefix/suffix, amount `0`.
+    push.0.0.{pair_suffix}.{pair_prefix}
+    # => [pair_prefix, pair_suffix, amount, 0, pad(28)]
 
-    # This is the procedure root of the `get_median` procedure
-    push.0xaa3a12d4e9de2dad37c50dba93809b9c17226d512e642d3d620c77088a85da71
-    # => [GET_MEDIAN_HASH, FOREIGN_INPUTS(16)]
+    # this is the procedure root of the `get_median` procedure.
+    push.{get_median_proc_root}
+    # => [GET_MEDIAN_HASH, foreign_procedure_inputs(16), pad(16)]
 
-    # The Pragma oracle account id: prefix then suffix, leaving suffix on top
-    push.8850886096234572817.9093477099503364096
-    # => [oracle_id_suffix, oracle_id_prefix, GET_MEDIAN_HASH, FOREIGN_INPUTS(16)]
+    # the Pragma oracle account id: prefix then suffix, leaving suffix on top.
+    push.{oracle_id_prefix}.{oracle_id_suffix}
+    # => [oracle_id_suffix, oracle_id_prefix, GET_MEDIAN_HASH, foreign_procedure_inputs(16), pad(16)]
 
     exec.tx::execute_foreign_procedure
-    # => [is_tracked, median_price, amount, PAD(13)]
-
-    debug.stack
-    # => [is_tracked, median_price, amount, PAD(13)]
+    # => [is_tracked, median_price, amount, pad(29)]
 
     dropw dropw dropw dropw
+    # => [pad(16)]
 end
 ```
 
-**Note**: _It's a good habit to add comments above each line of MASM code with the expected stack state. This improves readability and helps with debugging._
+Stack comments below instruction groups show the expected stack state after execution. The braces in this template are replaced by Rust before assembly.
 
 ### Create the script which calls the `get_price` procedure
 
 This is a Miden assembly script that will call the `get_price` procedure during the transaction.
 
-Inside of the `masm/scripts/` directory, create the `oracle_reader_script.masm` file:
+The transaction script is defined in `masm/scripts/oracle_reader_script.masm`:
 
 ```masm
 use external_contract::oracle_reader
 
-begin
-    exec.oracle_reader::get_price
+#! Queries the configured oracle through the reader account.
+#!
+#! Inputs:  [ARGS, pad(12)]
+#! Outputs: [pad(16)]
+#!
+#! Where:
+#! - ARGS contains unused transaction script arguments.
+#!
+#! Invocation: dyncall
+@transaction_script
+pub proc main(args: word)
+    dropw
+    # => [pad(16)]
+
+    call.oracle_reader::get_price
+    # => [pad(16)]
 end
 ```
 
 ## Step 3: Run the program
 
-Run the following command to execute src/main.rs:
+Compile-check the standalone program with `cargo check`. To execute it once a compatible deployment is available, set `MIDEN_ORACLE_ACCOUNT_ID` and `MIDEN_ORACLE_GET_MEDIAN_ROOT` in your shell, then run:
 
 ```bash
-cargo run --release
+TUTORIAL_NETWORK=testnet cargo run --release -- \
+  "$MIDEN_ORACLE_ACCOUNT_ID" "$MIDEN_ORACLE_GET_MEDIAN_ROOT"
 ```
 
-The output of our program will look something like this:
+The command defaults to pair prefix `1` and suffix `0`. Append the deployment's pair prefix and suffix as the third and fourth arguments when those values differ. Do not assume the old pair identifies BTC/USD on a new deployment.
+
+With a compatible deployment, the output includes:
 
 ```text
-Latest block: 489876
-Oracle accountId prefix: V1(AccountIdPrefixV1 { prefix: 8850886096234572817 }) suffix: 9093477099503364096
-Stack state before step 6324:
-├──  0: 1
-├──  1: 6439689500000
-├──  2: 0
-├──  3: 0
-├──  4: 0
-├──  5: 0
-├──  6: 0
-├──  7: 0
-├──  8: 0
-├──  9: 0
-├── 10: 0
-├── 11: 0
-├── 12: 0
-├── 13: 0
-├── 14: 0
-├── 15: 0
-├── 16: 0
-├── 17: 0
-├── 18: 0
-├── 19: 0
-├── 20: 0
-├── 21: 0
-├── 22: 0
-├── 23: 0
-├── 24: 0
-├── 25: 0
-├── 26: 0
-├── 27: 0
-├── 28: 0
-├── 29: 0
-├── 30: 0
-└── 31: 0
-
-View transaction on MidenScan: https://testnet.midenscan.com/tx/0xbf6048faa60c72c43ab5645d937d02d0d768ee4fdad3c64b736789fdf0ef6a44
+Latest block: <block_number>
+Oracle accountId prefix: <oracle_prefix> suffix: <oracle_suffix>
+View transaction on MidenScan: https://testnet.midenscan.com/tx/<transaction_id>
 ```
 
-The `get_median` procedure leaves three values on the stack. Index `0` holds `is_tracked` — `1` when Pragma tracks the requested pair. Index `1` holds the median price as a raw fixed-point integer; in the output above it is `6439689500000`. The number of decimal places is defined by Pragma's feed (BTC/USD is published with 8 decimals), so this reading is about `$64,396.89`. Index `2` holds the `amount` value that was passed into the call. Pragma publishes several price feeds on testnet; this tutorial reads the `BTC/USD` feed.
+The template expects `[is_tracked, median_price, amount]` on the stack, then drops those values. Before using the price in an application, check the feed's tracking status, freshness rules, and fixed-point precision, then store the value or use it within the same procedure.
 
 ### Running the tutorial
 
-To run this tutorial end-to-end, navigate to the `rust-client` directory in the [miden-tutorials](https://github.com/0xMiden/miden-tutorials/) repository and run:
+Once the deployment prerequisites are met, return to the root of the [tutorials repository](https://github.com/0xMiden/tutorials/) and run:
 
 ```bash
 cd rust-client
-cargo run --release --bin oracle_data_query
+TUTORIAL_NETWORK=testnet cargo run --release --bin oracle_data_query -- \
+  "$MIDEN_ORACLE_ACCOUNT_ID" "$MIDEN_ORACLE_GET_MEDIAN_ROOT"
 ```
 
-This defaults to Pragma's current testnet oracle. To read from a different deployment, pass its bech32 account ID as an argument: `cargo run --release --bin oracle_data_query -- <ORACLE_BECH32_ID>`.
+If both variables are exported in your shell, you can omit `--` and the explicit arguments. The account must use the `mtst1...` testnet prefix.
 
 ### Continue learning
 

--- a/docs/src/rust-client/public_account_interaction_tutorial.md
+++ b/docs/src/rust-client/public_account_interaction_tutorial.md
@@ -7,11 +7,13 @@ sidebar_position: 5
 
 _Using the Miden client in Rust to interact with public smart contracts on Miden_
 
+For toolchain requirements and shared fee helpers, see the [Rust client setup](./index.md#running-the-v016-examples).
+
 ## Overview
 
 In the previous tutorial, we built a simple counter contract and deployed it to the Miden testnet. However, we only covered how the contract’s deployer could interact with it. Now, let’s explore how anyone can interact with a public smart contract on Miden.
 
-We’ll retrieve the counter contract’s state from the chain and rebuild it locally so a local transaction can be executed against it. In the near future, Miden will support network transactions, making the process of submitting transactions to public smart contracts much more like traditional blockchains.
+We'll import the counter contract's public state from the chain and execute a local transaction against it. Its `NoAuth` authentication component permits this without a signature; a public account with signature authentication would still require the appropriate authorization. For contracts that should execute autonomously on behalf of users, continue with the network transactions tutorial after this one.
 
 Just like in the previous tutorial, we will use a script to invoke the increment function within the counter contract to update the count. However, this tutorial demonstrates how to call a procedure in a smart contract that was deployed by a different user on Miden.
 
@@ -22,120 +24,151 @@ Just like in the previous tutorial, we will use a script to invoke the increment
 
 ## Prerequisites
 
-This tutorial assumes you have a basic understanding of Miden assembly and completed the previous tutorial on deploying the counter contract. Although not a requirement, it is recommended to complete the counter contract deployment tutorial before starting this tutorial.
+This tutorial assumes you have a basic understanding of Miden assembly and a counter deployed with the code from the previous tutorial. Keep the `mtst1...` account ID printed by that deployment; the standalone program requires it.
+
+The counter deployment example also funds the contract's native fee balance.
+This example spends from that existing balance when incrementing the counter;
+ensure the imported contract has enough funds. The runner supplies a freshly
+deployed, funded counter automatically.
 
 ## Step 1: Initialize your repository
 
-Create a new Rust repository for your Miden project and navigate to it with the following command:
+From the parent directory of your `tutorials` clone, create a sibling Cargo project:
 
 ```bash
-cargo new miden-counter-contract
-cd miden-counter-contract
+cargo new miden-public-account-interaction
+cd miden-public-account-interaction
+rustup override set 1.98.1
+cp ../tutorials/rust-client/Cargo.lock Cargo.lock
 ```
 
 Add the following dependencies to your `Cargo.toml` file:
 
 ```toml
 [dependencies]
-miden-client = { version = "0.15", features = ["testing", "tonic"] }
-miden-client-sqlite-store = { version = "0.15", package = "miden-client-sqlite-store" }
-miden-protocol = { version = "0.15" }
-rand = { version = "0.9" }
-tokio = { version = "1.46", features = ["rt-multi-thread", "net", "macros", "fs"] }
+# Clone tutorials next to this Cargo project (see Rust client setup).
+rust-client = { path = "../tutorials/rust-client" }
+miden-client = { version = "=0.16.0", features = ["testing", "tonic"] }
+miden-client-sqlite-store = { version = "=0.16.0", package = "miden-client-sqlite-store" }
+miden-protocol = { version = "=0.16.0" }
+rand = { version = "0.10" }
+tokio = { version = "1.48", features = ["rt-multi-thread", "net", "macros", "fs"] }
+
+[profile.dev]
+opt-level = 2
 ```
 
-## Step 2: Build the counter contract
+## Step 2: Prepare the counter module and script
 
-For better code organization, we will separate the Miden assembly code from our Rust code.
-
-Create a directory named `masm` at the **root** of your `miden-counter-contract` directory. This will contain our contract and script masm code.
-
-Initialize the `masm` directory:
-
-```bash
-mkdir -p masm/accounts masm/scripts
-```
-
-This will create:
-
-```text
-masm/
-├── accounts/
-└── scripts/
-```
-
-Inside of the `masm/accounts/` directory, create the `counter.masm` file:
+The account already exists on-chain. We use the repository’s `masm/accounts/counter.masm` module to link the increment transaction script:
 
 ```masm
 use miden::protocol::active_account
 use miden::protocol::native_account
-use miden::core::word
 use miden::core::sys
+
+# CONSTANTS
+# =================================================================================================
 
 const COUNTER_SLOT = word("miden::tutorials::counter")
 
-#! Inputs:  []
-#! Outputs: [count]
-pub proc get_count
+# PUBLIC INTERFACE
+# =================================================================================================
+
+#! Returns the current count.
+#!
+#! Inputs:  [pad(16)]
+#! Outputs: [count, pad(15)]
+#!
+#! Invocation: call
+@account_procedure
+pub proc get_count() -> felt
     push.COUNTER_SLOT[0..2] exec.active_account::get_item
-    # => [count]
+    # => [[count, 0, 0, 0], pad(16)]
 
     exec.sys::truncate_stack
-    # => [count]
+    # => [count, pad(15)]
 end
 
-#! Inputs:  []
-#! Outputs: []
-pub proc increment_count
+#! Increments the current count by one.
+#!
+#! Inputs:  [pad(16)]
+#! Outputs: [pad(16)]
+#!
+#! Invocation: call
+@account_procedure
+pub proc increment_count()
     push.COUNTER_SLOT[0..2] exec.active_account::get_item
-    # => [count]
+    # => [[count, 0, 0, 0], pad(16)]
 
     add.1
-    # => [count+1]
+    # => [[count + 1, 0, 0, 0], pad(16)]
 
     push.COUNTER_SLOT[0..2] exec.native_account::set_item
-    # => []
+    # => [OLD_VALUE, pad(16)]
+
+    dropw
+    # => [pad(16)]
 
     exec.sys::truncate_stack
-    # => []
+    # => [pad(16)]
 end
 ```
 
-Inside of the `masm/scripts/` directory, create the `counter_script.masm` file:
+The transaction script is defined in `masm/scripts/counter_script.masm`:
 
 ```masm
 use external_contract::counter_contract
 
-begin
+#! Increments the counter.
+#!
+#! Inputs:  [ARGS, pad(12)]
+#! Outputs: [pad(16)]
+#!
+#! Where:
+#! - ARGS contains unused transaction script arguments.
+#!
+#! Invocation: dyncall
+@transaction_script
+pub proc main(args: word)
+    dropw
+    # => [pad(16)]
+
     call.counter_contract::increment_count
+    # => [pad(16)]
 end
 ```
 
 **Note**: _We explained in the previous counter contract tutorial what exactly happens at each step in the `increment_count` procedure._
 
-### Step 3: Set up your `src/main.rs` file
+## Step 3: Set up your `src/main.rs` file
 
 Copy and paste the following code into your `src/main.rs` file:
 
 ```rust no_run
+use rust_client::TutorialClientExt;
 use std::{path::PathBuf, sync::Arc};
 
 use miden_client::{
+    ClientError,
     account::{AccountId, StorageSlotName},
     builder::ClientBuilder,
     keystore::FilesystemKeyStore,
-    rpc::{Endpoint, GrpcClient},
+    rpc::{GrpcClient, VerifyingRpcClient},
     transaction::TransactionRequestBuilder,
-    ClientError,
 };
 use miden_client_sqlite_store::ClientBuilderSqliteExt;
+use rust_client::TutorialNetwork;
 
 #[tokio::main]
 async fn main() -> Result<(), ClientError> {
     // Initialize client
-    let endpoint = Endpoint::testnet();
+    let network = TutorialNetwork::from_env()?;
+    let endpoint = network.endpoint();
     let timeout_ms = 10_000;
-    let rpc_client = Arc::new(GrpcClient::new(&endpoint, timeout_ms));
+    let rpc_client = Arc::new(VerifyingRpcClient::new(GrpcClient::new(
+        &endpoint, timeout_ms,
+    )));
 
     // Initialize keystore
     let keystore_path = PathBuf::from("./keystore");
@@ -147,7 +180,6 @@ async fn main() -> Result<(), ClientError> {
         .rpc(rpc_client)
         .sqlite_store(store_path)
         .authenticator(keystore.clone())
-        .in_debug_mode(true.into())
         .build()
         .await?;
 
@@ -160,11 +192,9 @@ async fn main() -> Result<(), ClientError> {
 
 ## Step 4: Reading public state from a smart contract
 
-To read the public storage state of a smart contract on Miden we either instantiate the `TonicRpcClient` by itself, or use the `test_rpc_api()` method on the `Client` instance. In this example, we will be using the `test_rpc_api()` method.
+This tutorial uses `Client::import_account_by_id` to import a public account from testnet and read its storage. First run the [counter contract tutorial](./counter_contract_tutorial.md), then copy the deployed counter's `mtst1...` account ID. Pass that ID to this program instead of hard-coding an address, because testnet is reset periodically.
 
-We will be reading the public storage state of the counter contract deployed on the testnet at address `mtst1apcqs7aj3a2cf5t6pnsfy0p4ns7wl7sp`.
-
-Add the following code snippet to the end of your `src/main.rs` function:
+Insert the following code inside `main`, immediately before its final `Ok(())`:
 
 ```rust ignore
 // -------------------------------------------------------------------------
@@ -172,9 +202,19 @@ Add the following code snippet to the end of your `src/main.rs` function:
 // -------------------------------------------------------------------------
 println!("\n[STEP 1] Reading data from public state");
 
-// Define the Counter Contract account id from counter contract deploy
-let (_, counter_contract_id) =
-    AccountId::from_bech32("mtst1apcqs7aj3a2cf5t6pnsfy0p4ns7wl7sp").unwrap();
+// Pass the account ID printed by `counter_contract_deploy` as the first argument, or via
+// `MIDEN_COUNTER_ACCOUNT_ID`.
+let counter_contract_bech32 = std::env::args()
+    .nth(1)
+    .or_else(|| std::env::var("MIDEN_COUNTER_ACCOUNT_ID").ok())
+    .expect("pass the counter account ID from counter_contract_deploy");
+let (account_network, counter_contract_id) =
+    AccountId::from_bech32(&counter_contract_bech32).expect("invalid counter account ID");
+assert_eq!(
+    account_network,
+    network.network_id(),
+    "counter account must match the selected tutorial network"
+);
 
 client
     .import_account_by_id(counter_contract_id)
@@ -190,24 +230,29 @@ println!(
     "Account details: {:?}",
     counter_contract.storage().slots().first().unwrap()
 );
+let counter_slot_name =
+    StorageSlotName::new("miden::tutorials::counter").expect("valid slot name");
+let count_before = counter_contract
+    .storage()
+    .get_item(&counter_slot_name)
+    .unwrap()[0];
 ```
 
-Run the following command to execute src/main.rs:
+Set `MIDEN_COUNTER_ACCOUNT_ID` to the deployed `mtst1...` address in your shell, or replace the quoted variable below with that address. Run the following command to execute `src/main.rs`:
 
 ```bash
-cargo run --release
+TUTORIAL_NETWORK=testnet cargo run --release -- "$MIDEN_COUNTER_ACCOUNT_ID"
 ```
 
-After the program executes, you should see the counter contract count value and nonce printed to the terminal, for example:
+The program prints the imported storage slot. For a freshly deployed counter, the abridged output is:
 
 ```text
-count val: [0, 0, 0, 5]
-counter nonce: 5
+Account details: StorageSlot { ... content: Value(Word([1, 0, 0, 0])) }
 ```
 
-## Step 5: Importing a public account
+## Step 5: Increment the imported counter
 
-Add the following code snippet to the end of your `src/main.rs` function:
+Insert the following code after the import step, inside `main` and before `Ok(())`:
 
 ```rust ignore
 // -------------------------------------------------------------------------
@@ -215,18 +260,18 @@ Add the following code snippet to the end of your `src/main.rs` function:
 // -------------------------------------------------------------------------
 println!("\n[STEP 2] Call the increment_count procedure in the counter contract");
 
-// Load the MASM sources at compile time so the binary is independent of
-// the working directory it is run from.
-let script_code = include_str!("../masm/scripts/counter_script.masm");
-let counter_code = include_str!("../masm/accounts/counter.masm");
+// Read the MASM source from the tutorials repository.
+let script_code =
+    std::fs::read_to_string("../tutorials/masm/scripts/counter_script.masm").unwrap();
+let counter_code = std::fs::read_to_string("../tutorials/masm/accounts/counter.masm").unwrap();
 
 // Compile the script with the counter contract code linked as a module
 // on the same `CodeBuilder` chain.
 let tx_script = client
     .code_builder()
-    .with_linked_module("external_contract::counter_contract", counter_code)
+    .with_linked_module("external_contract::counter_contract", &counter_code)
     .unwrap()
-    .compile_tx_script(script_code)
+    .compile_tx_script(&script_code)
     .unwrap();
 
 // Build a transaction request with the custom script
@@ -237,12 +282,13 @@ let tx_increment_request = TransactionRequestBuilder::new()
 
 // Execute and submit the transaction
 let tx_id = client
-    .submit_new_transaction(counter_contract.id(), tx_increment_request)
+    .submit_tutorial_transaction(counter_contract_id, tx_increment_request)
     .await
     .unwrap();
 
 println!(
-    "View transaction on MidenScan: https://testnet.midenscan.com/tx/{:?}",
+    "View transaction on MidenScan: {}/tx/{:?}",
+    network.explorer_url(),
     tx_id
 );
 
@@ -250,16 +296,18 @@ client.sync_state().await.unwrap();
 
 // Retrieve updated contract data to see the incremented counter
 let account = client
-    .get_account(counter_contract.id())
+    .get_account(counter_contract_id)
     .await
     .unwrap()
     .expect("counter contract not found");
-let counter_slot_name =
-    miden_client::account::StorageSlotName::new("miden::tutorials::counter")
-        .expect("valid slot name");
 println!(
     "counter contract storage: {:?}",
     account.storage().get_item(&counter_slot_name)
+);
+assert_eq!(
+    account.storage().get_item(&counter_slot_name).unwrap()[0],
+    count_before + miden_client::ONE,
+    "the imported counter must increment exactly once",
 );
 ```
 
@@ -268,24 +316,29 @@ println!(
 The final `src/main.rs` file should look like this:
 
 ```rust no_run
+use rust_client::TutorialClientExt;
 use std::{path::PathBuf, sync::Arc};
 
 use miden_client::{
+    ClientError,
     account::{AccountId, StorageSlotName},
     builder::ClientBuilder,
     keystore::FilesystemKeyStore,
-    rpc::{Endpoint, GrpcClient},
+    rpc::{GrpcClient, VerifyingRpcClient},
     transaction::TransactionRequestBuilder,
-    ClientError,
 };
 use miden_client_sqlite_store::ClientBuilderSqliteExt;
+use rust_client::TutorialNetwork;
 
 #[tokio::main]
 async fn main() -> Result<(), ClientError> {
     // Initialize client
-    let endpoint = Endpoint::testnet();
+    let network = TutorialNetwork::from_env()?;
+    let endpoint = network.endpoint();
     let timeout_ms = 10_000;
-    let rpc_client = Arc::new(GrpcClient::new(&endpoint, timeout_ms));
+    let rpc_client = Arc::new(VerifyingRpcClient::new(GrpcClient::new(
+        &endpoint, timeout_ms,
+    )));
 
     // Initialize keystore
     let keystore_path = PathBuf::from("./keystore");
@@ -297,7 +350,6 @@ async fn main() -> Result<(), ClientError> {
         .rpc(rpc_client)
         .sqlite_store(store_path)
         .authenticator(keystore.clone())
-        .in_debug_mode(true.into())
         .build()
         .await?;
 
@@ -309,9 +361,19 @@ async fn main() -> Result<(), ClientError> {
     // -------------------------------------------------------------------------
     println!("\n[STEP 1] Reading data from public state");
 
-    // Define the Counter Contract account id from counter contract deploy
-    let (_, counter_contract_id) =
-        AccountId::from_bech32("mtst1apcqs7aj3a2cf5t6pnsfy0p4ns7wl7sp").unwrap();
+    // Pass the account ID printed by `counter_contract_deploy` as the first argument, or via
+    // `MIDEN_COUNTER_ACCOUNT_ID`.
+    let counter_contract_bech32 = std::env::args()
+        .nth(1)
+        .or_else(|| std::env::var("MIDEN_COUNTER_ACCOUNT_ID").ok())
+        .expect("pass the counter account ID from counter_contract_deploy");
+    let (account_network, counter_contract_id) =
+        AccountId::from_bech32(&counter_contract_bech32).expect("invalid counter account ID");
+    assert_eq!(
+        account_network,
+        network.network_id(),
+        "counter account must match the selected tutorial network"
+    );
 
     client
         .import_account_by_id(counter_contract_id)
@@ -327,24 +389,30 @@ async fn main() -> Result<(), ClientError> {
         "Account details: {:?}",
         counter_contract.storage().slots().first().unwrap()
     );
+    let counter_slot_name =
+        StorageSlotName::new("miden::tutorials::counter").expect("valid slot name");
+    let count_before = counter_contract
+        .storage()
+        .get_item(&counter_slot_name)
+        .unwrap()[0];
 
     // -------------------------------------------------------------------------
     // STEP 2: Call the Counter Contract with a script
     // -------------------------------------------------------------------------
     println!("\n[STEP 2] Call the increment_count procedure in the counter contract");
 
-    // Load the MASM sources at compile time so the binary is independent of
-    // the working directory it is run from.
-    let script_code = include_str!("../masm/scripts/counter_script.masm");
-    let counter_code = include_str!("../masm/accounts/counter.masm");
+    // Read the MASM source from the tutorials repository.
+    let script_code =
+        std::fs::read_to_string("../tutorials/masm/scripts/counter_script.masm").unwrap();
+    let counter_code = std::fs::read_to_string("../tutorials/masm/accounts/counter.masm").unwrap();
 
     // Compile the script with the counter contract code linked as a module
     // on the same `CodeBuilder` chain.
     let tx_script = client
         .code_builder()
-        .with_linked_module("external_contract::counter_contract", counter_code)
+        .with_linked_module("external_contract::counter_contract", &counter_code)
         .unwrap()
-        .compile_tx_script(script_code)
+        .compile_tx_script(&script_code)
         .unwrap();
 
     // Build a transaction request with the custom script
@@ -355,12 +423,13 @@ async fn main() -> Result<(), ClientError> {
 
     // Execute and submit the transaction
     let tx_id = client
-        .submit_new_transaction(counter_contract.id(), tx_increment_request)
+        .submit_tutorial_transaction(counter_contract_id, tx_increment_request)
         .await
         .unwrap();
 
     println!(
-        "View transaction on MidenScan: https://testnet.midenscan.com/tx/{:?}",
+        "View transaction on MidenScan: {}/tx/{:?}",
+        network.explorer_url(),
         tx_id
     );
 
@@ -368,16 +437,18 @@ async fn main() -> Result<(), ClientError> {
 
     // Retrieve updated contract data to see the incremented counter
     let account = client
-        .get_account(counter_contract.id())
+        .get_account(counter_contract_id)
         .await
         .unwrap()
         .expect("counter contract not found");
-    let counter_slot_name =
-        miden_client::account::StorageSlotName::new("miden::tutorials::counter")
-            .expect("valid slot name");
     println!(
         "counter contract storage: {:?}",
         account.storage().get_item(&counter_slot_name)
+    );
+    assert_eq!(
+        account.storage().get_item(&counter_slot_name).unwrap()[0],
+        count_before + miden_client::ONE,
+        "the imported counter must increment exactly once",
     );
     Ok(())
 }
@@ -386,62 +457,32 @@ async fn main() -> Result<(), ClientError> {
 Run the following command to execute src/main.rs:
 
 ```bash
-cargo run --release
+TUTORIAL_NETWORK=testnet cargo run --release -- "$MIDEN_COUNTER_ACCOUNT_ID"
 ```
 
 The output of our program will look something like this depending on the current count value in the smart contract:
 
 ```text
-Client initialized successfully.
-Latest block: 242342
+Latest block: <block_number>
 
-[STEP 1] Building counter contract from public state
-count val: [0, 0, 0, 1]
-counter nonce: 1
+[STEP 1] Reading data from public state
+Account details: StorageSlot { ... content: Value(Word([1, 0, 0, 0])) }
 
 [STEP 2] Call the increment_count procedure in the counter contract
-Procedure 1: "0x92495ca54d519eb5e4ba22350f837904d3895e48d74d8079450f19574bb84cb6"
-Procedure 2: "0xecd7eb223a5524af0cc78580d96357b298bb0b3d33fe95aeb175d6dab9de2e54"
-number of procedures: 2
-Final script:
-begin
-    # => []
-    call.0xecd7eb223a5524af0cc78580d96357b298bb0b3d33fe95aeb175d6dab9de2e54
-end
-Stack state before step 1812:
-├──  0: 2
-├──  1: 0
-├──  2: 0
-├──  3: 0
-├──  4: 0
-├──  5: 0
-├──  6: 0
-├──  7: 0
-├──  8: 0
-├──  9: 0
-├── 10: 0
-├── 11: 0
-├── 12: 0
-├── 13: 0
-├── 14: 0
-├── 15: 0
-├── 16: 0
-├── 17: 0
-├── 18: 0
-└── 19: 0
-
-View transaction on MidenScan: https://testnet.midenscan.com/tx/0x8183aed150f20b9c26d4cb7840bfc92571ea45ece31116170b11cdff2649eb5c
-counter contract storage: Ok(RpoDigest([0, 0, 0, 2]))
+View transaction on MidenScan: https://testnet.midenscan.com/tx/<transaction_id>
+counter contract storage: Ok(Word([2, 0, 0, 0]))
 ```
 
 ### Running the example
 
-To run the full example, navigate to the `rust-client` directory in the [miden-tutorials](https://github.com/0xMiden/miden-tutorials/) repository and run this command:
+To run the checked-in example, return to the root of the [tutorials repository](https://github.com/0xMiden/tutorials/) and run:
 
 ```bash
 cd rust-client
-cargo run --release --bin counter_contract_increment
+TUTORIAL_NETWORK=testnet cargo run --release --bin counter_contract_increment -- "$MIDEN_COUNTER_ACCOUNT_ID"
 ```
+
+If `MIDEN_COUNTER_ACCOUNT_ID` is exported in your shell, you can omit `--` and the final argument.
 
 ### Continue learning
 

--- a/docs/src/rust-client/unauthenticated_note_how_to.md
+++ b/docs/src/rust-client/unauthenticated_note_how_to.md
@@ -7,23 +7,25 @@ sidebar_position: 9
 
 _Using unauthenticated notes for optimistic note consumption_
 
+For toolchain requirements and shared fee helpers, see the [Rust client setup](./index.md#running-the-v016-examples).
+
 ## Overview
 
-In this guide, we will explore how to leverage unauthenticated notes on Miden to settle transactions faster than the blocktime. Unauthenticated notes are essentially UTXOs that have not yet been fully committed into a block. This feature allows the notes to be created and consumed within the same block.
+In this guide, we supply a complete note to a consuming transaction before waiting for the note's inclusion proof. Such an input is unauthenticated: the node checks the dependency on its creation transaction. This lets a note be created and consumed within the same block, although confirmation still depends on block production.
 
-We construct a chain of transactions using the unauthenticated notes method on the transaction builder. Unauthenticated notes are also referred to as "unauthenticated notes" or "erasable notes". We also demonstrate how a note can be serialized and deserialized, highlighting the ability to transfer notes between client instances for asset transfers that can be settled between parties faster than the blocktime.
+We construct a chain with `TransactionRequestBuilder::build_consume_notes`, passing the complete `Note` without an inclusion proof. We also serialize and deserialize each note to demonstrate how its details could be sent between clients. The example uses one client for all accounts and waits for each transfer and consumption to confirm before beginning the next hop.
 
 For example, our demo creates a chain of unauthenticated note transactions:
 
 ```markdown
-Alice ➡ Bob ➡ Charlie ➡ Dave ➡ Eve ➡ Frank ➡ ...
+Alice ➡ Bob ➡ Charlie ➡ Dave ➡ Eve
 ```
 
 ## What we'll cover
 
 - **Introduction to Unauthenticated Notes:** Understand what unauthenticated notes are and how they differ from standard notes.
 - **Serialization Example:** See how to serialize and deserialize a note to demonstrate how notes can be propagated to client instances faster than the blocktime.
-- **Performance Insights:** Observe how unauthenticated notes can reduce transaction times dramatically.
+- **Confirmation and balances:** Check each transaction and verify the final balances after four transfers between five accounts.
 
 ## Step-by-step process
 
@@ -42,7 +44,7 @@ Alice ➡ Bob ➡ Charlie ➡ Dave ➡ Eve ➡ Frank ➡ ...
 4. **Minting and Transacting with Unauthenticated Notes:**
    - Mint tokens for one of the accounts (Alice) from the deployed faucet.
    - Create a note representing the minted tokens.
-   - Build and submit a transaction that uses the unauthenticated note via the "unauthenticated" method.
+   - Submit the note-creation transaction without waiting for confirmation, then pass the complete note to `.build_consume_notes(vec![note])`. This calls `input_notes` internally without extra execution arguments.
    - Serialize the note to demonstrate how it could be transferred to another client instance.
    - Consume the note in a subsequent transaction, effectively creating a chain of unauthenticated transactions.
 
@@ -50,73 +52,81 @@ Alice ➡ Bob ➡ Charlie ➡ Dave ➡ Eve ➡ Frank ➡ ...
    - Measure the time taken for each transaction iteration.
    - Sync the client state and print account balances to verify the transactions.
 
+## Set up the Rust project
+
+Start in the directory containing your `tutorials` clone and create a sibling Cargo project:
+
+```bash
+cargo new miden-unauthenticated-notes
+cd miden-unauthenticated-notes
+rustup override set 1.98.1
+cp ../tutorials/rust-client/Cargo.lock Cargo.lock
+```
+
+Keep the generated `[package]` section in `Cargo.toml`, replace its empty `[dependencies]` section with the following, and add the development profile. The path assumes the repository clone is named `tutorials`.
+
+```toml
+[dependencies]
+# Clone tutorials next to this Cargo project (see Rust client setup).
+rust-client = { path = "../tutorials/rust-client" }
+miden-client = { version = "=0.16.0", features = ["testing", "tonic"] }
+miden-client-sqlite-store = { version = "=0.16.0", package = "miden-client-sqlite-store" }
+miden-protocol = { version = "=0.16.0" }
+rand = { version = "0.10" }
+tokio = { version = "1.48", features = ["rt-multi-thread", "net", "macros", "fs"] }
+
+[profile.dev]
+opt-level = 2
+```
+
+Copy the complete Rust example below into `src/main.rs`. Run it from this new project's directory with `TUTORIAL_NETWORK=testnet cargo run --release`. The client creates `store.sqlite3` and `keystore/` here; keep both out of version control.
+
 ## Full Rust code example
 
 ```rust no_run
-use rand::RngCore;
+use rand::Rng;
+use rust_client::TutorialClientExt;
 use std::{path::PathBuf, sync::Arc};
-use tokio::time::{sleep, Duration, Instant};
+use tokio::time::{Duration, Instant};
 
 use miden_client::{
+    Client, ClientError,
     account::{
-        component::{
-            BasicWallet, BurnPolicyConfig, FungibleFaucet, MintPolicyConfig, PolicyRegistration,
-            TokenName, TokenPolicyManager,
-        },
         AccountBuilder, AccountType,
+        component::{
+            create_singlesig_user_fungible_faucet, BasicWallet, BurnPolicy, FungibleFaucet,
+            MintPolicy, TokenName, TokenPolicyManager,
+        },
     },
-    address::NetworkId,
-    asset::{AssetAmount, AssetCallbackFlag, AssetVaultKey, FungibleAsset, TokenSymbol},
-    auth::{AuthSchemeId, AuthSecretKey, AuthSingleSig},
+    asset::{AssetAmount, AssetId, FungibleAsset, TokenSymbol},
+    auth::{AuthSecretKey, AuthSingleSig},
     builder::ClientBuilder,
     keystore::{FilesystemKeyStore, Keystore},
-    note::{Note, NoteAttachments, NoteType, P2idNote},
-    rpc::{Endpoint, GrpcClient},
-    store::TransactionFilter,
-    transaction::{TransactionId, TransactionRequestBuilder, TransactionStatus},
+    note::{Note, NoteType, P2idNote},
+    rpc::{GrpcClient, VerifyingRpcClient},
+    transaction::{TransactionId, TransactionRequestBuilder},
     utils::{Deserializable, Serializable},
-    Client, ClientError,
 };
 use miden_client_sqlite_store::ClientBuilderSqliteExt;
+use rust_client::{FeeConfig, TutorialNetwork, fund_account_for_fees};
 
 /// Waits for a specific transaction to be committed.
 async fn wait_for_tx(
     client: &mut Client<FilesystemKeyStore>,
     tx_id: TransactionId,
 ) -> Result<(), ClientError> {
-    loop {
-        client.sync_state().await?;
-
-        // Check transaction status
-        let txs = client
-            .get_transactions(TransactionFilter::Ids(vec![tx_id]))
-            .await?;
-        let tx_committed = if !txs.is_empty() {
-            matches!(txs[0].status, TransactionStatus::Committed { .. })
-        } else {
-            false
-        };
-
-        if tx_committed {
-            println!("✅ transaction {} committed", tx_id.to_hex());
-            break;
-        }
-
-        println!(
-            "Transaction {} not yet committed. Waiting...",
-            tx_id.to_hex()
-        );
-        sleep(Duration::from_secs(2)).await;
-    }
-    Ok(())
+    rust_client::wait_for_transaction(client, tx_id).await
 }
 
 #[tokio::main]
 async fn main() -> Result<(), ClientError> {
     // Initialize client
-    let endpoint = Endpoint::testnet();
+    let network = TutorialNetwork::from_env()?;
+    let endpoint = network.endpoint();
     let timeout_ms = 10_000;
-    let rpc_client = Arc::new(GrpcClient::new(&endpoint, timeout_ms));
+    let rpc_client = Arc::new(VerifyingRpcClient::new(GrpcClient::new(
+        &endpoint, timeout_ms,
+    )));
 
     // Initialize keystore
     let keystore_path = PathBuf::from("./keystore");
@@ -128,12 +138,12 @@ async fn main() -> Result<(), ClientError> {
         .rpc(rpc_client)
         .sqlite_store(store_path)
         .authenticator(keystore.clone())
-        .in_debug_mode(true.into())
         .build()
         .await?;
 
     let sync_summary = client.sync_state().await.unwrap();
     println!("Latest block: {}", sync_summary.block_num);
+    let fee_config = FeeConfig::from_client(&client, network).await?;
 
     //------------------------------------------------------------
     // STEP 1: Deploy a fungible faucet
@@ -153,38 +163,40 @@ async fn main() -> Result<(), ClientError> {
     let max_supply = AssetAmount::new(1_000_000).unwrap();
 
     // Build the account
-    let faucet_account = AccountBuilder::new(init_seed)
-        .account_type(AccountType::Public)
-        .with_auth_component(AuthSingleSig::new(key_pair.public_key().to_commitment(), AuthSchemeId::Falcon512Poseidon2))
-        .with_component(
-            FungibleFaucet::builder()
-                .name(TokenName::new("MID").unwrap())
-                .symbol(symbol)
-                .decimals(decimals)
-                .max_supply(max_supply)
-                .build()
-                .unwrap(),
-        )
-        .with_components(
-            TokenPolicyManager::new()
-                .with_mint_policy(MintPolicyConfig::AllowAll, PolicyRegistration::Active)
-                .unwrap()
-                .with_burn_policy(BurnPolicyConfig::AllowAll, PolicyRegistration::Active)
-                .unwrap(),
-        )
+    let faucet = FungibleFaucet::builder()
+        .name(TokenName::new("MID").unwrap())
+        .symbol(symbol)
+        .decimals(decimals)
+        .max_supply(max_supply)
         .build()
         .unwrap();
+    let policies = TokenPolicyManager::builder()
+        .active_mint_policy(MintPolicy::allow_all())
+        .active_burn_policy(BurnPolicy::allow_all())
+        .build();
+    let faucet_account = create_singlesig_user_fungible_faucet(
+        init_seed,
+        faucet,
+        AuthSingleSig::from_public_key(key_pair.public_key()),
+        policies,
+        AccountType::Public,
+    )
+    .unwrap();
 
     // Add the faucet to the client
     client.add_account(&faucet_account, false).await?;
 
     println!(
         "Faucet account ID: {}",
-        faucet_account.id().to_bech32(NetworkId::Testnet)
+        faucet_account.id().to_bech32(network.network_id())
     );
 
     // Add the key pair to the keystore
-    keystore.add_key(&key_pair, faucet_account.id()).await.unwrap();
+    keystore
+        .add_key(&key_pair, faucet_account.id())
+        .await
+        .unwrap();
+    fund_account_for_fees(&mut client, faucet_account.id(), &fee_config).await?;
 
     // Resync to show newly deployed faucet
     tokio::time::sleep(Duration::from_secs(2)).await;
@@ -196,7 +208,7 @@ async fn main() -> Result<(), ClientError> {
     println!("\n[STEP 2] Creating new accounts");
 
     let mut accounts = vec![];
-    let number_of_accounts = 2;
+    let number_of_accounts = 5;
 
     for i in 0..number_of_accounts {
         let mut init_seed = [0_u8; 32];
@@ -206,7 +218,7 @@ async fn main() -> Result<(), ClientError> {
 
         let account = AccountBuilder::new(init_seed)
             .account_type(AccountType::Public)
-            .with_auth_component(AuthSingleSig::new(key_pair.public_key().to_commitment(), AuthSchemeId::Falcon512Poseidon2))
+            .with_component(AuthSingleSig::from_public_key(key_pair.public_key()))
             .with_component(BasicWallet)
             .build()
             .unwrap();
@@ -215,12 +227,13 @@ async fn main() -> Result<(), ClientError> {
         println!(
             "account id {:?}: {}",
             i,
-            account.id().to_bech32(NetworkId::Testnet)
+            account.id().to_bech32(network.network_id())
         );
         client.add_account(&account, true).await?;
 
         // Add the key pair to the keystore
         keystore.add_key(&key_pair, account.id()).await.unwrap();
+        fund_account_for_fees(&mut client, account.id(), &fee_config).await?;
     }
 
     // For demo purposes, Alice is the first account.
@@ -243,7 +256,7 @@ async fn main() -> Result<(), ClientError> {
         .unwrap();
 
     let tx_id = client
-        .submit_new_transaction(faucet_account.id(), transaction_request)
+        .submit_tutorial_transaction(faucet_account.id(), transaction_request)
         .await?;
     println!("Minted tokens. TX: {:?}", tx_id);
 
@@ -251,16 +264,17 @@ async fn main() -> Result<(), ClientError> {
     wait_for_tx(&mut client, tx_id).await?;
 
     // Get the minted note and consume it
-    let consumable_notes = client.get_consumable_notes(Some(alice.id())).await?;
+    let consumable_notes = client
+        .get_consumable_tutorial_notes(Some(alice.id()))
+        .await?;
 
     if let Some((note_record, _)) = consumable_notes.first() {
         let note: Note = note_record.clone().try_into()?;
-        let transaction_request = TransactionRequestBuilder::new()
-            .build_consume_notes(vec![note])
-            .unwrap();
+        let transaction_request =
+            TransactionRequestBuilder::new().build_consume_notes(vec![note])?;
 
         let consume_tx_id = client
-            .submit_new_transaction(alice.id(), transaction_request)
+            .submit_tutorial_transaction(alice.id(), transaction_request)
             .await?;
         println!("Consumed minted note. TX: {:?}", consume_tx_id);
 
@@ -277,10 +291,13 @@ async fn main() -> Result<(), ClientError> {
     for i in 0..number_of_accounts - 1 {
         let loop_start = Instant::now();
         println!("\nunauthenticated tx {:?}", i + 1);
-        println!("sender: {}", accounts[i].id().to_bech32(NetworkId::Testnet));
+        println!(
+            "sender: {}",
+            accounts[i].id().to_bech32(network.network_id())
+        );
         println!(
             "target: {}",
-            accounts[i + 1].id().to_bech32(NetworkId::Testnet)
+            accounts[i + 1].id().to_bech32(network.network_id())
         );
 
         // Time the creation of the p2id note
@@ -295,26 +312,30 @@ async fn main() -> Result<(), ClientError> {
             NoteType::Public
         };
 
-        let p2id_note = P2idNote::create(
-            accounts[i].id(),
-            accounts[i + 1].id(),
-            vec![fungible_asset_send_amount.into()],
-            note_type,
-            NoteAttachments::empty(),
-            client.rng(),
-        )
-        .unwrap();
+        let p2id_note: Note = P2idNote::builder()
+            .sender(accounts[i].id())
+            .target(accounts[i + 1].id())
+            .asset(fungible_asset_send_amount)
+            .note_type(note_type)
+            .generate_serial_number(client.rng())
+            .build()
+            .unwrap()
+            .into();
+
+        let output_note = p2id_note.clone();
 
         // Time transaction request building
         let transaction_request = TransactionRequestBuilder::new()
-            .own_output_notes(vec![p2id_note.clone()])
+            .own_output_notes(vec![output_note])
             .build()
             .unwrap();
 
-        let tx_id = client
+        // Do not wait for inclusion: the receiver is given the complete note below.
+        client.sync_state().await?;
+        let send_tx_id = client
             .submit_new_transaction(accounts[i].id(), transaction_request)
             .await?;
-        println!("Created note. TX: {:?}", tx_id);
+        println!("Created note. TX: {:?}", send_tx_id);
 
         // Note serialization/deserialization
         // This demonstrates how you could send the serialized note to another client instance
@@ -322,17 +343,17 @@ async fn main() -> Result<(), ClientError> {
         let deserialized_p2id_note = Note::read_from_bytes(&serialized).unwrap();
 
         // Time consume note request building
-        let consume_note_request = TransactionRequestBuilder::new()
-            .input_notes([(deserialized_p2id_note, None)])
-            .build()
-            .unwrap();
+        let consume_note_request =
+            TransactionRequestBuilder::new().build_consume_notes(vec![deserialized_p2id_note])?;
 
         let tx_id = client
-            .submit_new_transaction(accounts[i + 1].id(), consume_note_request)
+            .submit_tutorial_transaction(accounts[i + 1].id(), consume_note_request)
             .await?;
+        rust_client::wait_for_transaction(&mut client, send_tx_id).await?;
 
         println!(
-            "Consumed Note Tx on MidenScan: https://testnet.midenscan.com/tx/{:?}",
+            "Consumed Note Tx on MidenScan: {}/tx/{:?}",
+            network.explorer_url(),
             tx_id
         );
         println!(
@@ -350,19 +371,28 @@ async fn main() -> Result<(), ClientError> {
     // Final resync and display account balances
     tokio::time::sleep(Duration::from_secs(3)).await;
     client.sync_state().await?;
-    for account in accounts.clone() {
-        let new_account = client.get_account(account.id()).await.unwrap().expect("account not found");
+    for (index, account) in accounts.iter().enumerate() {
+        let new_account = client.get_account(account.id()).await.unwrap().unwrap();
         let balance = new_account
             .vault()
-            .get_balance(AssetVaultKey::new_fungible(
-                faucet_account.id(),
-                AssetCallbackFlag::Disabled,
-            ))
+            .get_balance(AssetId::new_fungible(faucet_account.id()))
             .unwrap();
         println!(
             "Account: {} balance: {}",
-            account.id().to_bech32(NetworkId::Testnet),
+            account.id().to_bech32(network.network_id()),
             balance
+        );
+        let expected = if index == 0 {
+            80
+        } else if index == accounts.len() - 1 {
+            20
+        } else {
+            0
+        };
+        assert_eq!(
+            balance.as_u64(),
+            expected,
+            "unexpected transfer-chain balance"
         );
     }
 
@@ -370,13 +400,13 @@ async fn main() -> Result<(), ClientError> {
 }
 ```
 
-The output of our program will look something like this:
+The following is an abbreviated output. IDs and timings vary; each measured iteration includes confirmation polling, and funding logs are omitted:
 
 ```text
-Latest block: 227040
+Latest block: <current_block_number>
 
 [STEP 1] Deploying a new fungible faucet.
-Faucet account ID: <faucet_id>
+Faucet account ID: <faucet_testnet_account_id>
 
 [STEP 2] Creating new accounts
 account id 0: <account_0_id>
@@ -384,101 +414,71 @@ account id 1: <account_1_id>
 account id 2: <account_2_id>
 account id 3: <account_3_id>
 account id 4: <account_4_id>
-account id 5: <account_5_id>
-account id 6: <account_6_id>
-account id 7: <account_7_id>
-account id 8: <account_8_id>
-account id 9: <account_9_id>
 
 [STEP 3] Mint tokens
 Minting tokens for Alice...
+Minted tokens. TX: <transaction_id>
+Consumed minted note. TX: <transaction_id>
 
 [STEP 4] Create unauthenticated note tx chain
 
 unauthenticated tx 1
 sender: <account_0_id>
 target: <account_1_id>
-Consumed Note Tx on MidenScan: https://testnet.midenscan.com/tx/0x31f48117c645c5b4ccff78ef356bad764798d4f207925e492ebbae1b86ef4f55
-Total time for loop iteration 0: 1.952243542s
+Created note. TX: <send_transaction_id>
+Transaction committed: <consume_transaction_id>
+Transaction committed: <send_transaction_id>
+Consumed Note Tx on MidenScan: https://testnet.midenscan.com/tx/<consume_transaction_id>
+Total time for loop iteration 0: <elapsed_time>
 
 unauthenticated tx 2
 sender: <account_1_id>
 target: <account_2_id>
-Consumed Note Tx on MidenScan: https://testnet.midenscan.com/tx/0x45b4c62c6e8e79a1c7200d1c84dc6304a88debd37b20b069dd739498827354c1
-Total time for loop iteration 1: 2.091625458s
+Created note. TX: <send_transaction_id>
+Transaction committed: <consume_transaction_id>
+Transaction committed: <send_transaction_id>
+Consumed Note Tx on MidenScan: https://testnet.midenscan.com/tx/<consume_transaction_id>
+Total time for loop iteration 1: <elapsed_time>
 
 unauthenticated tx 3
 sender: <account_2_id>
 target: <account_3_id>
-Consumed Note Tx on MidenScan: https://testnet.midenscan.com/tx/0xb2241e10df8f6f891b910975a3b4f4fd47657c47de164138300d683cfca5dd61
-Total time for loop iteration 2: 1.846021291s
+Created note. TX: <send_transaction_id>
+Transaction committed: <consume_transaction_id>
+Transaction committed: <send_transaction_id>
+Consumed Note Tx on MidenScan: https://testnet.midenscan.com/tx/<consume_transaction_id>
+Total time for loop iteration 2: <elapsed_time>
 
 unauthenticated tx 4
 sender: <account_3_id>
 target: <account_4_id>
-Consumed Note Tx on MidenScan: https://testnet.midenscan.com/tx/0xd3ea6fa1da6c317f055ac4b069388d93b88d526039e01531879e75598e0f8cff
-Total time for loop iteration 3: 1.877627958s
+Created note. TX: <send_transaction_id>
+Transaction committed: <consume_transaction_id>
+Transaction committed: <send_transaction_id>
+Consumed Note Tx on MidenScan: https://testnet.midenscan.com/tx/<consume_transaction_id>
+Total time for loop iteration 3: <elapsed_time>
 
-unauthenticated tx 5
-sender: <account_4_id>
-target: <account_5_id>
-Consumed Note Tx on MidenScan: https://testnet.midenscan.com/tx/0x6098638ec0ff7331432c037331ee7372977abe20af5c56315985fd314e21548d
-Total time for loop iteration 4: 1.884586875s
-
-unauthenticated tx 6
-sender: <account_5_id>
-target: <account_6_id>
-Consumed Note Tx on MidenScan: https://testnet.midenscan.com/tx/0x8258292e49e0cfdd96603450c2de6738afecb1e7482ede0fb68ea375e884e1d8
-Total time for loop iteration 5: 1.886505875s
-
-unauthenticated tx 7
-sender: <account_6_id>
-target: <account_7_id>
-Consumed Note Tx on MidenScan: https://testnet.midenscan.com/tx/0x9e0f84e00a9393bf6e5f224d55ccdf8bd0ef32ee20c3299e2dfccf1771001dfd
-Total time for loop iteration 6: 2.095149458s
-
-unauthenticated tx 8
-sender: <account_7_id>
-target: <account_8_id>
-Consumed Note Tx on MidenScan: https://testnet.midenscan.com/tx/0xa9db6445dfaa44ccf9dd52bf4cd8d9057946571ccb5299a7a56c59faf2ed2093
-Total time for loop iteration 7: 1.935587291s
-
-unauthenticated tx 9
-sender: <account_8_id>
-target: <account_9_id>
-Consumed Note Tx on MidenScan: https://testnet.midenscan.com/tx/0xba4bb4ae3c7aaf949cdd3be8c9ea52169f958e7dca8e9d4541fd5ac939393e41
-Total time for loop iteration 8: 1.964682833s
-
-Total execution time for unauthenticated note txs: 17.534611542s
-blocks: [BlockNumber(227047), BlockNumber(227047), BlockNumber(227047), BlockNumber(227047), BlockNumber(227047), BlockNumber(227047), BlockNumber(227047), BlockNumber(227047), BlockNumber(227047)]
+Total execution time for unauthenticated note txs: <elapsed_time>
 Account: <account_0_id> balance: 80
 Account: <account_1_id> balance: 0
 Account: <account_2_id> balance: 0
 Account: <account_3_id> balance: 0
-Account: <account_4_id> balance: 0
-Account: <account_5_id> balance: 0
-Account: <account_6_id> balance: 0
-Account: <account_7_id> balance: 0
-Account: <account_8_id> balance: 0
-Account: <account_9_id> balance: 20
+Account: <account_4_id> balance: 20
 ```
 
 ## Conclusion
 
-Unauthenticated notes on Miden offer a powerful mechanism for achieving faster asset settlements by allowing notes to be both created and consumed within the same block. In this guide, we walked through:
+This example builds, serializes, and consumes complete notes through `build_consume_notes` without first waiting for their inclusion proofs. It confirms four transfers across five accounts and checks the tutorial-asset balances `[80, 0, 0, 0, 20]`; each account's native fee balance is separate.
 
-- **Minting and Transacting with Unauthenticated Notes:** Building, serializing, and consuming notes quickly using the Miden client's "unauthenticated note" method.
-- **Performance Observations:** Measuring and demonstrating how unauthenticated notes enable assets to be sent faster than the blocktime.
-
-By following this guide, you should now have a clear understanding of how to build and deploy high-performance transactions using unauthenticated notes on Miden. Unauthenticated notes are the ideal approach for applications like central limit order books (CLOBs) or other DeFi platforms where transaction speed is critical.
+Applications can use this pattern to submit dependent transactions before the notes are committed. The node must still accept the creation transaction for its dependent consumption to settle.
 
 ### Running the example
 
-To run the unauthenticated note transfer example, navigate to the `rust-client` directory in the [miden-tutorials](https://github.com/0xMiden/miden-tutorials/) repository and run this command:
+From the root of your `tutorials` clone, run the checked-in example:
 
 ```bash
 cd rust-client
-cargo run --release --bin unauthenticated_note_transfer
+TUTORIAL_NETWORK=testnet cargo run --release --bin unauthenticated_note_transfer
 ```
 
 ### Continue learning

--- a/docs/src/web-client/bridging_with_epoch_tutorial.md
+++ b/docs/src/web-client/bridging_with_epoch_tutorial.md
@@ -5,13 +5,13 @@ sidebar_position: 9
 
 # Bridging Miden to and from EVM with Epoch
 
-_Move assets between Miden and Sepolia testnet through the Epoch protocol intent SDK, without writing a custom bridge_
+_Move assets between Miden testnet and Sepolia testnet through the Epoch protocol intent SDK, without writing a custom bridge_
 
 ## Overview
 
-This is a guided tour of the runnable reference app under [`examples/bridging-app/`](https://github.com/0xMiden/tutorials/tree/main/examples/bridging-app), which bridges fungible tokens between Miden and an EVM chain (Sepolia testnet) in both directions through the [Epoch protocol](https://epochprotocol.xyz/) intent SDK. Clone and run the app, then read the steps below as annotations on the integration points you'd port into your own Miden frontend. Every fenced code block is a verbatim slice of the app; the file and line range above each block points to the source.
+This is a guided tour of the reference app under [`examples/bridging-app/`](https://github.com/0xMiden/tutorials/tree/main/examples/bridging-app), which bridges fungible tokens between Miden testnet and Sepolia through the [Epoch protocol](https://epochprotocol.xyz/) intent SDK. Clone and run the app, then read the steps below as annotations on the integration points you'd port into your own Miden frontend. Every fenced code block is a verbatim slice of the app; the file and line range above each block points to the source.
 
-> **When to use Epoch vs Agglayer.** This tutorial uses **Epoch** because it is the only Miden bridge with a working TypeScript SDK, EVM-wallet integration, and broad chain coverage today — Epoch's Compact contract is deployed on Ethereum, Polygon, Optimism, Arbitrum, Base (mainnet) and on Sepolia plus six other EVM testnets. If your app is **authored in Rust/MASM, needs Polygon CDK ecosystem compatibility, or settles on a Polygon Agglayer-connected rollup**, the Agglayer protocol surface ships in-tree at [`protocol/crates/miden-agglayer/SPEC.md`](https://github.com/0xMiden/protocol/blob/next/crates/miden-agglayer/SPEC.md); Miden testnet ↔ Sepolia bridging via Agglayer went live on 2026-04-24.
+Live settlement requires an Epoch allocator and asset faucet deployed on the selected Miden network and compatible with v0.16. Devnet is available for explicit checks by setting `VITE_MIDEN_NETWORK`, `VITE_MIDEN_RPC_URL`, and `VITE_MIDEN_PROVER` to `devnet` with a matching allocator and faucet.
 
 Stack: Vite + React 19 + TypeScript, `@miden-sdk/react`, `@epoch-protocol/epoch-intents-sdk`, [RainbowKit](https://www.rainbowkit.com/) + [wagmi](https://wagmi.sh/) + [viem](https://viem.sh/).
 
@@ -20,14 +20,14 @@ Stack: Vite + React 19 + TypeScript, `@miden-sdk/react`, `@epoch-protocol/epoch-
 - Wire the Epoch SDK against a wagmi `walletClient`, including the chain-id override for Miden-source intents.
 - Build a Miden → EVM bridge: reverse-quote, sign a P2IDE note via the MidenFi wallet adapter, submit the intent, and poll for settlement.
 - Build the reverse EVM → Miden bridge: deposit an ERC-20 into Epoch's Compact contract and receive a P2ID note on Miden.
-- A `EpochIntentSDK` API reference card with all 11 public methods.
+- An `EpochIntentSDK` API reference card for quoting, settlement, and recovery.
 - Inline pitfalls — the eleven traps every Epoch integration hits before the first successful round-trip.
 
 ## Prerequisites
 
 You need three things to follow along.
 
-1. The reference app, cloned from this repo. The bridging-specific layer (Epoch SDK wiring, wagmi/RainbowKit + viem, intent forms, status panels) lives in `examples/bridging-app/`; `yarn create miden-app` (≥ 1.0.7) is the Miden + Vite + WASM scaffold it started from. Clone the repo, `cd examples/bridging-app`, then `cp .env.example .env` inside that directory and fill in: `VITE_RAINBOWKIT_PROJECT_ID` (a [WalletConnect Cloud](https://cloud.walletconnect.com/) project id — required), `VITE_ALLOCATOR_URL` (default `https://testnet-dev.epochprotocol.xyz`), `VITE_MIDEN_RPC_URL` (default `testnet`), `VITE_MIDEN_PROVER` (default `testnet`), and the optional `VITE_MIDENSCAN_URL`. See the [setup guide](./setup_guide.md) if this is your first Miden frontend.
+1. The reference app, cloned from this repo. The bridging-specific layer (Epoch SDK wiring, wagmi/RainbowKit + viem, intent forms, status panels) lives in `examples/bridging-app/`; `yarn create miden-app` (≥ 1.0.7) is the Miden + Vite + WASM scaffold it started from. Clone the repo, `cd examples/bridging-app`, then `cp .env.example .env` inside that directory and fill in: `VITE_RAINBOWKIT_PROJECT_ID` (a [WalletConnect Cloud](https://cloud.walletconnect.com/) project id — required), `VITE_ALLOCATOR_URL` (an Epoch allocator compatible with the pinned SDK), `VITE_MIDEN_NETWORK` (default `testnet`), optional `VITE_MIDEN_RPC_URL` and `VITE_MIDEN_PROVER` overrides, `VITE_MIDEN_USDC_FAUCET_ID` from the selected allocator deployment, and the optional `VITE_MIDENSCAN_URL`. The wallet network, RPC, faucet, and allocator must agree. Keep native MIDEN tokens in the wallet to pay both collateral and note-consumption fees. See the [setup guide](./setup_guide.md) if this is your first Miden frontend.
 
 2. Two wallets: an EVM wallet supported by [RainbowKit](https://www.rainbowkit.com/) (MetaMask, Rabby, Coinbase Wallet, …) and the [MidenFi browser extension](https://chromewebstore.google.com/detail/miden-wallet/ablmompanofnodfdkgchkpmphailefpb) for signing P2IDE notes on Miden.
 
@@ -90,7 +90,7 @@ The snippet below sits inside the `useEpochIntent` hook — `walletClient` is `u
 ```
 
 :::caution Do not follow the package README
-The npm package ships a `# Compact SDK` README that documents a different SDK and a different surface. Treat `EpochIntentSDK`'s exported method names from `dist/index.d.ts` as the source of truth — the [API Reference Card](#api-reference-card) below lists them.
+The npm package ships a `# Compact SDK` README that documents a different SDK and a different surface. Treat `EpochIntentSDK`'s exported method names from `dist/sdk/epoch-intent-sdk.d.ts` as the source of truth — the [API Reference Card](#api-reference-card) below lists them.
 :::
 
 The `useWithdrawIntent` hook keeps `walletClient.chain.id` untouched — the EVM → Miden direction uses the real Sepolia chain id (`11155111`).
@@ -99,9 +99,9 @@ The `useWithdrawIntent` hook keeps `walletClient.chain.id` untouched — the EVM
 
 A Miden → EVM bridge runs four stages: `getTaskData` (the allocator computes a quote envelope), `getIntentQuote` (price discovery), `solveIntent` (the user signs a P2IDE note on Miden via the wallet adapter callback), and a 5-second polling loop against `getIntentStatus` until the solver lands the EVM transfer. The reference app's `buildEpochTaskDataParams` produces the envelope and computes `midenReclaimHeight` at the call site so it stays relative to the current Miden chain tip (Pitfalls row 4 has the technical reason).
 
-**From `examples/bridging-app/src/services/epoch-bridge.ts` (lines 141–173):**
+**From `examples/bridging-app/src/services/epoch-bridge.ts` (lines 133–165):**
 
-<!-- source: examples/bridging-app/src/services/epoch-bridge.ts:141-173 -->
+<!-- source: examples/bridging-app/src/services/epoch-bridge.ts:133-165 -->
 
 ```typescript
   // Reclaim height must come from the call site as `currentMidenBlock + N`.
@@ -139,48 +139,51 @@ A Miden → EVM bridge runs four stages: `getTaskData` (the allocator computes a
   };
 ```
 
-Once the quote returns and the user clicks **Confirm & sign**, the `createMidenP2IDNote` callback fires. The reference app's callback uses `useMidenFiWallet().requestSend` to construct an explicitly `'public'` P2IDE `SendTransaction`, guards the amount under `Number.MAX_SAFE_INTEGER` (the wallet adapter's `SendTransaction` constructor takes a `number`, not a `bigint`), and awaits a 120-second `waitForTransaction(txId, 120_000)` to read the output note id.
+Once the quote returns and the user clicks **Confirm & sign**, `createMidenP2IDENote` receives the allocator, relative recall window, and mandate-binding attachment from Epoch. The app builds a public P2IDE note containing those exact values, prepares a fee-aware custom request, and asks the wallet to sign it with `requestTransaction`. Amounts remain `bigint`. After confirmation it locates the exact collateral note ID, excluding any `TX_FEE` output.
 
-**From `examples/bridging-app/src/components/crosschain/IntentForm.tsx` (lines 200–243):**
+**From `examples/bridging-app/src/components/crosschain/IntentForm.tsx` (lines 202–248):**
 
-<!-- source: examples/bridging-app/src/components/crosschain/IntentForm.tsx:200-243 -->
+<!-- source: examples/bridging-app/src/components/crosschain/IntentForm.tsx:202-248 -->
 
 ```typescript
-    const createMidenP2IDNote: SolveIntentParams['createMidenP2IDNote'] = async (
+    const createMidenP2IDENote: SolveIntentParams['createMidenP2IDENote'] = async (
       faucetIdParam,
       amountParam,
       allocatorId,
+      recallBlocks,
+      bindingAttachmentFelts,
     ) => {
       setConfirmStatus('Resource lock required — creating P2IDE note on Miden…');
       try {
         if (!midenAccountId) {
           throw new Error('Missing Miden account id');
         }
-        if (!requestSend) {
-          throw new Error('Miden wallet adapter is not connected');
+        if (!requestTransaction || !waitForTransaction || !client) {
+          throw new Error('Connect a Miden wallet that supports custom transactions and confirmation');
         }
 
-        const normalizedAmount = BigInt(amountParam);
-        if (normalizedAmount > BigInt(Number.MAX_SAFE_INTEGER)) {
-          throw new Error('Amount too large for wallet adapter send');
-        }
-
-        const payload = new SendTransaction(
-          midenAccountId,
-          allocatorId,
-          faucetIdParam,
-          'public',
-          Number(normalizedAmount),
+        const { request, expectedNoteId } = await runExclusive(async () => {
+          const head = await client.syncState();
+          const note = createEpochCollateralNote({
+            sender: midenAccountId, allocator: allocatorId, faucet: faucetIdParam,
+            amount: BigInt(amountParam), currentBlock: head.blockNum(),
+            recallBlocks, bindingAttachmentFelts,
+          });
+          const builder = await client.feeAwareTransactionRequestBuilder(AccountId.fromHex(midenAccountId));
+          return {
+            expectedNoteId: note.id().toString(),
+            request: builder.withOwnOutputNotes(new NoteArray([note])).build(),
+          };
+        });
+        const txId = await requestTransaction(
+          Transaction.createCustomTransaction(midenAccountId, allocatorId, request),
         );
-        const txId = await requestSend(payload);
 
-        // Prefer adapter waitForTransaction to get the output note id.
-        if (!waitForTransaction) {
-          throw new Error('Miden wallet adapter is missing waitForTransaction');
-        }
+        // Wait for the wallet to confirm the collateral before submitting it to Epoch.
         const finalized = await waitForTransaction(txId, 120_000);
-        const first = finalized.outputNotes?.[0];
-        const noteId = first ? first.id().toString() : '';
+        // A fee-paying transaction also creates a TX_FEE note. Match our exact
+        // collateral note instead of assuming outputNotes[0] is the payment.
+        const noteId = finalized.outputNotes?.find(note => note.id().toString() === expectedNoteId)?.id().toString();
         if (!noteId) {
           throw new Error(`Could not read output note id for tx ${txId}`);
         }
@@ -192,7 +195,7 @@ Once the quote returns and the user clicks **Confirm & sign**, the `createMidenP
     };
 ```
 
-Success is signalled by the 5-second polling loop: `getIntentStatus` returns an `IntentTransactionStatus[]`, which the app reduces into the composite `IntentFlowStatus`. The forward bridge is settled once the destination chain reports a terminal-OK row (`evmCompleted`) and the synthetic Miden row carries a terminal `midenStatus` — the EVM transfer landed and the allocator consumed the P2IDE note. That reducer is destination-chain aware: it filters status rows to the chain the user selected, never reports completion while any destination-chain row is still `pending`, and takes the last destination-chain success — so an intermediate allocator/Compact row is never mistaken for the final settlement. The Pitfalls section below catalogues the gotchas this step inherits (public note type, awaiting `waitForTransaction`, advisory `midenFaucetDecimals`, the `Number.MAX_SAFE_INTEGER` guard).
+Success is signalled by the 5-second polling loop: `getIntentStatus` returns an `IntentTransactionStatus[]`, which the app reduces into the composite `IntentFlowStatus`. The forward bridge is settled once the destination chain reports a terminal-OK row (`evmCompleted`) and the synthetic Miden row carries a terminal `midenStatus` — the EVM transfer landed and the allocator consumed the P2IDE note. That reducer is destination-chain aware: it filters status rows to the chain the user selected, never reports completion while any destination-chain row is still `pending`, and takes the last destination-chain success — so an intermediate allocator/Compact row is never mistaken for the final settlement. The Pitfalls section below catalogues the gotchas this step inherits (public note type, awaiting `waitForTransaction`, advisory `midenFaucetDecimals`, the exact collateral-note ID check).
 
 ## Step 3: EVM → Miden bridge
 
@@ -202,9 +205,9 @@ The reverse direction lives in `buildEVMToMidenTaskDataParams` + `useWithdrawInt
 The Step 3 reverse quote folds a route fee into the required deposit, so a Step 2 bridge of exactly 1 USDC won't cover a 1-USDC reverse — the quote asks for ~1.01 USDC and MetaMask flags `depositERC20AndRegister` as likely to fail (the `approve` lands first; rejecting the deposit is recoverable). Set Step 2's `min output` to about `2e18` for headroom, or run a second forward bridge before retrying.
 :::
 
-**From `examples/bridging-app/src/services/epoch-bridge.ts` (lines 224–245):**
+**From `examples/bridging-app/src/services/epoch-bridge.ts` (lines 216–237):**
 
-<!-- source: examples/bridging-app/src/services/epoch-bridge.ts:224-245 -->
+<!-- source: examples/bridging-app/src/services/epoch-bridge.ts:216-237 -->
 
 ```typescript
   const taskDataParams = {
@@ -234,7 +237,7 @@ The Step 3 reverse quote folds a route fee into the required deposit, so a Step 
 `solveIntent({ ..., collateralType: CollateralType.EVM })` then walks the user's wallet through an ERC-20 `approve` (only on the first deposit of a given token) and `depositERC20AndRegister` / `depositNativeAndRegister` against Epoch's [Compact](https://docs.epochprotocol.xyz/epoch-miden-integration/integration-guide) contract on Sepolia. The intent nonce extracted from the solve result drives the same 5-second status poll as the forward direction.
 
 :::caution Forced-withdrawal preflight
-If the user cancelled a prior EVM → Miden intent on the same Compact deposit id, the next intent will revert. Call `sdk.disableForcedWithdrawal({ ... })` first; the SDK error message names the deposit id when this preflight is required.
+If the user cancelled a prior EVM → Miden intent on the same Compact deposit id, the next intent will revert. Call `sdk.disableForcedWithdrawal(depositId)` first; the SDK error message names the deposit id when this preflight is required.
 :::
 
 :::caution The Withdraw token is Epoch's test ERC-20, not Circle's USDC
@@ -243,41 +246,41 @@ The "USDC" the Withdraw form lists is Epoch's test token (`0x2BB4FfD7…`), not 
 
 ## Step 4: The bridged P2ID note is consumed by your wallet
 
-Step 3's allocator delivers its output as a **P2ID note** addressed to your Miden account, not as a vault credit. In Miden's actor model, a note must be _consumed_ in a transaction before it becomes spendable balance. The Miden Wallet consumes incoming P2ID notes when it detects them, so the bridged funds appear as wallet balance within seconds and are immediately usable as the source for another Miden → EVM bridge. The reference app's `WithdrawConsume` component keeps this step informational: it shows the delivered note ID and links to Midenscan so you can confirm settlement.
+Step 3's allocator delivers its output as a **P2ID note** addressed to your Miden account, not as a vault credit. The note must be consumed in a transaction before it becomes spendable. Wallet auto-consumption depends on the installed wallet's configuration and sufficient native MIDEN for fees: a USDC-only note cannot pay that native fee. The reference app links the delivered note to Midenscan; confirm its consumption and the final wallet balance before treating the bridge as complete.
 
 ## API Reference Card
 
-Most apps only touch four methods (`getTaskData`, `getIntentQuote`, `solveIntent`, `getIntentStatus`); the rest cover recovery and read-only queries. Sources cite `dist/index.d.ts` from `@epoch-protocol/epoch-intents-sdk@1.0.23`.
+Most apps only touch four methods. The selected signatures below come from `dist/sdk/epoch-intent-sdk.d.ts` in the pinned `@epoch-protocol/epoch-intents-sdk@1.0.38`.
 
-| Method                      | Signature (abridged)                                                     | Use it to                                                              | Source               |
-| --------------------------- | ------------------------------------------------------------------------ | ---------------------------------------------------------------------- | -------------------- |
-| `getTaskData`               | `(params: GetTaskDataParams) => Promise<{ taskTypeString, intentData }>` | Construct the SIO envelope before quoting                              | `dist/index.d.ts:11` |
-| `solveIntent`               | `(params: SolveIntentParams) => Promise<SolveIntentResult>`              | Submit the intent + run the optional Miden P2ID note callback          | `dist/index.d.ts:12` |
-| `getIntentQuote`            | `(params: GetIntentQuoteParams) => Promise<IntentQuoteResult>`           | Reverse-quote (`tokenInAmount: '0'`) or forward quote                  | `dist/index.d.ts:13` |
-| `retryIntentSolve`          | `(id: string) => Promise<TransactionResult>`                             | Re-run the solver if a transient failure is observed                   | `dist/index.d.ts:14` |
-| `initateDepositWithdrawal`  | `(id: string) => Promise<TransactionResult>`                             | Initiate a forced withdrawal flow (verbatim misspelling; see Pitfalls) | `dist/index.d.ts:16` |
-| `disableForcedWithdrawal`   | `(params: DisableForcedWithdrawalParams) => Promise<TransactionResult>`  | Cancel a pending forced withdrawal so a new intent can solve           | `dist/index.d.ts:17` |
-| `withdrawToken`             | `(params: WithdrawTokenParams) => Promise<TransactionResult>`            | Reclaim an unfulfilled EVM-side deposit                                | `dist/index.d.ts:18` |
-| `getForcedWithdrawalStatus` | `(id: string) => Promise<ForcedWithdrawalStatus>`                        | Observe a forced-withdrawal lifecycle                                  | `dist/index.d.ts:19` |
-| `getDepositedBalances`      | `(addr: string) => Promise<DepositedBalance[]>`                          | List the user's locked balances in the Compact                         | `dist/index.d.ts:20` |
-| `getIntentStatus`           | `(addr: string, nonce: string) => Promise<IntentTransactionStatus[]>`    | Drive the 5s polling loop                                              | `dist/index.d.ts:21` |
-| `getHealthCheck`            | `() => Promise<HealthCheckResult>`                                       | Probe allocator availability before quoting                            | `dist/index.d.ts:22` |
+| Method                      | Signature (abridged)                                          | Purpose                      |
+| --------------------------- | ------------------------------------------------------------- | ---------------------------- |
+| `getTaskData`               | `(params: GetTaskDataParams)`                                 | Build the quote envelope     |
+| `getIntentQuote`            | `({ sponsorAddress, taskTypeString, intentData, isNative? })` | Obtain a quote               |
+| `solveIntent`               | `(params: SolveIntentParams)`                                 | Sign and submit the intent   |
+| `getIntentStatus`           | `(userAddress: string, nonce: string)`                        | Poll settlement              |
+| `retryIntentSolve`          | `(request: CompactRequest)`                                   | Retry a recorded allocation  |
+| `initateDepositWithdrawal`  | `(id: string)`                                                | Initiate forced withdrawal   |
+| `disableForcedWithdrawal`   | `(id: string)`                                                | Cancel forced withdrawal     |
+| `withdrawToken`             | `(id: string, recipient: string, amount: string)`             | Withdraw a deposit           |
+| `getForcedWithdrawalStatus` | `(account: string, id: string)`                               | Inspect recovery status      |
+| `getDepositedBalances`      | `(account: string, tokens: CompactTokenBalanceInput[])`       | Inspect locked balances      |
+| `getHealthCheck`            | `()`                                                          | Probe allocator availability |
 
 Recovery primitives (`retryIntentSolve`, `disableForcedWithdrawal`, `withdrawToken`, `initateDepositWithdrawal`) are the difference between an intent flow that "mostly works" and one that lets users recover from solver outages or network failures.
 
 ## Pitfalls
 
-Eleven traps every Epoch integration hits before the first successful round-trip. The reference app ships mitigations for each.
+Check these integration details before a live round trip:
 
-- **Don't follow the npm package README.** It documents an unrelated SDK; the [integration guide](https://docs.epochprotocol.xyz/epoch-miden-integration/integration-guide) and `dist/index.d.ts` are the source of truth.
+- **Don't follow the npm package README.** It documents an unrelated SDK; the [integration guide](https://docs.epochprotocol.xyz/epoch-miden-integration/integration-guide) and `dist/sdk/epoch-intent-sdk.d.ts` are the source of truth.
 - **Public notes only.** P2IDE notes for the allocator must be `'public'`; a `'private'` note is invisible to the solver.
-- **Always await `waitForTransaction`.** Reading `outputNotes[0]` early returns an empty array; the 120-second timeout covers proving + testnet submission.
-- **Reclaim height is `currentBlock + N`.** `midenReclaimHeight` is absolute; use `useSyncState().syncHeight + 1000` at the call site, never a literal.
+- **Await confirmation and match the note ID.** A fee-paying transaction also creates a `TX_FEE` output. Do not pass `outputNotes[0]` to Epoch; locate the exact collateral note ID after `waitForTransaction`.
+- **Honor Epoch’s callback window and binding.** `createMidenP2IDENote` supplies `recallBlocks` and `bindingAttachmentFelts`. Build a public P2IDE with `currentBlock + recallBlocks` after a fresh sync and include the attachment verbatim. A plain `SendTransaction` cannot represent this attachment. The quote’s preliminary reclaim-height field is not a substitute for the callback values.
 - **`minTokenOut` is base units.** The reverse-quote path passes it straight through — no `parseUnits`. For an 18-decimal token, `"1000000000000000000"` is one whole unit.
 - **Override `walletClient.chain.id` for Miden-source intents.** Set `chain.id = 999999999` for Miden → EVM only; leave it as the real EVM chain id for the reverse direction.
 - **`midenFaucetDecimals` is advisory.** Fall back to UI-selected decimals when the allocator value would change the displayed amount by an order of magnitude.
-- **`Number.MAX_SAFE_INTEGER` guard.** The wallet adapter's `SendTransaction` constructor takes a `number`; guard the amount before casting.
-- **No COOP/COEP on the dev server.** `midenVitePlugin({ crossOriginIsolation: false })` is mandatory — the default breaks gRPC-Web to `transport.miden.io`.
+- **Keep collateral amounts as `bigint`.** The custom request uses `FungibleAsset` directly, avoiding a lossy `number` conversion.
+- **Check browser cross-origin compatibility.** This single-threaded app uses `midenVitePlugin({ crossOriginIsolation: false })`; verify the chosen RPC and wallet support before enabling cross-origin isolation.
 - **Forced-withdrawal preflight.** Call `sdk.disableForcedWithdrawal` before re-running an EVM → Miden intent on a deposit id the user cancelled previously.
 - **`initateDepositWithdrawal` (misspelling).** The SDK exports the method with the typo — use it verbatim, do not silently rename.
 

--- a/docs/src/web-client/counter_contract_tutorial.md
+++ b/docs/src/web-client/counter_contract_tutorial.md
@@ -5,6 +5,13 @@ sidebar_position: 5
 
 _Using the Miden client to interact with a custom smart contract_
 
+:::note v0.16 setup
+
+Follow the [network and fee setup](./setup_guide.md#network-and-fee-setup)
+and copy the shared support files imported by the complete example.
+
+:::
+
 ## Overview
 
 In this tutorial, we will deploy a custom counter smart contract and increment its count using the Miden client. Each run creates a fresh counter account, deploys it to the network, and immediately calls its `increment_count` procedure via a transaction script — so the final count is always `1`.
@@ -42,7 +49,7 @@ This tutorial assumes you have a basic understanding of Miden assembly. To quick
 
 3. Install the Miden SDK:
    ```bash
-   yarn add @miden-sdk/miden-sdk@0.15.2
+   yarn add @miden-sdk/miden-sdk@0.16.0
    ```
 
 **NOTE!**: Be sure to add the `--webpack` command to your `package.json` when running the `dev script`. The dev script should look like this:
@@ -111,35 +118,53 @@ Create the file `lib/masm/counter_contract.masm` with the following Miden Assemb
 ```masm
 use miden::protocol::active_account
 use miden::protocol::native_account
-use miden::core::word
 use miden::core::sys
+
+# CONSTANTS
+# =================================================================================================
 
 const COUNTER_SLOT = word("miden::tutorials::counter")
 
-#! Inputs:  []
-#! Outputs: [count]
-pub proc get_count
+# PUBLIC INTERFACE
+# =================================================================================================
+
+#! Returns the current count.
+#!
+#! Inputs:  [pad(16)]
+#! Outputs: [count, pad(15)]
+#!
+#! Invocation: call
+@account_procedure
+pub proc get_count() -> felt
     push.COUNTER_SLOT[0..2] exec.active_account::get_item
-    # => [count]
+    # => [[count, 0, 0, 0], pad(16)]
 
     exec.sys::truncate_stack
-    # => [count]
+    # => [count, pad(15)]
 end
 
-#! Inputs:  []
-#! Outputs: []
-pub proc increment_count
+#! Increments the current count by one.
+#!
+#! Inputs:  [pad(16)]
+#! Outputs: [pad(16)]
+#!
+#! Invocation: call
+@account_procedure
+pub proc increment_count()
     push.COUNTER_SLOT[0..2] exec.active_account::get_item
-    # => [count]
+    # => [[count, 0, 0, 0], pad(16)]
 
     add.1
-    # => [count+1]
+    # => [[count + 1, 0, 0, 0], pad(16)]
 
     push.COUNTER_SLOT[0..2] exec.native_account::set_item
-    # => []
+    # => [OLD_VALUE, pad(16)]
+
+    dropw
+    # => [pad(16)]
 
     exec.sys::truncate_stack
-    # => []
+    # => [pad(16)]
 end
 ```
 
@@ -193,11 +218,14 @@ Copy and paste the following code into the `lib/incrementCounterContract.ts` fil
 import counterContractCode from './masm/counter_contract.masm';
 import {
   AuthSecretKey,
-  StorageMode,
   StorageSlot,
   StorageResult,
-  MidenClient,
 } from '@miden-sdk/miden-sdk/lazy';
+import {
+  createFundableContractAccount,
+  createTutorialClient,
+  fundAccountForFees,
+} from './feeSupport';
 
 export async function incrementCounterContract(): Promise<void> {
   if (typeof window === 'undefined') {
@@ -205,17 +233,11 @@ export async function incrementCounterContract(): Promise<void> {
     return;
   }
 
-  // Wait for the WASM module to finish initializing before touching any
-  // wasm-bindgen type (see setup_guide.md "Entry points: eager vs lazy").
-  await MidenClient.ready();
-
-  const nodeEndpoint = 'https://rpc.testnet.miden.io';
-  const client = await MidenClient.create({ rpcUrl: nodeEndpoint });
+  const client = await createTutorialClient({ proverUrl: 'local' });
   console.log('Current block number: ', (await client.sync()).blockNum());
 
   const counterSlotName = 'miden::tutorials::counter';
 
-  // Compile the counter component
   const counterAccountComponent = await client.compile.component({
     code: counterContractCode,
     slots: [StorageSlot.emptyValue(counterSlotName)],
@@ -223,23 +245,37 @@ export async function incrementCounterContract(): Promise<void> {
 
   const walletSeed = new Uint8Array(32);
   crypto.getRandomValues(walletSeed);
-
   const auth = AuthSecretKey.rpoFalconWithRNG(walletSeed);
 
-  // Create the counter contract account
-  const account = await client.accounts.create({
-    storage: StorageMode.Public,
-    seed: walletSeed,
+  const account = await createFundableContractAccount(
+    client,
+    walletSeed,
     auth,
-    components: [counterAccountComponent],
-  });
+    [counterAccountComponent],
+  );
 
-  // Building the transaction script which will call the counter contract
+  await fundAccountForFees(client, account);
+
   const txScriptCode = `
-    use external_contract::counter_contract
-    begin
+use external_contract::counter_contract
+
+#! Increments the counter.
+#!
+#! Inputs:  [ARGS, pad(12)]
+#! Outputs: [pad(16)]
+#!
+#! Where:
+#! - ARGS contains unused transaction script arguments.
+#!
+#! Invocation: dyncall
+@transaction_script
+pub proc main(args: word)
+    dropw
+    # => [pad(16)]
+
     call.counter_contract::increment_count
-    end
+    # => [pad(16)]
+end
 `;
 
   const script = await client.compile.txScript({
@@ -252,27 +288,26 @@ export async function incrementCounterContract(): Promise<void> {
     ],
   });
 
-  // Executing the transaction script against the counter contract — this
-  // deploys the counter and runs `increment_count` in a single transaction.
-  await client.transactions.execute({
+  await client.sync();
+  const { txId } = await client.transactions.execute({
     account,
     script,
+    waitForConfirmation: true,
+    timeout: 120_000,
   });
+  console.log(`Transaction committed: ${txId.toHex()}`);
 
   console.log('Counter contract ID:', account.id().toString());
 
-  // Logging the count of the counter contract we just incremented
   const counter = await client.accounts.get(account);
-
   // `getItem()` is typed to return a low-level `Word`, but at runtime the SDK
   // wraps the slot in a `StorageResult` whose `toBigInt()` reads the first
   // felt — the count. The cast reflects that runtime type.
   const count = counter?.storage().getItem(counterSlotName) as unknown as
-    | StorageResult
-    | undefined;
-
+    StorageResult | undefined;
   const counterValue = Number(count!.toBigInt());
-
+  if (counterValue !== 1)
+    throw new Error(`Expected counter 1, got ${counterValue}`);
   console.log('Count: ', counterValue);
 }
 ```
@@ -312,52 +347,74 @@ Count:  1
 4. Adds `1` to the count value returned from `active_account::get_item`.
 5. Pushes the slot ID prefix and suffix again so we can write the updated count.
 6. Calls `native_account::set_item` which saves the incremented count to storage.
-7. Calls `sys::truncate_stack` to truncate the stack to size 16.
+7. Drops the previous storage word returned by `set_item`.
+8. Calls `sys::truncate_stack` to leave only the 16 padding elements.
 
 ```masm
 use miden::protocol::active_account
 use miden::protocol::native_account
-use miden::core::word
 use miden::core::sys
+
+# CONSTANTS
+# =================================================================================================
 
 const COUNTER_SLOT = word("miden::tutorials::counter")
 
-#! Inputs:  []
-#! Outputs: [count]
-pub proc get_count
+# PUBLIC INTERFACE
+# =================================================================================================
+
+#! Returns the current count.
+#!
+#! Inputs:  [pad(16)]
+#! Outputs: [count, pad(15)]
+#!
+#! Invocation: call
+@account_procedure
+pub proc get_count() -> felt
     push.COUNTER_SLOT[0..2] exec.active_account::get_item
-    # => [count]
+    # => [[count, 0, 0, 0], pad(16)]
 
     exec.sys::truncate_stack
-    # => [count]
+    # => [count, pad(15)]
 end
 
-#! Inputs:  []
-#! Outputs: []
-pub proc increment_count
+#! Increments the current count by one.
+#!
+#! Inputs:  [pad(16)]
+#! Outputs: [pad(16)]
+#!
+#! Invocation: call
+@account_procedure
+pub proc increment_count()
     push.COUNTER_SLOT[0..2] exec.active_account::get_item
-    # => [count]
+    # => [[count, 0, 0, 0], pad(16)]
 
     add.1
-    # => [count+1]
+    # => [[count + 1, 0, 0, 0], pad(16)]
 
     push.COUNTER_SLOT[0..2] exec.native_account::set_item
-    # => []
+    # => [OLD_VALUE, pad(16)]
+
+    dropw
+    # => [pad(16)]
 
     exec.sys::truncate_stack
-    # => []
+    # => [pad(16)]
 end
 ```
 
-**Note**: _It's a good habit to add comments below each line of MASM code with the expected stack state. This improves readability and helps with debugging._
+The examples follow the [protocol MASM conventions](https://github.com/0xMiden/protocol/tree/next/.claude/skills): public procedures declare typed signatures and invocation style, and stack comments list the top element first. Calls return 16 stack elements, including `pad(N)` padding; storage values are four-element words.
 
 ### Authentication Component
 
-**Important**: All accounts must have an authentication component. For smart contracts that do not require authentication (like our counter contract), we use a `NoAuth` component.
+The counter uses a Falcon single-signature authentication component. The client
+stores the secret key and signs transactions that increment the counter. Public
+storage lets other accounts read its state through FPI; it does not grant them
+permission to update it.
 
-This `NoAuth` component allows any user to interact with the smart contract without requiring signature verification.
-
-**Note**: _Adding the `account::incr_nonce` to a state changing procedure allows any user to call the procedure._
+The account also includes `BasicWallet` so it can consume a native-asset funding
+note and pay transaction fees. The `createFundableContractAccount` helper adds
+both components and registers the account and key in the client.
 
 ### Compiling the account component
 
@@ -372,17 +429,19 @@ const counterAccountComponent = await client.compile.component({
 
 ### Creating the contract account
 
-Use `client.accounts.create()` to build and register the contract. Passing `components` makes this a contract account, so no account type is needed — `storage` selects visibility (`StorageMode.Public` here). You must supply a `seed` (for deterministic ID derivation) and a raw `AuthSecretKey` — the client stores the key automatically:
+Use the repository helper to build the account with authentication, the custom
+counter component, and `BasicWallet`, then fund it before executing a script:
 
 ```ts
 const auth = AuthSecretKey.rpoFalconWithRNG(walletSeed);
 
-const account = await client.accounts.create({
-  storage: StorageMode.Public,
-  seed: walletSeed,
+const account = await createFundableContractAccount(
+  client,
+  walletSeed,
   auth,
-  components: [counterAccountComponent],
-});
+  [counterAccountComponent],
+);
+await fundAccountForFees(client, account);
 ```
 
 ### Compiling and executing the custom script
@@ -401,12 +460,15 @@ const script = await client.compile.txScript({
 });
 ```
 
-Then execute it with `client.transactions.execute()`:
+Synchronize, execute the script, and wait for commitment:
 
 ```ts
+await client.sync();
 await client.transactions.execute({
   account,
   script,
+  waitForConfirmation: true,
+  timeout: 120_000,
 });
 ```
 
@@ -417,8 +479,22 @@ This is the Miden assembly script that calls the `increment_count` procedure dur
 ```masm
 use external_contract::counter_contract
 
-begin
+#! Increments the counter.
+#!
+#! Inputs:  [ARGS, pad(12)]
+#! Outputs: [pad(16)]
+#!
+#! Where:
+#! - ARGS contains unused transaction script arguments.
+#!
+#! Invocation: dyncall
+@transaction_script
+pub proc main(args: word)
+    dropw
+    # => [pad(16)]
+
     call.counter_contract::increment_count
+    # => [pad(16)]
 end
 ```
 
@@ -429,7 +505,7 @@ To run a full working example navigate to the `web-client` directory in the [mid
 ```bash
 cd web-client
 yarn install
-yarn start
+yarn dev
 ```
 
 ### Resetting the `MidenClientDB`

--- a/docs/src/web-client/create_deploy_tutorial.md
+++ b/docs/src/web-client/create_deploy_tutorial.md
@@ -7,6 +7,15 @@ import { CodeSdkTabs } from '@site/src/components';
 
 _Using the Miden client in TypeScript to create accounts and deploy faucets_
 
+:::note v0.16 setup
+
+Follow the [network and fee setup](./setup_guide.md#network-and-fee-setup)
+and copy the shared support files imported by the complete example.
+For React snippets, initialize `authScheme` with `await tutorialAuthScheme()`
+as shown in the complete example.
+
+:::
+
 ## Overview
 
 In this tutorial, we'll build a simple Next.js application that demonstrates the fundamentals of interacting with the Miden blockchain using the Miden SDK. We'll walk through creating a Miden account for Alice and deploying a fungible faucet contract that can mint tokens. This sets the foundation for more complex operations like issuing assets and transferring them between accounts.
@@ -56,8 +65,8 @@ It is useful to think of notes on Miden as "cryptographic cashier's checks" that
 3. Install the Miden SDK:
 
 <CodeSdkTabs example={{
-  react: { code: `yarn add @miden-sdk/react @miden-sdk/miden-sdk@0.15.2` },
-  typescript: { code: `yarn add @miden-sdk/miden-sdk@0.15.2` },
+  react: { code: `yarn add @miden-sdk/react@0.16.0 @miden-sdk/miden-sdk@0.16.0` },
+  typescript: { code: `yarn add @miden-sdk/miden-sdk@0.16.0` },
 }} reactFilename="" tsFilename="" />
 
 **NOTE!**: Be sure to add the `--webpack` command to your `package.json` when running the `dev script`. The dev script should look like this:
@@ -129,9 +138,9 @@ export async function createMintConsume(): Promise<void> {
 .// wasm-bindgen type (see setup_guide.md "Entry points: eager vs lazy").
 .await MidenClient.ready();
 
-.// Connect to Miden testnet RPC endpoint
-.const client = await MidenClient.create({
-..rpcUrl: 'https://rpc.testnet.miden.io',
+.// Connect to Miden testnet with local proving
+.const client = await MidenClient.createTestnet({
+..proverUrl: 'local',
 .});
 
 .// 1. Sync with the latest blockchain state
@@ -215,7 +224,7 @@ Back in your library file, extend the function:
 react: { code: `const run = async () => {
 .// 1. Create Alice's wallet (public, mutable)
 .console.log('Creating account for Alice…');
-.const alice = await createWallet({ storageMode: StorageMode.Public });
+.const alice = await createWallet({ storageMode: StorageMode.Public, authScheme });
 .console.log('Alice ID:', alice.id().toString());
 };` },
 typescript: { code: `// lib/createMintConsume.ts
@@ -231,8 +240,8 @@ export async function createMintConsume(): Promise<void> {
 .// wasm-bindgen type (see setup_guide.md "Entry points: eager vs lazy").
 .await MidenClient.ready();
 
-.const client = await MidenClient.create({
-..rpcUrl: 'https://rpc.testnet.miden.io',
+.const client = await MidenClient.createTestnet({
+..proverUrl: 'local',
 .});
 
 .// 1. Sync with the latest blockchain state
@@ -258,6 +267,7 @@ Add this code after creating Alice's account:
 react: { code: `// 2. Deploy a fungible faucet
 console.log('Creating faucet…');
 const faucet = await createFaucet({
+.authScheme,
 .tokenSymbol: 'MID', // Token symbol (like ETH, BTC, etc.)
 .decimals: 8, // Decimals (8 means 1 MID = 100,000,000 base units)
 .maxSupply: BigInt(1_000_000), // Max supply: total tokens that can ever be minted
@@ -296,7 +306,7 @@ console.log('Setup complete.');` },
 In this tutorial, we've successfully:
 
 1. Set up a Next.js application with the Miden SDK
-2. Connected to the Miden testnet
+2. Connected to Miden testnet
 3. Created a wallet account for Alice
 4. Deployed a fungible faucet that can mint custom tokens
 
@@ -305,51 +315,123 @@ Your final `lib/react/createMintConsume.tsx` (React) or `lib/createMintConsume.t
 <CodeSdkTabs example={{
 react: { code: `'use client';
 
-import { MidenProvider, useMiden, useCreateWallet, useCreateFaucet } from '@miden-sdk/react/lazy';
-import { StorageMode } from '@miden-sdk/miden-sdk/lazy';
+import {
+.MidenProvider,
+.useMiden,
+.useCreateWallet,
+.useCreateFaucet,
+.useMint,
+.useConsume,
+.useSend,
+} from '@miden-sdk/react/lazy';
+import { NoteVisibility, StorageMode } from '@miden-sdk/miden-sdk/lazy';
+import { tutorialNetwork } from '../feeSupport';
+import {
+.TutorialButton,
+.tutorialAuthScheme,
+.useTutorialSupport,
+} from './tutorialSupport';
 
 function CreateMintConsumeInner() {
-.const { isReady } = useMiden();
+.const { sync } = useMiden();
 .const { createWallet } = useCreateWallet();
 .const { createFaucet } = useCreateFaucet();
+.const { mint } = useMint();
+.const { consume } = useConsume();
+.const { send } = useSend();
+.const {
+..fundAccount,
+..committed,
+..waitForTokenNotes,
+..waitForNote,
+..assertBalance,
+.} = useTutorialSupport();
 
 .const run = async () => {
-..// 1. Create Alice's wallet (public, mutable)
-..console.log('Creating account for Alice…');
-..const alice = await createWallet({ storageMode: StorageMode.Public });
+..console.log('Synchronizing before creating accounts…');
+..await sync();
+..console.log('Creating Alice with useCreateWallet…');
+..const authScheme = await tutorialAuthScheme();
+..// Native fee tokens and the tutorial's MID token are separate assets.
+..const alice = await createWallet({
+...storageMode: StorageMode.Public,
+...authScheme,
+..});
 ..console.log('Alice ID:', alice.id().toString());
+..await fundAccount(alice);
 
-..// 2. Deploy a fungible faucet
-..console.log('Creating faucet…');
+..// v0.16 faucets include BasicWallet, so they can receive fee funding.
 ..const faucet = await createFaucet({
 ...tokenSymbol: 'MID',
 ...decimals: 8,
 ...maxSupply: BigInt(1_000_000),
 ...storageMode: StorageMode.Public,
+...authScheme,
 ..});
 ..console.log('Faucet ID:', faucet.id().toString());
+..await fundAccount(faucet);
 
-..console.log('Setup complete.');
+..await sync();
+..const minted = await mint({
+...faucetId: faucet,
+...targetAccountId: alice,
+...amount: BigInt(1000),
+...noteType: NoteVisibility.Public,
+..});
+..await committed(minted.transactionId);
+..const notes = await waitForTokenNotes(alice, faucet);
+..const consumed = await consume({ accountId: alice.id().toString(), notes });
+..await committed(consumed.transactionId);
+..await assertBalance(alice, faucet, BigInt(1000));
+
+..const bob = await createWallet({
+...storageMode: StorageMode.Public,
+...authScheme,
+..});
+..const sent = await send({
+...from: alice,
+...to: bob,
+...assetId: faucet,
+...amount: BigInt(100),
+...noteType: NoteVisibility.Public,
+...returnNote: true,
+..});
+..await committed(sent.txId);
+..if (!sent.note) throw new Error('Send did not return its output note');
+..await waitForNote(sent.note.id().toString());
+..await assertBalance(alice, faucet, BigInt(900));
+..console.log('Tokens sent successfully!');
 .};
 
 .return (
-..<div>
-...<button onClick={run} disabled={!isReady}>
-....{isReady ? 'Start' : 'Initializing…'}
-...</button>
-..</div>
+..<TutorialButton
+...name="createMintConsume"
+...label="Run: Create, Mint, Consume & Send"
+...run={run}
+../>
 .);
 }
 
 export default function CreateMintConsume() {
 .return (
-..<MidenProvider config={{ rpcUrl: 'testnet', prover: 'local' }}>
+..<MidenProvider
+...config={{
+....rpcUrl: tutorialNetwork(),
+....prover: 'local',
+....autoSyncInterval: 0,
+...}}
+..>
 ...<CreateMintConsumeInner />
 ..</MidenProvider>
 .);
 }`},
-  typescript: { code:`// lib/createMintConsume.ts
-import { MidenClient, StorageMode } from '@miden-sdk/miden-sdk/lazy';
+  typescript: { code: `// lib/createMintConsume.ts
+import { NoteVisibility, StorageMode } from '@miden-sdk/miden-sdk/lazy';
+import {
+.consumeAllFeeAware,
+.createTutorialClient,
+.fundAccountForFees,
+} from './feeSupport';
 
 export async function createMintConsume(): Promise<void> {
 .if (typeof window === 'undefined') {
@@ -357,12 +439,8 @@ export async function createMintConsume(): Promise<void> {
 ..return;
 .}
 
-.// Wait for the WASM module to finish initializing before touching any
-.// wasm-bindgen type (see setup_guide.md "Entry points: eager vs lazy").
-.await MidenClient.ready();
-
-.const client = await MidenClient.create({
-..rpcUrl: 'https://rpc.testnet.miden.io',
+.const client = await createTutorialClient({
+..proverUrl: 'local',
 .});
 
 .// 1. Sync with the latest blockchain state
@@ -376,7 +454,8 @@ export async function createMintConsume(): Promise<void> {
 .});
 .console.log('Alice ID:', alice.id().toString());
 
-.// 3. Deploy a fungible faucet
+.// 3. Create our own fungible faucet. SDK v0.16 includes BasicWallet,
+.// allowing both accounts to consume native fee funding before minting MID.
 .console.log('Creating faucet…');
 .const faucet = await client.accounts.create({
 ..type: 0, // 0 = FungibleFaucet
@@ -386,8 +465,48 @@ export async function createMintConsume(): Promise<void> {
 ..storage: StorageMode.Public,
 .});
 .console.log('Faucet ID:', faucet.id().toString());
+.await fundAccountForFees(client, alice);
+.await fundAccountForFees(client, faucet);
 
-.console.log('Setup complete.');
+.// 4. Mint tokens to Alice.
+.console.log('Minting tokens to Alice...');
+.await client.sync();
+.const { txId: mintTxId } = await client.transactions.mint({
+..account: faucet,
+..to: alice,
+..amount: BigInt(1000),
+..type: NoteVisibility.Public,
+.});
+.console.log('Waiting for transaction confirmation...');
+.await client.transactions.waitFor(mintTxId, { timeout: 120_000 });
+
+.// 5-6. Consume all available notes for Alice.
+.console.log('Consuming minted notes...');
+.await consumeAllFeeAware(client, alice);
+
+.console.log('Notes consumed.');
+
+.// 7. Send tokens to Bob
+.const bob = await client.accounts.create({
+..storage: StorageMode.Public,
+.});
+.console.log("Sending tokens to Bob's account...");
+.await client.sync();
+.const { txId: sendTxId } = await client.transactions.send({
+..account: alice,
+..to: bob,
+..token: faucet,
+..amount: BigInt(100),
+..type: NoteVisibility.Public,
+..waitForConfirmation: true,
+..timeout: 120_000,
+.});
+.console.log(\`Transaction committed: \${sendTxId.toHex()}\`);
+.const updatedAlice = await client.accounts.get(alice);
+.const balance = updatedAlice?.vault().getBalance(faucet.id());
+.if (balance !== BigInt(900))
+..throw new Error(\`Expected Alice to retain 900 MID, got \${balance}\`);
+.console.log('Tokens sent successfully!');
 }` },
 }} reactFilename="lib/react/createMintConsume.tsx" tsFilename="lib/createMintConsume.ts" />
 

--- a/docs/src/web-client/creating_multiple_notes_tutorial.md
+++ b/docs/src/web-client/creating_multiple_notes_tutorial.md
@@ -7,6 +7,15 @@ import { CodeSdkTabs } from '@site/src/components';
 
 _Using the Miden client in TypeScript to create several P2ID notes in a single transaction_
 
+:::note v0.16 setup
+
+Follow the [network and fee setup](./setup_guide.md#network-and-fee-setup)
+and copy the shared support files imported by the complete example.
+For React snippets, initialize `authScheme` with `await tutorialAuthScheme()`
+as shown in the complete example.
+
+:::
+
 ## Overview
 
 In the previous sections we learned how to create accounts, deploy faucets, and mint tokens. In this tutorial we will:
@@ -61,8 +70,8 @@ proving service. This means your browser never has to generate the full ZK proof
 3. Install the Miden SDK:
 
 <CodeSdkTabs example={{
-  react: { code: `yarn add @miden-sdk/react @miden-sdk/miden-sdk@0.15.2` },
-  typescript: { code: `yarn add @miden-sdk/miden-sdk@0.15.2` },
+  react: { code: `yarn add @miden-sdk/react@0.16.0 @miden-sdk/miden-sdk@0.16.0` },
+  typescript: { code: `yarn add @miden-sdk/miden-sdk@0.16.0` },
 }} reactFilename="" tsFilename="" />
 
 **NOTE!**: Be sure to add the `--webpack` command to your `package.json` when running the `dev script`. The dev script should look like this:
@@ -193,9 +202,7 @@ export async function multiSendWithDelegatedProver(): Promise<void> {
 .// Wait for WASM to be ready before touching any wasm-bindgen type.
 .await MidenClient.ready();
 
-.const client = await MidenClient.create({
-..rpcUrl: 'https://rpc.testnet.miden.io',
-.});
+.const client = await MidenClient.createTestnet();
 
 .console.log('Latest block:', (await client.sync()).blockNum());
 }` },
@@ -208,12 +215,13 @@ Add the code snippet below to the function. This code creates a wallet and fauce
 <CodeSdkTabs example={{
 react: { code: `// 1. Create Alice's wallet
 console.log('Creating account for Alice…');
-const alice = await createWallet({ storageMode: StorageMode.Public });
+const alice = await createWallet({ storageMode: StorageMode.Public, authScheme });
 const aliceId = alice.id().toString();
 console.log('Alice account ID:', aliceId);
 
 // 2. Deploy a fungible faucet
 const faucet = await createFaucet({
+.authScheme,
 .tokenSymbol: 'MID',
 .decimals: 8,
 .maxSupply: BigInt(1_000_000),
@@ -272,28 +280,36 @@ await client.transactions.consumeAll({
 
 ## Step 5 — Build and Create P2ID notes
 
-Add the following code to the function. This code builds three P2ID notes with 100 `MID` each (one per hardcoded recipient address), and then creates all three notes in the same transaction.
+Add the following code to the function. This code creates three testnet recipients, builds a P2ID note with 100 `MID` for each, and then creates all three notes in the same transaction.
 
 <CodeSdkTabs example={{
-react: { code: `// 5. Send 100 MID to three recipients in a single transaction
+react: { code: `// 5. Create three recipients and send 100 MID to each in one transaction
+const recipients = await Promise.all(
+.Array.from({ length: 3 }, () =>
+..createWallet({ storageMode: StorageMode.Public, authScheme }),
+.),
+);
+
 await sendMany({
 .from: alice,
 .assetId: faucet,
-.recipients: [
-..{ to: 'mtst1arqeemdpnzu4k52wlpd3xekl5uklfjl5', amount: BigInt(100) },
-..{ to: 'mtst1arqk5qt3kms0cut9rdtqdaz8y5xmj245', amount: BigInt(100) },
-..{ to: 'mtst1aq6kyfrh23n9gvt6jkg0z7fyts99hdqr', amount: BigInt(100) },
-.],
+.recipients: recipients.map((account) => ({
+..to: account.id().toString(),
+..amount: BigInt(100),
+.})),
 .noteType: NoteVisibility.Public,
 });
 
 console.log('All notes created ✅');`},
   typescript: { code:`// ── build 3 P2ID notes (100 MID each) ─────────────────────────────────────────────
-const recipientAddresses = [
-.'mtst1arqeemdpnzu4k52wlpd3xekl5uklfjl5',
-.'mtst1arqk5qt3kms0cut9rdtqdaz8y5xmj245',
-.'mtst1aq6kyfrh23n9gvt6jkg0z7fyts99hdqr',
-];
+const recipients = await Promise.all(
+.Array.from({ length: 3 }, () =>
+..client.accounts.create({ storage: StorageMode.Public }),
+.),
+);
+const recipientAddresses = recipients.map((account) =>
+.account.id().toString(),
+);
 
 const p2idNotes = recipientAddresses.map((addr) =>
 .createP2IDNote({
@@ -319,107 +335,133 @@ Your library file should now look like this:
 <CodeSdkTabs example={{
 react: { code: `'use client';
 
-import { MidenProvider, useMiden, useCreateWallet, useCreateFaucet, useMint, useConsume, useMultiSend, useWaitForCommit, useWaitForNotes } from '@miden-sdk/react/lazy';
+import {
+.MidenProvider,
+.useMiden,
+.useCreateWallet,
+.useCreateFaucet,
+.useMint,
+.useConsume,
+.useMultiSend,
+} from '@miden-sdk/react/lazy';
 import { NoteVisibility, StorageMode } from '@miden-sdk/miden-sdk/lazy';
+import { tutorialNetwork } from '../feeSupport';
+import {
+.TutorialButton,
+.tutorialAuthScheme,
+.useTutorialSupport,
+} from './tutorialSupport';
 
 function MultiSendInner() {
-.const { isReady } = useMiden();
+.const { sync } = useMiden();
 .const { createWallet } = useCreateWallet();
 .const { createFaucet } = useCreateFaucet();
 .const { mint } = useMint();
 .const { consume } = useConsume();
 .const { sendMany } = useMultiSend();
-.const { waitForCommit } = useWaitForCommit();
-.const { waitForConsumableNotes } = useWaitForNotes();
+.const { fundAccount, committed, waitForTokenNotes, assertBalance } =
+..useTutorialSupport();
 
 .const run = async () => {
-..// 1. Create Alice's wallet
-..console.log('Creating account for Alice…');
-..const alice = await createWallet({ storageMode: StorageMode.Public });
-..const aliceId = alice.id().toString();
-..console.log('Alice account ID:', aliceId);
-
-..// 2. Deploy a fungible faucet
+..await sync();
+..const authScheme = await tutorialAuthScheme();
+..const alice = await createWallet({
+...storageMode: StorageMode.Public,
+...authScheme,
+..});
+..console.log('Alice ID:', alice.id().toString());
+..await fundAccount(alice);
 ..const faucet = await createFaucet({
 ...tokenSymbol: 'MID',
 ...decimals: 8,
 ...maxSupply: BigInt(1_000_000),
 ...storageMode: StorageMode.Public,
+...authScheme,
 ..});
-..const faucetId = faucet.id().toString();
-..console.log('Faucet ID:', faucetId);
+..console.log('Faucet ID:', faucet.id().toString());
+..await fundAccount(faucet);
 
-..// 3. Mint 10,000 MID to Alice
-..const mintResult = await mint({
-...faucetId,
-...targetAccountId: aliceId,
+..await sync();
+..const minted = await mint({
+...faucetId: faucet,
+...targetAccountId: alice,
 ...amount: BigInt(10_000),
 ...noteType: NoteVisibility.Public,
 ..});
+..await committed(minted.transactionId);
+..const notes = await waitForTokenNotes(alice, faucet);
+..const consumed = await consume({ accountId: alice.id().toString(), notes });
+..await committed(consumed.transactionId);
 
-..console.log('Waiting for settlement…');
-..await waitForCommit(mintResult.transactionId);
-
-..// 4. Consume the freshly minted notes
-..const notes = await waitForConsumableNotes({ accountId: aliceId });
-..await consume({ accountId: aliceId, notes });
-
-..// 5. Send 100 MID to three recipients in a single transaction
-..await sendMany({
+..const recipients = [];
+..for (let index = 0; index < 3; index += 1) {
+...recipients.push(
+....await createWallet({ storageMode: StorageMode.Public, authScheme }),
+...);
+..}
+..const sent = await sendMany({
 ...from: alice,
 ...assetId: faucet,
-...recipients: [
-....{ to: 'mtst1arqeemdpnzu4k52wlpd3xekl5uklfjl5', amount: BigInt(100) },
-....{ to: 'mtst1arqk5qt3kms0cut9rdtqdaz8y5xmj245', amount: BigInt(100) },
-....{ to: 'mtst1aq6kyfrh23n9gvt6jkg0z7fyts99hdqr', amount: BigInt(100) },
-...],
+...recipients: recipients.map((account) => ({
+....to: account,
+....amount: BigInt(100),
+...})),
 ...noteType: NoteVisibility.Public,
 ..});
-
+..await committed(sent.transactionId);
+..for (const recipient of recipients) {
+...const outputs = await waitForTokenNotes(recipient, faucet);
+...if (
+....outputs.length !== 1 ||
+....outputs[0].details().assets().fungibleAssets()[0]?.amount() !==
+.....BigInt(100)
+...) {
+....throw new Error(\`Expected one 100 MID note for \${recipient.id()}\`);
+...}
+..}
+..await assertBalance(alice, faucet, BigInt(9700));
 ..console.log('All notes created ✅');
 .};
 
 .return (
-..<div>
-...<button onClick={run} disabled={!isReady}>
-....{isReady ? 'Run: Multi-Send with Delegated Proving' : 'Initializing…'}
-...</button>
-..</div>
+..<TutorialButton
+...name="multiSendWithDelegatedProver"
+...label="Run: Multi-Send with Delegated Proving"
+...run={run}
+../>
 .);
 }
 
 export default function MultiSendWithDelegatedProver() {
 .return (
-..<MidenProvider config={{ rpcUrl: 'testnet', prover: 'testnet' }}>
+..<MidenProvider
+...config={{
+....rpcUrl: tutorialNetwork(),
+....prover: tutorialNetwork(),
+....autoSyncInterval: 0,
+...}}
+..>
 ...<MultiSendInner />
 ..</MidenProvider>
 .);
 }`},
-  typescript: { code:`import {
-.MidenClient,
+  typescript: { code: `import {
+.NoteArray,
 .NoteVisibility,
 .StorageMode,
 .createP2IDNote,
-.NoteArray,
-.TransactionRequestBuilder,
 } from '@miden-sdk/miden-sdk/lazy';
+import {
+.consumeAllFeeAware,
+.createTutorialClient,
+.fundAccountForFees,
+} from './feeSupport';
 
-/\*\*
-.\* Demonstrates multi-send functionality with delegated proving on the Miden Network
-.\* Creates multiple P2ID (Pay to ID) notes for different recipients
-.\*
-.\* @throws {Error} If the function cannot be executed in a browser environment
-.\*/
 export async function multiSendWithDelegatedProver(): Promise<void> {
 .// Ensure this runs only in a browser context
 .if (typeof window === 'undefined') return console.warn('Run in browser');
 
-.// Wait for WASM to be ready before touching any wasm-bindgen type.
-.await MidenClient.ready();
-
-.const client = await MidenClient.create({
-..rpcUrl: 'https://rpc.testnet.miden.io',
-.});
+.const client = await createTutorialClient();
 
 .console.log('Latest block:', (await client.sync()).blockNum());
 
@@ -430,7 +472,7 @@ export async function multiSendWithDelegatedProver(): Promise<void> {
 .});
 .console.log('Alice account ID:', alice.id().toString());
 
-.// ── Creating new faucet ──────────────────────────────────────────────────────
+.// ── Creating new faucet ────────────────────────────────────────────────────
 .const faucet = await client.accounts.create({
 ..type: 0, // 0 = FungibleFaucet
 ..symbol: 'MID',
@@ -439,29 +481,30 @@ export async function multiSendWithDelegatedProver(): Promise<void> {
 ..storage: StorageMode.Public,
 .});
 .console.log('Faucet ID:', faucet.id().toString());
+.await fundAccountForFees(client, alice);
+.await fundAccountForFees(client, faucet);
 
-.// ── mint 10 000 MID to Alice ──────────────────────────────────────────────────────
+.// ── mint 10 000 MID to Alice ───────────────────────────────────────────────
+.await client.sync();
 .const { txId: mintTxId } = await client.transactions.mint({
 ..account: faucet,
 ..to: alice,
 ..amount: BigInt(10_000),
 ..type: NoteVisibility.Public,
 .});
-
 .console.log('waiting for settlement');
-.await client.transactions.waitFor(mintTxId);
-
-.// ── consume the freshly minted notes ──────────────────────────────────────────────
-.await client.transactions.consumeAll({
-..account: alice,
-.});
+.await client.transactions.waitFor(mintTxId, { timeout: 120_000 });
+.await consumeAllFeeAware(client, alice);
 
 .// ── build 3 P2ID notes (100 MID each) ─────────────────────────────────────────────
-.const recipientAddresses = [
-..'mtst1arqeemdpnzu4k52wlpd3xekl5uklfjl5',
-..'mtst1arqk5qt3kms0cut9rdtqdaz8y5xmj245',
-..'mtst1aq6kyfrh23n9gvt6jkg0z7fyts99hdqr',
-.];
+.const recipients = await Promise.all(
+..Array.from({ length: 3 }, () =>
+...client.accounts.create({ storage: StorageMode.Public }),
+..),
+.);
+.const recipientAddresses = recipients.map((account) =>
+..account.id().toString(),
+.);
 
 .const p2idNotes = recipientAddresses.map((addr) =>
 ..createP2IDNote({
@@ -473,9 +516,18 @@ export async function multiSendWithDelegatedProver(): Promise<void> {
 .);
 
 .// ── create all P2ID notes ───────────────────────────────────────────────────────────────
-.const builder = new TransactionRequestBuilder();
-.const txRequest = builder.withOwnOutputNotes(new NoteArray(p2idNotes)).build();
-.await client.transactions.submit(alice, txRequest);
+.await client.sync();
+.const builder = await client.feeAwareTransactionRequestBuilder(alice);
+.const outputs = new NoteArray();
+.for (const note of p2idNotes) outputs.push(note);
+.const request = builder.withOwnOutputNotes(outputs).build();
+.const { txId } = await client.transactions.submit(alice, request);
+.await client.transactions.waitFor(txId, { timeout: 120_000 });
+.console.log(\`Transaction committed: \${txId.toHex()}\`);
+.const updatedAlice = await client.accounts.get(alice);
+.const balance = updatedAlice?.vault().getBalance(faucet.id());
+.if (balance !== BigInt(9_700))
+..throw new Error(\`Expected Alice to retain 9700 MID, got \${balance}\`);
 
 .console.log('All notes created ✅');
 }` },
@@ -488,7 +540,7 @@ To run a full working example navigate to the `web-client` directory in the [mid
 ```bash
 cd web-client
 yarn install
-yarn start
+yarn dev
 ```
 
 ### Resetting the `MidenClientDB`

--- a/docs/src/web-client/foreign_procedure_invocation_tutorial.md
+++ b/docs/src/web-client/foreign_procedure_invocation_tutorial.md
@@ -7,6 +7,13 @@ sidebar_position: 7
 
 _Using foreign procedure invocation to craft read-only cross-contract calls with the Miden client_
 
+:::note v0.16 setup
+
+Follow the [network and fee setup](./setup_guide.md#network-and-fee-setup)
+and copy the shared support files imported by the complete example.
+
+:::
+
 ## Overview
 
 In the previous tutorial we deployed a fresh counter smart contract and incremented its count with a transaction script.
@@ -57,7 +64,7 @@ This tutorial assumes you have a basic understanding of Miden assembly and compl
 
 3. Install the Miden SDK:
    ```bash
-   yarn add @miden-sdk/miden-sdk@0.15.2
+   yarn add @miden-sdk/miden-sdk@0.16.0
    ```
 
 **NOTE!**: Be sure to add the `--webpack` command to your `package.json` when running the `dev script`. The dev script should look like this:
@@ -128,35 +135,53 @@ Create the file `lib/masm/counter_contract.masm`. This is the same counter contr
 ```masm
 use miden::protocol::active_account
 use miden::protocol::native_account
-use miden::core::word
 use miden::core::sys
+
+# CONSTANTS
+# =================================================================================================
 
 const COUNTER_SLOT = word("miden::tutorials::counter")
 
-#! Inputs:  []
-#! Outputs: [count]
-pub proc get_count
+# PUBLIC INTERFACE
+# =================================================================================================
+
+#! Returns the current count.
+#!
+#! Inputs:  [pad(16)]
+#! Outputs: [count, pad(15)]
+#!
+#! Invocation: call
+@account_procedure
+pub proc get_count() -> felt
     push.COUNTER_SLOT[0..2] exec.active_account::get_item
-    # => [count]
+    # => [[count, 0, 0, 0], pad(16)]
 
     exec.sys::truncate_stack
-    # => [count]
+    # => [count, pad(15)]
 end
 
-#! Inputs:  []
-#! Outputs: []
-pub proc increment_count
+#! Increments the current count by one.
+#!
+#! Inputs:  [pad(16)]
+#! Outputs: [pad(16)]
+#!
+#! Invocation: call
+@account_procedure
+pub proc increment_count()
     push.COUNTER_SLOT[0..2] exec.active_account::get_item
-    # => [count]
+    # => [[count, 0, 0, 0], pad(16)]
 
     add.1
-    # => [count+1]
+    # => [[count + 1, 0, 0, 0], pad(16)]
 
     push.COUNTER_SLOT[0..2] exec.native_account::set_item
-    # => []
+    # => [OLD_VALUE, pad(16)]
+
+    dropw
+    # => [pad(16)]
 
     exec.sys::truncate_stack
-    # => []
+    # => [pad(16)]
 end
 ```
 
@@ -165,30 +190,56 @@ end
 Create the file `lib/masm/count_reader.masm`. This is the new "count copy" contract that reads the counter value via FPI and stores it locally:
 
 ```masm
-use miden::protocol::active_account
 use miden::protocol::native_account
 use miden::protocol::tx
-use miden::core::word
 use miden::core::sys
+use {AccountId, AccountProcedureRoot} from miden::protocol::types
+
+# CONSTANTS
+# =================================================================================================
 
 const COUNT_READER_SLOT = word("miden::tutorials::count_reader")
 
-# => [account_id_suffix, account_id_prefix, PROC_HASH(4), foreign_procedure_inputs(16)]
-pub proc copy_count
+# PUBLIC INTERFACE
+# =================================================================================================
+
+#! Copies the count returned by the foreign counter into this account's storage.
+#!
+#! Inputs:  [foreign_account_id_{suffix,prefix}, FOREIGN_PROC_ROOT, pad(10)]
+#! Outputs: [pad(16)]
+#!
+#! Where:
+#! - foreign_account_id_{suffix,prefix} identifies the public counter account.
+#! - FOREIGN_PROC_ROOT is the root of its get_count procedure.
+#!
+#! Invocation: call
+@account_procedure
+@locals(6)
+pub proc copy_count(foreign_account_id: AccountId, foreign_proc_root: AccountProcedureRoot)
+    # save the foreign target while preparing its sixteen zero inputs
+    loc_store.4 loc_store.5 loc_storew_le.0 dropw
+    # => [pad(16)]
+
+    padw padw padw padw
+    # => [foreign_procedure_inputs(16), pad(16)]
+
+    padw loc_loadw_le.0 loc_load.5 loc_load.4
+    # => [foreign_account_id_suffix, foreign_account_id_prefix, FOREIGN_PROC_ROOT, foreign_procedure_inputs(16), pad(16)]
+
     exec.tx::execute_foreign_procedure
-    # => [count, pad(12)]
+    # => [[count, 0, 0, 0], pad(28)]
 
     push.COUNT_READER_SLOT[0..2]
-    # [slot_id_prefix, slot_id_suffix, count, pad(12)]
+    # => [slot_id_suffix, slot_id_prefix, [count, 0, 0, 0], pad(28)]
 
     exec.native_account::set_item
-    # => [OLD_VALUE, pad(12)]
+    # => [OLD_VALUE, pad(28)]
 
-    dropw dropw dropw dropw
-    # => []
+    dropw
+    # => [pad(28)]
 
     exec.sys::truncate_stack
-    # => []
+    # => [pad(16)]
 end
 ```
 
@@ -245,11 +296,14 @@ import counterContractCode from './masm/counter_contract.masm';
 import countReaderCode from './masm/count_reader.masm';
 import {
   AuthSecretKey,
-  StorageMode,
   StorageSlot,
   StorageResult,
-  MidenClient,
 } from '@miden-sdk/miden-sdk/lazy';
+import {
+  createFundableContractAccount,
+  createTutorialClient,
+  fundAccountForFees,
+} from './feeSupport';
 
 export async function foreignProcedureInvocation(): Promise<void> {
   if (typeof window === 'undefined') {
@@ -257,12 +311,7 @@ export async function foreignProcedureInvocation(): Promise<void> {
     return;
   }
 
-  // Wait for the WASM module to finish initializing before touching any
-  // wasm-bindgen type (see setup_guide.md "Entry points: eager vs lazy").
-  await MidenClient.ready();
-
-  const nodeEndpoint = 'https://rpc.testnet.miden.io';
-  const client = await MidenClient.create({ rpcUrl: nodeEndpoint });
+  const client = await createTutorialClient({ proverUrl: 'local' });
   console.log('Current block number: ', (await client.sync()).blockNum());
 
   const counterSlotName = 'miden::tutorials::counter';
@@ -282,21 +331,38 @@ export async function foreignProcedureInvocation(): Promise<void> {
   crypto.getRandomValues(counterSeed);
   const counterAuth = AuthSecretKey.rpoFalconWithRNG(counterSeed);
 
-  const counterAccount = await client.accounts.create({
-    storage: StorageMode.Public,
-    seed: counterSeed,
-    auth: counterAuth,
-    components: [counterComponent],
-  });
+  const counterAccount = await createFundableContractAccount(
+    client,
+    counterSeed,
+    counterAuth,
+    [counterComponent],
+  );
+
+  await fundAccountForFees(client, counterAccount);
 
   // Deploy the counter to the node by executing a transaction on it
   const deployScript = await client.compile.txScript({
     code: `
-      use external_contract::counter_contract
-      begin
-        call.counter_contract::increment_count
-      end
-    `,
+use external_contract::counter_contract
+
+#! Increments the counter.
+#!
+#! Inputs:  [ARGS, pad(12)]
+#! Outputs: [pad(16)]
+#!
+#! Where:
+#! - ARGS contains unused transaction script arguments.
+#!
+#! Invocation: dyncall
+@transaction_script
+pub proc main(args: word)
+    dropw
+    # => [pad(16)]
+
+    call.counter_contract::increment_count
+    # => [pad(16)]
+end
+`,
     libraries: [
       {
         namespace: 'external_contract::counter_contract',
@@ -307,10 +373,12 @@ export async function foreignProcedureInvocation(): Promise<void> {
 
   // Wait for the deploy transaction to be committed to a block
   // before using it as a foreign account in FPI
+  await client.sync();
   await client.transactions.execute({
     account: counterAccount,
     script: deployScript,
     waitForConfirmation: true,
+    timeout: 120_000,
   });
   console.log('Counter contract ID:', counterAccount.id().toString());
 
@@ -328,12 +396,14 @@ export async function foreignProcedureInvocation(): Promise<void> {
   crypto.getRandomValues(readerSeed);
   const readerAuth = AuthSecretKey.rpoFalconWithRNG(readerSeed);
 
-  const countReaderAccount = await client.accounts.create({
-    storage: StorageMode.Public,
-    seed: readerSeed,
-    auth: readerAuth,
-    components: [countReaderComponent],
-  });
+  const countReaderAccount = await createFundableContractAccount(
+    client,
+    readerSeed,
+    readerAuth,
+    [countReaderComponent],
+  );
+
+  await fundAccountForFees(client, countReaderAccount);
 
   console.log('Count reader contract ID:', countReaderAccount.id().toString());
 
@@ -347,11 +417,21 @@ export async function foreignProcedureInvocation(): Promise<void> {
   const getCountProcHash = counterComponent.getProcedureHash('get_count');
 
   const fpiScriptCode = `
-    use external_contract::count_reader_contract
-    use miden::core::sys
+use external_contract::count_reader_contract
+use miden::core::sys
 
-    begin
-    padw padw padw padw
+#! Copies a public counter through the reader account.
+#!
+#! Inputs:  [ARGS, pad(12)]
+#! Outputs: [pad(16)]
+#!
+#! Where:
+#! - ARGS contains unused transaction script arguments.
+#!
+#! Invocation: dyncall
+@transaction_script
+pub proc main(args: word)
+    dropw
     # => [pad(16)]
 
     push.${getCountProcHash}
@@ -364,12 +444,11 @@ export async function foreignProcedureInvocation(): Promise<void> {
     # => [account_id_suffix, account_id_prefix, GET_COUNT_HASH, pad(16)]
 
     call.count_reader_contract::copy_count
-    # => []
+    # => [pad(16)]
 
     exec.sys::truncate_stack
-    # => []
-
-    end
+    # => [pad(16)]
+end
 `;
 
   const script = await client.compile.txScript({
@@ -382,11 +461,15 @@ export async function foreignProcedureInvocation(): Promise<void> {
     ],
   });
 
-  await client.transactions.execute({
+  await client.sync();
+  const { txId } = await client.transactions.execute({
     account: countReaderAccount,
     script,
     foreignAccounts: [counterAccount],
+    waitForConfirmation: true,
+    timeout: 120_000,
   });
+  console.log(`Transaction committed: ${txId.toHex()}`);
 
   const updatedCountReader = await client.accounts.get(countReaderAccount);
   // `getItem()` is typed to return a low-level `Word`, but at runtime the SDK
@@ -398,7 +481,11 @@ export async function foreignProcedureInvocation(): Promise<void> {
 
   if (countReaderStorage) {
     const countValue = Number(countReaderStorage.toBigInt());
+    if (countValue !== 1)
+      throw new Error(`Expected copied counter 1, got ${countValue}`);
     console.log('Count copied via Foreign Procedure Invocation:', countValue);
+  } else {
+    throw new Error('Count reader storage was not available after commitment');
   }
 
   console.log('\nForeign Procedure Invocation Transaction completed!');
@@ -435,30 +522,56 @@ Foreign Procedure Invocation Transaction completed!
 The count reader smart contract contains a `copy_count` procedure that uses `tx::execute_foreign_procedure` to call the `get_count` procedure in the counter contract.
 
 ```masm
-use miden::protocol::active_account
 use miden::protocol::native_account
 use miden::protocol::tx
-use miden::core::word
 use miden::core::sys
+use {AccountId, AccountProcedureRoot} from miden::protocol::types
+
+# CONSTANTS
+# =================================================================================================
 
 const COUNT_READER_SLOT = word("miden::tutorials::count_reader")
 
-# => [account_id_suffix, account_id_prefix, PROC_HASH(4), foreign_procedure_inputs(16)]
-pub proc copy_count
+# PUBLIC INTERFACE
+# =================================================================================================
+
+#! Copies the count returned by the foreign counter into this account's storage.
+#!
+#! Inputs:  [foreign_account_id_{suffix,prefix}, FOREIGN_PROC_ROOT, pad(10)]
+#! Outputs: [pad(16)]
+#!
+#! Where:
+#! - foreign_account_id_{suffix,prefix} identifies the public counter account.
+#! - FOREIGN_PROC_ROOT is the root of its get_count procedure.
+#!
+#! Invocation: call
+@account_procedure
+@locals(6)
+pub proc copy_count(foreign_account_id: AccountId, foreign_proc_root: AccountProcedureRoot)
+    # save the foreign target while preparing its sixteen zero inputs
+    loc_store.4 loc_store.5 loc_storew_le.0 dropw
+    # => [pad(16)]
+
+    padw padw padw padw
+    # => [foreign_procedure_inputs(16), pad(16)]
+
+    padw loc_loadw_le.0 loc_load.5 loc_load.4
+    # => [foreign_account_id_suffix, foreign_account_id_prefix, FOREIGN_PROC_ROOT, foreign_procedure_inputs(16), pad(16)]
+
     exec.tx::execute_foreign_procedure
-    # => [count, pad(12)]
+    # => [[count, 0, 0, 0], pad(28)]
 
     push.COUNT_READER_SLOT[0..2]
-    # [slot_id_prefix, slot_id_suffix, count, pad(12)]
+    # => [slot_id_suffix, slot_id_prefix, [count, 0, 0, 0], pad(28)]
 
     exec.native_account::set_item
-    # => [OLD_VALUE, pad(12)]
+    # => [OLD_VALUE, pad(28)]
 
-    dropw dropw dropw dropw
-    # => []
+    dropw
+    # => [pad(28)]
 
     exec.sys::truncate_stack
-    # => []
+    # => [pad(16)]
 end
 ```
 
@@ -467,10 +580,10 @@ To call the `get_count` procedure, we push its hash along with the counter contr
 The stack state before calling `tx::execute_foreign_procedure` should look like this:
 
 ```
-# => [account_id_suffix, account_id_prefix, PROC_HASH(4), foreign_procedure_inputs(16)]
+# => [foreign_account_id_suffix, foreign_account_id_prefix, FOREIGN_PROC_ROOT, foreign_procedure_inputs(16), pad(16)]
 ```
 
-`execute_foreign_procedure` always requires exactly 16 `foreign_procedure_inputs` on the stack below the procedure hash and account ID. Since `get_count` takes no arguments, we pass 16 zero words (`padw padw padw padw`) as the inputs.
+`execute_foreign_procedure` always requires exactly 16 `foreign_procedure_inputs` on the stack below the procedure hash and account ID. Since `get_count` takes no arguments, `copy_count` prepares 16 zero field elements (four words: `padw padw padw padw`) as the inputs. The transaction script only passes the account ID and procedure root; the reader saves them in local memory while preparing those inputs.
 
 After calling the `get_count` procedure in the counter contract, we save the count into the
 `miden::tutorials::count_reader` storage slot.
@@ -483,8 +596,18 @@ The transaction script that executes the foreign procedure invocation looks like
 use external_contract::count_reader_contract
 use miden::core::sys
 
-begin
-    padw padw padw padw
+#! Copies a public counter through the reader account.
+#!
+#! Inputs:  [ARGS, pad(12)]
+#! Outputs: [pad(16)]
+#!
+#! Where:
+#! - ARGS contains unused transaction script arguments.
+#!
+#! Invocation: dyncall
+@transaction_script
+pub proc main(args: word)
+    dropw
     # => [pad(16)]
 
     push.${getCountProcHash}
@@ -497,19 +620,20 @@ begin
     # => [account_id_suffix, account_id_prefix, GET_COUNT_HASH, pad(16)]
 
     call.count_reader_contract::copy_count
-    # => []
+    # => [pad(16)]
 
     exec.sys::truncate_stack
-    # => []
+    # => [pad(16)]
 end
 ```
 
 This script:
 
-1. Pushes the procedure hash of the `get_count` function
-2. Pushes the counter contract's account ID suffix and prefix
-3. Calls the `copy_count` procedure in our count reader contract
-4. Truncates the stack
+1. Discards the unused transaction script arguments.
+2. Pushes the procedure root of `get_count`.
+3. Pushes the counter account ID prefix, then suffix, leaving the suffix on top.
+4. Calls `copy_count`, which prepares the foreign call and stores the result.
+5. Truncates the stack.
 
 ## Key Miden Client Concepts for FPI
 
@@ -575,7 +699,7 @@ To run a full working example navigate to the `web-client` directory in the [mid
 ```bash
 cd web-client
 yarn install
-yarn start
+yarn dev
 ```
 
 ### Resetting the `MidenClientDB`

--- a/docs/src/web-client/mint_consume_create_tutorial.md
+++ b/docs/src/web-client/mint_consume_create_tutorial.md
@@ -7,6 +7,15 @@ import { CodeSdkTabs } from '@site/src/components';
 
 _Using the Miden client in TypeScript to mint, consume, and transfer assets_
 
+:::note v0.16 setup
+
+Follow the [network and fee setup](./setup_guide.md#network-and-fee-setup)
+and copy the shared support files imported by the complete example.
+For React snippets, initialize `authScheme` with `await tutorialAuthScheme()`
+as shown in the complete example.
+
+:::
+
 ## Overview
 
 In the previous tutorial, we set up the foundation - creating Alice's wallet and deploying a faucet. Now we'll put these to use by minting and transferring assets.
@@ -102,8 +111,9 @@ _The standard asset transfer note on Miden is the P2ID note (Pay-to-Id). There i
 Now that Alice has tokens in her account, she can send some to Bob:
 
 <CodeSdkTabs example={{
-react: { code: `// 7. Send 100 tokens to Bob
-const bobAddress = 'mtst1arpsz3jlmjxl7u2jjzfsc0wyqyaas6a9';
+react: { code: `// 7. Create Bob and send him 100 tokens
+const bob = await createWallet({ storageMode: StorageMode.Public, authScheme });
+const bobAddress = bob.id().toString();
 console.log("Sending tokens to Bob's account...");
 await send({
 .from: alice,
@@ -113,8 +123,11 @@ await send({
 .noteType: NoteVisibility.Public,
 });
 console.log('Tokens sent successfully!');` },
-typescript: { code: `// 7. Send tokens to Bob
-const bobAddress = 'mtst1arpsz3jlmjxl7u2jjzfsc0wyqyaas6a9';
+typescript: { code: `// 7. Create Bob and send him tokens
+const bob = await client.accounts.create({
+.storage: StorageMode.Public,
+});
+const bobAddress = bob.id().toString();
 console.log("Sending tokens to Bob's account...");
 
 await client.transactions.send({
@@ -143,89 +156,123 @@ Here's the complete `lib/react/createMintConsume.tsx` (React) or `lib/createMint
 <CodeSdkTabs example={{
 react: { code: `'use client';
 
-import { MidenProvider, useMiden, useCreateWallet, useCreateFaucet, useMint, useConsume, useSend, useWaitForCommit, useWaitForNotes } from '@miden-sdk/react/lazy';
+import {
+.MidenProvider,
+.useMiden,
+.useCreateWallet,
+.useCreateFaucet,
+.useMint,
+.useConsume,
+.useSend,
+} from '@miden-sdk/react/lazy';
 import { NoteVisibility, StorageMode } from '@miden-sdk/miden-sdk/lazy';
+import { tutorialNetwork } from '../feeSupport';
+import {
+.TutorialButton,
+.tutorialAuthScheme,
+.useTutorialSupport,
+} from './tutorialSupport';
 
 function CreateMintConsumeInner() {
-.const { isReady } = useMiden();
+.const { sync } = useMiden();
 .const { createWallet } = useCreateWallet();
 .const { createFaucet } = useCreateFaucet();
 .const { mint } = useMint();
 .const { consume } = useConsume();
 .const { send } = useSend();
-.const { waitForCommit } = useWaitForCommit();
-.const { waitForConsumableNotes } = useWaitForNotes();
+.const {
+..fundAccount,
+..committed,
+..waitForTokenNotes,
+..waitForNote,
+..assertBalance,
+.} = useTutorialSupport();
 
 .const run = async () => {
-..// 1. Create Alice's wallet (public, mutable)
-..console.log('Creating account for Alice…');
-..const alice = await createWallet({ storageMode: StorageMode.Public });
-..const aliceId = alice.id().toString();
-..console.log('Alice ID:', aliceId);
+..console.log('Synchronizing before creating accounts…');
+..await sync();
+..console.log('Creating Alice with useCreateWallet…');
+..const authScheme = await tutorialAuthScheme();
+..// Native fee tokens and the tutorial's MID token are separate assets.
+..const alice = await createWallet({
+...storageMode: StorageMode.Public,
+...authScheme,
+..});
+..console.log('Alice ID:', alice.id().toString());
+..await fundAccount(alice);
 
-..// 2. Deploy a fungible faucet
-..console.log('Creating faucet…');
+..// v0.16 faucets include BasicWallet, so they can receive fee funding.
 ..const faucet = await createFaucet({
 ...tokenSymbol: 'MID',
 ...decimals: 8,
 ...maxSupply: BigInt(1_000_000),
 ...storageMode: StorageMode.Public,
+...authScheme,
 ..});
-..const faucetId = faucet.id().toString();
-..console.log('Faucet ID:', faucetId);
+..console.log('Faucet ID:', faucet.id().toString());
+..await fundAccount(faucet);
 
-..// 3. Mint 1000 tokens to Alice
-..console.log('Minting tokens to Alice...');
-..const mintResult = await mint({
-...faucetId,
-...targetAccountId: aliceId,
+..await sync();
+..const minted = await mint({
+...faucetId: faucet,
+...targetAccountId: alice,
 ...amount: BigInt(1000),
 ...noteType: NoteVisibility.Public,
 ..});
-..console.log('Mint tx:', mintResult.transactionId);
+..await committed(minted.transactionId);
+..const notes = await waitForTokenNotes(alice, faucet);
+..const consumed = await consume({ accountId: alice.id().toString(), notes });
+..await committed(consumed.transactionId);
+..await assertBalance(alice, faucet, BigInt(1000));
 
-..// 4. Wait for the mint transaction to be committed
-..await waitForCommit(mintResult.transactionId);
-
-..// 5. Wait for consumable notes to appear, then consume them
-..const notes = await waitForConsumableNotes({ accountId: alice });
-..console.log('Consumable notes:', notes.length);
-
-..console.log('Consuming minted notes...');
-..await consume({ accountId: alice.id().toString(), notes });
-..console.log('Notes consumed.');
-
-..// 7. Send 100 tokens to Bob
-..const bobAddress = 'mtst1arpsz3jlmjxl7u2jjzfsc0wyqyaas6a9';
-..console.log("Sending tokens to Bob's account...");
-..await send({
+..const bob = await createWallet({
+...storageMode: StorageMode.Public,
+...authScheme,
+..});
+..const sent = await send({
 ...from: alice,
-...to: bobAddress,
+...to: bob,
 ...assetId: faucet,
 ...amount: BigInt(100),
 ...noteType: NoteVisibility.Public,
+...returnNote: true,
 ..});
+..await committed(sent.txId);
+..if (!sent.note) throw new Error('Send did not return its output note');
+..await waitForNote(sent.note.id().toString());
+..await assertBalance(alice, faucet, BigInt(900));
 ..console.log('Tokens sent successfully!');
 .};
 
 .return (
-..<div>
-...<button onClick={run} disabled={!isReady}>
-....{isReady ? 'Run: Create, Mint, Consume & Send' : 'Initializing…'}
-...</button>
-..</div>
+..<TutorialButton
+...name="createMintConsume"
+...label="Run: Create, Mint, Consume & Send"
+...run={run}
+../>
 .);
 }
 
 export default function CreateMintConsume() {
 .return (
-..<MidenProvider config={{ rpcUrl: 'testnet', prover: 'local' }}>
+..<MidenProvider
+...config={{
+....rpcUrl: tutorialNetwork(),
+....prover: 'local',
+....autoSyncInterval: 0,
+...}}
+..>
 ...<CreateMintConsumeInner />
 ..</MidenProvider>
 .);
 }`},
-  typescript: { code:`// lib/createMintConsume.ts
-import { MidenClient, NoteVisibility, StorageMode } from '@miden-sdk/miden-sdk/lazy';
+  typescript: { code: `// lib/createMintConsume.ts
+import { NoteVisibility, StorageMode } from '@miden-sdk/miden-sdk/lazy';
+import {
+.consumeAllFeeAware,
+.createTutorialClient,
+.fundAccountForFees,
+} from './feeSupport';
 
 export async function createMintConsume(): Promise<void> {
 .if (typeof window === 'undefined') {
@@ -233,11 +280,8 @@ export async function createMintConsume(): Promise<void> {
 ..return;
 .}
 
-.// Wait for WASM to be ready before touching any wasm-bindgen type.
-.await MidenClient.ready();
-
-.const client = await MidenClient.create({
-..rpcUrl: 'https://rpc.testnet.miden.io',
+.const client = await createTutorialClient({
+..proverUrl: 'local',
 .});
 
 .// 1. Sync with the latest blockchain state
@@ -251,7 +295,8 @@ export async function createMintConsume(): Promise<void> {
 .});
 .console.log('Alice ID:', alice.id().toString());
 
-.// 3. Deploy a fungible faucet
+.// 3. Create our own fungible faucet. SDK v0.16 includes BasicWallet,
+.// allowing both accounts to consume native fee funding before minting MID.
 .console.log('Creating faucet…');
 .const faucet = await client.accounts.create({
 ..type: 0, // 0 = FungibleFaucet
@@ -261,38 +306,47 @@ export async function createMintConsume(): Promise<void> {
 ..storage: StorageMode.Public,
 .});
 .console.log('Faucet ID:', faucet.id().toString());
+.await fundAccountForFees(client, alice);
+.await fundAccountForFees(client, faucet);
 
-.// 4. Mint tokens to Alice
-
+.// 4. Mint tokens to Alice.
 .console.log('Minting tokens to Alice...');
+.await client.sync();
 .const { txId: mintTxId } = await client.transactions.mint({
 ..account: faucet,
 ..to: alice,
 ..amount: BigInt(1000),
 ..type: NoteVisibility.Public,
 .});
-
 .console.log('Waiting for transaction confirmation...');
-.await client.transactions.waitFor(mintTxId);
+.await client.transactions.waitFor(mintTxId, { timeout: 120_000 });
 
-.// 5-6. Consume all available notes for Alice in a single transaction
+.// 5-6. Consume all available notes for Alice.
 .console.log('Consuming minted notes...');
-.await client.transactions.consumeAll({
-..account: alice,
-.});
+.await consumeAllFeeAware(client, alice);
 
 .console.log('Notes consumed.');
 
 .// 7. Send tokens to Bob
-.const bobAddress = 'mtst1arpsz3jlmjxl7u2jjzfsc0wyqyaas6a9';
+.const bob = await client.accounts.create({
+..storage: StorageMode.Public,
+.});
 .console.log("Sending tokens to Bob's account...");
-.await client.transactions.send({
+.await client.sync();
+.const { txId: sendTxId } = await client.transactions.send({
 ..account: alice,
-..to: bobAddress,
+..to: bob,
 ..token: faucet,
 ..amount: BigInt(100),
 ..type: NoteVisibility.Public,
+..waitForConfirmation: true,
+..timeout: 120_000,
 .});
+.console.log(\`Transaction committed: \${sendTxId.toHex()}\`);
+.const updatedAlice = await client.accounts.get(alice);
+.const balance = updatedAlice?.vault().getBalance(faucet.id());
+.if (balance !== BigInt(900))
+..throw new Error(\`Expected Alice to retain 900 MID, got \${balance}\`);
 .console.log('Tokens sent successfully!');
 }` },
 }} reactFilename="lib/react/createMintConsume.tsx" tsFilename="lib/createMintConsume.ts" />

--- a/docs/src/web-client/react_wallet_tutorial.md
+++ b/docs/src/web-client/react_wallet_tutorial.md
@@ -34,6 +34,17 @@ By the end of this tutorial, you will have a working wallet that can:
 - Familiarity with React and TypeScript
 - `yarn`
 
+:::note v0.16 testnet and fees
+
+A new wallet needs native fee tokens before sending assets. Request and claim a
+funding note from the testnet faucet, as described in the
+[fee setup](./setup_guide.md#network-and-fee-setup). Claim the returned
+note ID and wait for confirmation before sending.
+
+Select testnet in both the client and any external wallet adapter.
+
+:::
+
 ---
 
 ## Step 1: Project Setup and MidenProvider
@@ -50,7 +61,7 @@ First, create a new Vite + React project and install the Miden React SDK.
 2. Install the Miden React SDK:
 
    ```bash
-   yarn add @miden-sdk/react
+   yarn add @miden-sdk/miden-sdk@0.16.0 @miden-sdk/react@0.16.0
    ```
 
 3. Configure the `MidenProvider` in your `main.tsx` file. The provider initializes the Miden client and makes it available to all child components:
@@ -78,8 +89,8 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
 
 The `MidenProvider` accepts a `config` object with the following options:
 
-- `rpcUrl`: The RPC endpoint to connect to (`"testnet"` or a custom URL)
-- `prover`: The prover to use (`"testnet"` for delegated proving, or `"local"` for local proving)
+- `rpcUrl`: The RPC endpoint to connect to (`"testnet"`, `"devnet"`, or a custom URL)
+- `prover`: The prover to use (`"testnet"` for testnet delegated proving, or `"local"` for local proving)
 
 ---
 
@@ -146,6 +157,7 @@ The `useCreateWallet()` hook provides a function to create new wallet accounts.
 
 ```tsx
 import { useMiden, useAccounts, useCreateWallet } from '@miden-sdk/react/lazy';
+import { getWasmOrThrow } from '@miden-sdk/miden-sdk/lazy';
 
 export default function App() {
   const { isReady, error } = useMiden();
@@ -161,7 +173,12 @@ export default function App() {
     return (
       <div>
         <h1>Wallet</h1>
-        <button onClick={() => createWallet()} disabled={isCreating}>
+        <button
+          onClick={async () => createWallet({
+            authScheme: (await getWasmOrThrow()).AuthScheme.AuthRpoFalcon512,
+          })}
+          disabled={isCreating}
+        >
           {isCreating ? 'Creating...' : 'Create wallet'}
         </button>
       </div>
@@ -175,6 +192,10 @@ function Wallet({ accountId }: { accountId: string }) {
   return <div>Wallet: {accountId}</div>;
 }
 ```
+
+Pass the low-level Falcon enum explicitly with the pinned lazy React SDK. The
+high-level client's authentication enum is not interchangeable with the numeric
+enum expected by this hook.
 
 The `useCreateWallet()` hook returns:
 
@@ -465,7 +486,7 @@ import {
   useConsume,
   useSend,
 } from '@miden-sdk/react/lazy';
-import { NoteVisibility } from '@miden-sdk/miden-sdk/lazy';
+import { NoteVisibility, getWasmOrThrow } from '@miden-sdk/miden-sdk/lazy';
 
 const Panel = ({ title, children }: { title: string; children: ReactNode }) => (
   <div className="panel">
@@ -478,7 +499,9 @@ export default function App() {
   const { isReady, error } = useMiden();
   const { wallets, isLoading } = useAccounts();
   const { createWallet, isCreating } = useCreateWallet();
-  const handleCreate = () => createWallet();
+  const handleCreate = async () => createWallet({
+    authScheme: (await getWasmOrThrow()).AuthScheme.AuthRpoFalcon512,
+  });
   const createLabel = isCreating ? 'Creating...' : 'Create wallet';
 
   if (error) return <div className="center">Error: {error.message}</div>;
@@ -633,27 +656,42 @@ function Wallet({ accountId }: { accountId: string }) {
 
 ## Running the Example
 
-To run a full working example, navigate to the `packages/react-sdk/examples/wallet` directory in the [miden-client](https://github.com/0xMiden/miden-client/) repository:
+The complete upstream wallet example lives in
+[`packages/react-sdk/examples/wallet` in the web-sdk v0.16.0 release](https://github.com/0xMiden/web-sdk/tree/v0.16.0/packages/react-sdk/examples/wallet).
+Follow that example's README for its workspace setup and select testnet in its
+provider configuration.
+
+To exercise this repository's three React transaction examples on testnet:
 
 ```bash
-git clone https://github.com/0xMiden/miden-client.git
-cd miden-client/packages/react-sdk/examples/wallet
+cd web-client
 yarn install
 yarn dev
 ```
 
+Open `/react-tutorials` and select an example. These examples create and fund their
+own accounts; the wallet UI above starts with an empty wallet that needs funding.
+
 ### Resetting the MidenClientDB
 
-The Miden client stores account and note data in the browser's IndexedDB. To clear this data, paste the following into your browser console:
+The Miden client stores account and note data in the browser's IndexedDB.
+Upgrading from v0.15 automatically recreates the Miden store; export private
+notes and any other local data you need before upgrading. To manually reset only
+Miden databases on the current origin, close other tabs using the client and run:
 
 ```javascript
 (async () => {
   const dbs = await indexedDB.databases();
   for (const db of dbs) {
-    await indexedDB.deleteDatabase(db.name);
-    console.log(`Deleted database: ${db.name}`);
+    if (!db.name?.startsWith('MidenClientDB')) continue;
+    await new Promise((resolve, reject) => {
+      const request = indexedDB.deleteDatabase(db.name);
+      request.onsuccess = () => resolve();
+      request.onerror = () => reject(request.error);
+      request.onblocked = () => reject(new Error('Close other Miden tabs and retry'));
+    });
+    console.log(`Deleted Miden database: ${db.name}`);
   }
-  console.log('All databases deleted.');
 })();
 ```
 
@@ -701,13 +739,15 @@ This unified interface means your wallet UI code works the same regardless of wh
 
 [Para](https://para.space/) provides a modal-based authentication flow that allows users to sign in with their EVM wallets (MetaMask, WalletConnect, etc.).
 
-**Installation:**
+:::note Compatible Para release required
 
-```bash
-yarn add @miden-sdk/use-miden-para-react
-```
+`@miden-sdk/use-miden-para-react@0.15.1` requires v0.15 SDK packages.
+The pattern below needs an adapter release with v0.16-compatible peer dependencies;
+check the [package metadata](https://registry.npmjs.org/@miden-sdk/use-miden-para-react) before installing.
 
-**Usage:**
+:::
+
+**Integration pattern (requires a compatible adapter):**
 
 ```tsx
 import { ParaSignerProvider } from '@miden-sdk/use-miden-para-react';
@@ -753,13 +793,15 @@ function Wallet() {
 
 [Turnkey](https://turnkey.com/) provides programmatic key management, giving your application full control over the authentication flow.
 
-**Installation:**
+:::note Compatible Turnkey release required
 
-```bash
-yarn add @miden-sdk/miden-turnkey-react @turnkey/sdk-browser
-```
+`@miden-sdk/miden-turnkey-react@1.15.1` requires v0.15 SDK packages.
+The pattern below needs an adapter release with v0.16-compatible peer dependencies;
+check the [package metadata](https://registry.npmjs.org/@miden-sdk/miden-turnkey-react) before installing.
 
-**Usage:**
+:::
+
+**Integration pattern (requires a compatible adapter):**
 
 ```tsx
 import { TurnkeySignerProvider } from '@miden-sdk/miden-turnkey-react';
@@ -809,18 +851,19 @@ The `useTurnkeySigner()` hook is available for advanced use cases where you need
 **Installation:**
 
 ```bash
-yarn add @miden-sdk/miden-wallet-adapter-react
+yarn add @miden-sdk/miden-wallet-adapter-react@0.16.0 @miden-sdk/miden-wallet-adapter-base@0.16.0
 ```
 
 **Usage:**
 
 ```tsx
 import { MidenFiSignerProvider } from '@miden-sdk/miden-wallet-adapter-react';
+import { WalletAdapterNetwork } from '@miden-sdk/miden-wallet-adapter-base';
 import { MidenProvider, useSigner } from '@miden-sdk/react/lazy';
 
 function App() {
   return (
-    <MidenFiSignerProvider network="testnet">
+    <MidenFiSignerProvider network={WalletAdapterNetwork.Testnet}>
       <MidenProvider config={{ rpcUrl: 'testnet' }}>
         <Wallet />
       </MidenProvider>
@@ -845,11 +888,14 @@ function Wallet() {
 
 **MidenFiSignerProvider Props:**
 
-| Prop                    | Type                      | Description                            |
-| ----------------------- | ------------------------- | -------------------------------------- |
-| `network`               | `"testnet" \| "localnet"` | Target network                         |
-| `privateDataPermission` | `boolean`                 | Whether to request private data access |
-| `allowedPrivateData`    | `string[]`                | List of allowed private data types     |
+| Prop                    | Type                    | Description                              |
+| ----------------------- | ----------------------- | ---------------------------------------- |
+| `network`               | `WalletAdapterNetwork`  | `Testnet`, `Devnet`, or `Localnet`       |
+| `privateDataPermission` | `PrivateDataPermission` | Permission level for private data access |
+| `allowedPrivateData`    | `AllowedPrivateData`    | Private-data categories the app requests |
+
+Import the enums from `@miden-sdk/miden-wallet-adapter-base`. Do not pass raw
+network strings, booleans, or string arrays in place of these enum values.
 
 ---
 
@@ -934,5 +980,5 @@ The `SignerContextValue` interface requires:
 Now that you've built a React wallet, explore these related topics:
 
 - [Creating Multiple Notes in a Single Transaction](./creating_multiple_notes_tutorial.md) - Learn about batch operations
-- [Miden React SDK Reference](https://github.com/0xMiden/miden-client/tree/main/packages/react-sdk) - Full API documentation
+- [Miden React SDK Reference](https://github.com/0xMiden/web-sdk/tree/v0.16.0/packages/react-sdk) - Full API documentation
 - [Miden Documentation](https://docs.miden.io/) - Core Miden concepts

--- a/docs/src/web-client/setup_guide.md
+++ b/docs/src/web-client/setup_guide.md
@@ -16,13 +16,13 @@ This guide covers the configuration required to use the Miden web SDK (`@miden-s
 ## Install the SDK
 
 ```bash
-yarn add @miden-sdk/miden-sdk
+yarn add @miden-sdk/miden-sdk@0.16.0
 ```
 
 For React hook support:
 
 ```bash
-yarn add @miden-sdk/react
+yarn add @miden-sdk/miden-sdk@0.16.0 @miden-sdk/react@0.16.0
 ```
 
 These tutorials use Next.js, so all code examples import from the SDK's `/lazy` subpath — see [Entry points: eager vs lazy](#entry-points-eager-vs-lazy) below for why that's required.
@@ -109,9 +109,7 @@ export async function doSomething() {
   if (typeof window === 'undefined') return;
   await MidenClient.ready();
   // Safe to construct wasm-bindgen types from here.
-  const client = await MidenClient.create({
-    rpcUrl: 'https://rpc.testnet.miden.io',
-  });
+  const client = await MidenClient.createTestnet();
   // …
 }
 ```
@@ -120,15 +118,16 @@ In React, the `@miden-sdk/react/lazy` provider manages WASM readiness for you vi
 
 ```tsx
 import { useMiden, useCreateWallet } from '@miden-sdk/react/lazy';
+import { getWasmOrThrow } from '@miden-sdk/miden-sdk/lazy';
 
 function Component() {
   const { isReady } = useMiden();
   const { createWallet } = useCreateWallet();
   return (
     <button
-      onClick={() =>
+      onClick={async () =>
         createWallet({
-          /* … */
+          authScheme: (await getWasmOrThrow()).AuthScheme.AuthRpoFalcon512,
         })
       }
       disabled={!isReady}
@@ -144,6 +143,31 @@ function Component() {
 Never construct wasm-bindgen types (`AccountId`, `Note`, `createP2IDNote`, `TransactionRequestBuilder`, etc.) at module top level or in a render-body `useMemo` — always inside an effect, event handler, or async hook callback where WASM is already initialized. For display-only cases like shortening an address, slice the bech32 string directly (`addr.slice(0, 8) + '…' + addr.slice(-4)`); don't parse it with `AccountId.fromBech32()` just to get a prefix.
 
 :::
+
+## Network and fee setup
+
+The v0.16 examples use testnet by default. Run them with `yarn tutorials --web`
+from the repository root; add `--web=react:createMintConsume` to select a React example.
+For explicit devnet testing, run `TUTORIAL_NETWORK=devnet yarn tutorials --web`.
+
+New accounts need the native fee asset before executing transactions. The examples
+request a public P2ID note from the faucet and consume it as their first transaction,
+paying that transaction's fee from the input note. User-created faucets include
+`BasicWallet`, so they can receive fee funding too. The SDK supplies native
+fee-conversion data automatically.
+
+Copy `web-client/lib/feeSupport.ts` with the complete TypeScript examples and
+`web-client/lib/react/tutorialSupport.tsx` with React examples. These repository
+helpers fund accounts, synchronize state, and await confirmation. They select
+application notes by ID or token and exclude `TX_FEE` notes (tag `0xFEE`).
+
+The React helper's `tutorialAuthScheme()` returns the low-level Falcon enum
+required by wallet and faucet hooks; it differs from the high-level client enum.
+
+The faucet URL and funding amount default to the selected network's faucet and its advertised
+`base_amount`. Override them with `NEXT_PUBLIC_MIDEN_FAUCET_URL` and
+`NEXT_PUBLIC_MIDEN_FEE_AMOUNT`, or `MIDEN_FAUCET_URL` and `MIDEN_FEE_AMOUNT` in the
+repository runner. `NEXT_PUBLIC_MIDEN_NETWORK` selects the network when running the app directly.
 
 ## Node.js 22+ `localStorage` polyfill
 

--- a/docs/src/web-client/unauthenticated_note_how_to.md
+++ b/docs/src/web-client/unauthenticated_note_how_to.md
@@ -7,6 +7,15 @@ import { CodeSdkTabs } from '@site/src/components';
 
 _Using unauthenticated notes for optimistic note consumption with the Miden client_
 
+:::note v0.16 setup
+
+Follow the [network and fee setup](./setup_guide.md#network-and-fee-setup)
+and copy the shared support files imported by the complete example.
+For React snippets, initialize `authScheme` with `await tutorialAuthScheme()`
+as shown in the complete example.
+
+:::
+
 ## Overview
 
 In this tutorial, we will explore how to leverage unauthenticated notes on Miden to settle transactions faster than the blocktime using the Miden client. Unauthenticated notes are essentially UTXOs that have not yet been fully committed into a block. This feature allows the notes to be created and consumed within the same batch during [batch production](https://0xmiden.github.io/miden-docs/imported/miden-base/src/blockchain.html#batch-production).
@@ -43,7 +52,7 @@ This tutorial assumes you have a basic understanding of Miden assembly. To quick
    - Install the Miden SDK.
 
 2. **Client Initialization:**
-   - Set up the Miden client to connect with the Miden testnet.
+   - Set up the Miden client to connect with Miden testnet.
 
 3. **Account Creation:**
    - Create wallet accounts for Alice and multiple transfer recipients.
@@ -77,8 +86,8 @@ This tutorial assumes you have a basic understanding of Miden assembly. To quick
 3. Install the Miden SDK:
 
 <CodeSdkTabs example={{
-  react: { code: `yarn add @miden-sdk/react @miden-sdk/miden-sdk@0.15.2` },
-  typescript: { code: `yarn add @miden-sdk/miden-sdk@0.15.2` },
+  react: { code: `yarn add @miden-sdk/react@0.16.0 @miden-sdk/miden-sdk@0.16.0` },
+  typescript: { code: `yarn add @miden-sdk/miden-sdk@0.16.0` },
 }} reactFilename="" tsFilename="" />
 
 **NOTE!**: Be sure to add the `--webpack` command to your `package.json` when running the `dev script`. The dev script should look like this:
@@ -162,63 +171,80 @@ Copy and paste the following code into `lib/react/unauthenticatedNoteTransfer.ts
 <CodeSdkTabs example={{
 react: { code: `'use client';
 
-import { MidenProvider, useMiden, useCreateWallet, useCreateFaucet, useMint, useConsume, useSend, useWaitForCommit, useWaitForNotes } from '@miden-sdk/react/lazy';
+import {
+.MidenProvider,
+.useMiden,
+.useCreateWallet,
+.useCreateFaucet,
+.useMint,
+.useConsume,
+.useSend,
+.type Account,
+} from '@miden-sdk/react/lazy';
 import { NoteVisibility, StorageMode } from '@miden-sdk/miden-sdk/lazy';
+import { tutorialExplorerUrl, tutorialNetwork } from '../feeSupport';
+import {
+.TutorialButton,
+.tutorialAuthScheme,
+.useTutorialSupport,
+} from './tutorialSupport';
 
 function UnauthenticatedNoteTransferInner() {
-.const { isReady } = useMiden();
+.const { sync } = useMiden();
 .const { createWallet } = useCreateWallet();
 .const { createFaucet } = useCreateFaucet();
 .const { mint } = useMint();
 .const { consume } = useConsume();
 .const { send } = useSend();
-.const { waitForCommit } = useWaitForCommit();
-.const { waitForConsumableNotes } = useWaitForNotes();
+.const { fundAccount, committed, waitForTokenNotes, assertBalance } =
+..useTutorialSupport();
 
 .const run = async () => {
-..// 1. Create Alice and 5 wallets for the transfer chain
-..console.log('Creating accounts…');
-..const alice = await createWallet({ storageMode: StorageMode.Public });
-..console.log('Alice account ID:', alice.id().toString());
-
-..const wallets = [];
-..for (let i = 0; i < 5; i++) {
-...const wallet = await createWallet({ storageMode: StorageMode.Public });
+..await sync();
+..const authScheme = await tutorialAuthScheme();
+..const alice = await createWallet({
+...storageMode: StorageMode.Public,
+...authScheme,
+..});
+..console.log('Alice ID:', alice.id().toString());
+..await fundAccount(alice);
+..const wallets: Account[] = [];
+..for (let index = 0; index < 5; index += 1) {
+...const wallet = await createWallet({
+....storageMode: StorageMode.Public,
+....authScheme,
+...});
+...console.log(\`Wallet \${index}:\`, wallet.id().toString());
+...// Every recipient pays fees when consuming and forwarding the note.
+...await fundAccount(wallet);
 ...wallets.push(wallet);
-...console.log(\`Wallet \${i}:\`, wallet.id().toString());
 ..}
-
-..// 2. Deploy a fungible faucet
 ..const faucet = await createFaucet({
 ...tokenSymbol: 'MID',
 ...decimals: 8,
 ...maxSupply: BigInt(1_000_000),
 ...storageMode: StorageMode.Public,
+...authScheme,
 ..});
 ..console.log('Faucet ID:', faucet.id().toString());
-
-..// 3. Mint 10,000 MID to Alice
-..const mintResult = await mint({
+..await fundAccount(faucet);
+..await sync();
+..const minted = await mint({
 ...faucetId: faucet,
 ...targetAccountId: alice,
 ...amount: BigInt(10_000),
 ...noteType: NoteVisibility.Public,
 ..});
+..await committed(minted.transactionId);
+..const notes = await waitForTokenNotes(alice, faucet);
+..const consumed = await consume({ accountId: alice.id().toString(), notes });
+..await committed(consumed.transactionId);
 
-..console.log('Waiting for settlement…');
-..await waitForCommit(mintResult.transactionId);
-
-..// 4. Consume the freshly minted notes
-..const notes = await waitForConsumableNotes({ accountId: alice });
-..await consume({ accountId: alice.id().toString(), notes });
-
-..// 5. Create the unauthenticated note transfer chain:
-..// Alice → Wallet 0 → Wallet 1 → Wallet 2 → Wallet 3 → Wallet 4
-..console.log('Starting unauthenticated transfer chain…');
+..// Pass full Note objects directly, without fetching an inclusion proof.
 ..let currentSender = alice;
-..for (let i = 0; i < wallets.length; i++) {
-...const wallet = wallets[i];
-...const { note } = await send({
+..for (let index = 0; index < wallets.length; index += 1) {
+...const wallet = wallets[index];
+...const sent = await send({
 ....from: currentSender,
 ....to: wallet,
 ....assetId: faucet,
@@ -226,58 +252,68 @@ function UnauthenticatedNoteTransferInner() {
 ....noteType: NoteVisibility.Public,
 ....returnNote: true,
 ...});
-...const result = await consume({ accountId: wallet.id().toString(), notes: [note] });
+...if (!sent.note) throw new Error('Send did not return its output note');
+...const received = await consume({
+....accountId: wallet.id().toString(),
+....notes: [sent.note],
+...});
+...await committed(sent.txId);
+...await committed(received.transactionId);
+...await assertBalance(wallet, faucet, BigInt(50));
 ...console.log(
-....\`Transfer \${i + 1}: https://testnet.midenscan.com/tx/\${result.transactionId}\`,
+....\`Transfer \${index + 1}: \${tutorialExplorerUrl()}/tx/\${received.transactionId}\`,
 ...);
 ...currentSender = wallet;
 ..}
-
+..await assertBalance(alice, faucet, BigInt(9950));
+..for (const wallet of wallets.slice(0, -1))
+...await assertBalance(wallet, faucet, BigInt(0));
 ..console.log('Asset transfer chain completed ✅');
 .};
 
 .return (
-..<div>
-...<button onClick={run} disabled={!isReady}>
-....{isReady ? 'Run: Unauthenticated Note Transfer' : 'Initializing…'}
-...</button>
-..</div>
+..<TutorialButton
+...name="unauthenticatedNoteTransfer"
+...label="Run: Unauthenticated Note Transfer"
+...run={run}
+../>
 .);
 }
 
 export default function UnauthenticatedNoteTransfer() {
 .return (
-..<MidenProvider config={{ rpcUrl: 'testnet', prover: 'local' }}>
+..<MidenProvider
+...config={{
+....rpcUrl: tutorialNetwork(),
+....prover: 'local',
+....autoSyncInterval: 0,
+...}}
+..>
 ...<UnauthenticatedNoteTransferInner />
 ..</MidenProvider>
 .);
 }`},
-  typescript: { code:`import {
-.MidenClient,
-.NoteVisibility,
-.StorageMode,
-} from '@miden-sdk/miden-sdk/lazy';
+  typescript: { code: `import { NoteVisibility, StorageMode } from '@miden-sdk/miden-sdk/lazy';
+import {
+.consumeAllFeeAware,
+.createTutorialClient,
+.fundAccountForFees,
+.tutorialExplorerUrl,
+} from './feeSupport';
 
-/\*\*
-.\* Demonstrates unauthenticated note transfer chain against Miden testnet
-.\* Creates a chain of P2ID (Pay to ID) notes: Alice → wallet 1 → wallet 2 → wallet 3 → wallet 4
-.\*
-.\* @throws {Error} If the function cannot be executed in a browser environment
-.\*/
 export async function unauthenticatedNoteTransfer(): Promise<void> {
 .// Ensure this runs only in a browser context
 .if (typeof window === 'undefined') return console.warn('Run in browser');
 
-.// Wait for WASM to be ready before touching any wasm-bindgen type.
-.await MidenClient.ready();
-
-.const client = await MidenClient.create({
-..rpcUrl: 'https://rpc.testnet.miden.io',
+.const client = await createTutorialClient({
+..proverUrl: 'local',
 .});
 
 .console.log('Latest block:', (await client.sync()).blockNum());
 
-.// ── Creating accounts ──────────────────────────────────────────────────────
+.// ── Creating new account ──────────────────────────────────────────────────────
+.console.log('Creating accounts');
+
 .console.log('Creating account for Alice…');
 .const alice = await client.accounts.create({
 ..storage: StorageMode.Public,
@@ -293,7 +329,6 @@ export async function unauthenticatedNoteTransfer(): Promise<void> {
 ..console.log('wallet ', i.toString(), wallet.id().toString());
 .}
 
-.// ── Creating new faucet ──────────────────────────────────────────────────────
 .const faucet = await client.accounts.create({
 ..type: 0, // 0 = FungibleFaucet
 ..symbol: 'MID',
@@ -302,22 +337,23 @@ export async function unauthenticatedNoteTransfer(): Promise<void> {
 ..storage: StorageMode.Public,
 .});
 .console.log('Faucet ID:', faucet.id().toString());
+.await fundAccountForFees(client, alice);
+.await fundAccountForFees(client, faucet);
 
-.// ── Mint 10,000 MID to Alice ──────────────────────────────────────────────────────
+.await client.sync();
 .const { txId: mintTxId } = await client.transactions.mint({
 ..account: faucet,
 ..to: alice,
 ..amount: BigInt(10_000),
 ..type: NoteVisibility.Public,
 .});
-
 .console.log('Waiting for settlement');
-.await client.transactions.waitFor(mintTxId);
+.await client.transactions.waitFor(mintTxId, { timeout: 120_000 });
+.await consumeAllFeeAware(client, alice);
 
-.// ── Consume the freshly minted note ──────────────────────────────────────────────
-.await client.transactions.consumeAll({
-..account: alice,
-.});
+.for (const wallet of wallets) {
+..await fundAccountForFees(client, wallet);
+.}
 
 .// ── Create unauthenticated note transfer chain ─────────────────────────────────────────────
 .// Alice → wallet 1 → wallet 2 → wallet 3 → wallet 4
@@ -330,25 +366,37 @@ export async function unauthenticatedNoteTransfer(): Promise<void> {
 ..console.log('Sender:', sender.id().toString());
 ..console.log('Receiver:', receiver.id().toString());
 
-..const { note } = await client.transactions.send({
+..await client.sync();
+..const { note, txId: sendTxId } = await client.transactions.send({
 ...account: sender,
 ...to: receiver,
 ...token: faucet,
 ...amount: BigInt(50),
 ...type: NoteVisibility.Public,
 ...returnNote: true,
+...waitForConfirmation: false,
 ..});
 
+..// Pass the full note before waiting for the sender's transaction.
+..await client.sync();
 ..const { txId: consumeTxId } = await client.transactions.consume({
 ...account: receiver,
 ...notes: [note],
+...waitForConfirmation: true,
+...timeout: 120_000,
 ..});
+..await client.transactions.waitFor(sendTxId, { timeout: 120_000 });
+..console.log(\`Transaction committed: \${consumeTxId.toHex()}\`);
 
 ..console.log(
-...\`Consumed Note Tx on MidenScan: https://testnet.midenscan.com/tx/\${consumeTxId.toHex()}\`,
+...\`Consumed Note Tx on MidenScan: \${tutorialExplorerUrl()}/tx/\${consumeTxId.toHex()}\`,
 ..);
 .}
 
+.const lastWallet = await client.accounts.get(wallets[wallets.length - 1]);
+.const balance = lastWallet?.vault().getBalance(faucet.id());
+.if (balance !== BigInt(50))
+..throw new Error(\`Expected last wallet to hold 50 MID, got \${balance}\`);
 .console.log('Asset transfer chain completed ✅');
 }` },
 }} reactFilename="lib/react/unauthenticatedNoteTransfer.tsx" tsFilename="lib/unauthenticatedNoteTransfer.ts" />
@@ -454,7 +502,7 @@ To run a full working example navigate to the `web-client` directory in the [mid
 ```bash
 cd web-client
 yarn install
-yarn start
+yarn dev
 ```
 
 ### Continue learning

--- a/examples/bridging-app/.env.example
+++ b/examples/bridging-app/.env.example
@@ -1,15 +1,21 @@
 # Miden SDK network configuration
-# Supported values: devnet | testnet | local | https://your-rpc-url
+# Wallet network: devnet | testnet | local
+VITE_MIDEN_NETWORK=testnet
+# RPC: devnet | testnet | local | https://your-rpc-url
 VITE_MIDEN_RPC_URL=testnet
 
 # Prover configuration
 # Supported values: devnet | testnet | local | https://your-prover-url
 VITE_MIDEN_PROVER=testnet
 
-# Epoch allocator service URL (Sepolia <-> Miden testnet bridging).
+# Epoch allocator compatible with v0.16 on the selected Miden network.
 VITE_ALLOCATOR_URL=https://testnet-dev.epochprotocol.xyz
 
-# Optional: override the Miden testnet explorer used for tx links.
+# Obtain the USDC faucet ID from an allocator deployed on the selected network.
+# When unset, enter the faucet ID manually in the form.
+VITE_MIDEN_USDC_FAUCET_ID=
+
+# Optional: override the selected network's explorer used for tx links.
 # Default if unset: https://testnet.midenscan.com
 # VITE_MIDENSCAN_URL=https://testnet.midenscan.com
 

--- a/examples/bridging-app/README.md
+++ b/examples/bridging-app/README.md
@@ -15,24 +15,30 @@ yarn install
 yarn dev
 ```
 
-Open [http://localhost:5173](http://localhost:5173). The app exposes two tabs — `Bridge to EVM` (Miden → Sepolia) and `Withdraw to Miden` (Sepolia → Miden) — wired to the Epoch testnet allocator (`testnet-dev.epochprotocol.xyz`).
+Open [http://localhost:5173](http://localhost:5173). The app exposes two tabs — `Bridge to EVM` (Miden → Sepolia) and `Withdraw to Miden` (Sepolia → Miden). It defaults to Miden **testnet**. A live round trip requires an Epoch allocator and asset faucet deployed on that same network, plus both wallets.
 
 ## Environment
 
 Copy `.env.example` to `.env` and supply the required values:
 
-| Variable                     | Required | Description                                                                 |
-| ---------------------------- | -------- | --------------------------------------------------------------------------- |
-| `VITE_RAINBOWKIT_PROJECT_ID` | yes      | WalletConnect Cloud project id from <https://cloud.walletconnect.com/>.     |
-| `VITE_ALLOCATOR_URL`         | yes      | Epoch allocator endpoint (default `https://testnet-dev.epochprotocol.xyz`). |
-| `VITE_MIDEN_RPC_URL`         | no       | Miden RPC; defaults to `testnet`.                                           |
-| `VITE_MIDEN_PROVER`          | no       | Miden prover; defaults to `testnet`.                                        |
-| `VITE_MIDENSCAN_URL`         | no       | Override block-explorer base; defaults to `https://testnet.midenscan.com`.  |
+| Variable                     | Required     | Description                                                                                                       |
+| ---------------------------- | ------------ | ----------------------------------------------------------------------------------------------------------------- |
+| `VITE_RAINBOWKIT_PROJECT_ID` | yes          | WalletConnect Cloud project id from <https://cloud.walletconnect.com/>.                                           |
+| `VITE_ALLOCATOR_URL`         | yes          | An Epoch allocator compatible with v0.16 on the selected Miden network.                                           |
+| `VITE_MIDEN_NETWORK`         | no           | `testnet` (default), `devnet`, or `local`; selects the wallet network and RPC/prover defaults.                    |
+| `VITE_MIDEN_RPC_URL`         | no           | Override Miden RPC; must match the selected wallet network.                                                       |
+| `VITE_MIDEN_PROVER`          | no           | Override the prover; `local` uses local proving.                                                                  |
+| `VITE_MIDEN_USDC_FAUCET_ID`  | yes for USDC | Allocator-approved faucet on the selected network. If unset, enter it manually in the form; no old ID is assumed. |
+| `VITE_MIDENSCAN_URL`         | no           | Override block-explorer base; defaults to the selected network's Midenscan.                                       |
+
+For explicit devnet checks, set `VITE_MIDEN_NETWORK`, `VITE_MIDEN_RPC_URL`, and
+`VITE_MIDEN_PROVER` to `devnet` and use a matching allocator and faucet.
 
 ## Prerequisites
 
 - An EVM wallet supported by [RainbowKit](https://www.rainbowkit.com/) (MetaMask, Rabby, Coinbase Wallet, …).
 - The [MidenFi browser extension](https://chromewebstore.google.com/detail/miden-wallet/ablmompanofnodfdkgchkpmphailefpb) to sign the P2IDE note on Miden.
+- Native MIDEN tokens in the Miden wallet to pay transaction fees.
 - A small Sepolia ETH balance for gas; grab some from the [pk910 PoW faucet](https://sepolia-faucet.pk910.de/) or the [Google Cloud Sepolia faucet](https://cloud.google.com/application/web3/faucet/ethereum/sepolia).
 
 ## Scripts
@@ -41,7 +47,7 @@ Copy `.env.example` to `.env` and supply the required values:
 yarn dev            # Vite dev server (http://localhost:5173)
 yarn build          # tsc -b && vite build
 yarn preview        # Serve the production build locally
-yarn test           # Vitest (scaffold-inherited tests)
+yarn test           # Vitest
 yarn lint           # ESLint
 ```
 

--- a/examples/bridging-app/package.json
+++ b/examples/bridging-app/package.json
@@ -14,11 +14,11 @@
     "test:coverage": "vitest --run --coverage"
   },
   "dependencies": {
-    "@epoch-protocol/epoch-intents-sdk": "^1.0.23",
-    "@miden-sdk/miden-sdk": "0.14.4",
-    "@miden-sdk/miden-wallet-adapter-base": "0.14.3",
-    "@miden-sdk/miden-wallet-adapter-react": "0.14.3",
-    "@miden-sdk/react": "0.14.4",
+    "@epoch-protocol/epoch-intents-sdk": "1.0.38",
+    "@miden-sdk/miden-sdk": "0.16.0",
+    "@miden-sdk/miden-wallet-adapter-base": "0.16.0",
+    "@miden-sdk/miden-wallet-adapter-react": "0.16.0",
+    "@miden-sdk/react": "0.16.0",
     "@phosphor-icons/react": "^2.1.10",
     "@rainbow-me/rainbowkit": "^2.2.10",
     "@tanstack/react-query": "^5.90.20",
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.36.0",
-    "@miden-sdk/vite-plugin": "0.14.4",
+    "@miden-sdk/vite-plugin": "0.16.0",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",

--- a/examples/bridging-app/src/components/__tests__/IntentForm.test.tsx
+++ b/examples/bridging-app/src/components/__tests__/IntentForm.test.tsx
@@ -37,12 +37,8 @@ vi.mock('@miden-sdk/miden-wallet-adapter-react', () => ({
   }),
 }));
 vi.mock('@miden-sdk/miden-wallet-adapter-base', () => ({
-  // IntentForm constructs a `SendTransaction` only in the Confirm-&-sign flow,
-  // which these tests do not exercise. A minimal class stub keeps imports
-  // resolvable without dragging in the real WASM-backed SDK.
-  SendTransaction: class {
-    constructor(public sender: string, public recipient: string, public faucet: string, public note: string, public amount: number) {}
-  },
+  // These rendering tests do not submit the custom collateral transaction.
+  Transaction: { createCustomTransaction: vi.fn() },
 }));
 vi.mock('wagmi', () => ({
   useAccount: () => ({ address: undefined, isConnected: false }),

--- a/examples/bridging-app/src/components/__tests__/WithdrawConsume.test.tsx
+++ b/examples/bridging-app/src/components/__tests__/WithdrawConsume.test.tsx
@@ -30,7 +30,7 @@ describe('WithdrawConsume', () => {
     expect(
       screen.getByRole('heading', { name: /Note delivered to your Miden wallet/i }),
     ).toBeInTheDocument();
-    expect(screen.getByText(/Miden Wallet auto-consumes incoming notes/i)).toBeInTheDocument();
+    expect(screen.getByText(/sufficient native MIDEN to pay the consumption fee/i)).toBeInTheDocument();
     // Truncated note id (head of the hex string) is rendered.
     expect(screen.getByText(/0xnote1234/i)).toBeInTheDocument();
     // Midenscan link points at the right path.

--- a/examples/bridging-app/src/components/crosschain/IntentForm.tsx
+++ b/examples/bridging-app/src/components/crosschain/IntentForm.tsx
@@ -3,8 +3,9 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { SelectContent, SelectItem, SelectRoot, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { useMidenFiWallet } from '@miden-sdk/miden-wallet-adapter-react';
-import { SendTransaction } from '@miden-sdk/miden-wallet-adapter-base';
-import { useSyncState } from '@miden-sdk/react';
+import { Transaction } from '@miden-sdk/miden-wallet-adapter-base';
+import { AccountId, NoteArray } from '@miden-sdk/miden-sdk';
+import { useMiden, useSyncState } from '@miden-sdk/react';
 import { useState } from 'react';
 import { toast } from 'sonner';
 import type { CrossChainIntentParams } from '../../types/miden';
@@ -16,6 +17,8 @@ import { DEFAULT_SEPOLIA_CHAIN_ID_STR } from '../../constants/chains';
 import { useAccount } from 'wagmi';
 import { useIntentTransactionStatus } from '../../hooks/useIntentTransactionStatus';
 import { selectDestinationSettlement } from '../../lib/intentSettlement';
+import { createEpochCollateralNote } from '../../services/epoch-collateral';
+import { midenscanNoteUrl } from '../../lib/explorers';
 
 const SEPOLIA_TOKENS = [
   { symbol: 'USDC', address: '0x2BB4FfD7E2c6D432b697554Efd77fA13bdbefd69', decimals: 18 },
@@ -41,7 +44,7 @@ interface Props {
   }>;
   isLoadingMidenAssets: boolean;
   onFetchQuote: (params: CrossChainIntentParams) => Promise<void>;
-  onConfirmIntent: (createMidenP2IDNote: SolveIntentParams['createMidenP2IDNote']) => Promise<unknown>;
+  onConfirmIntent: (createMidenP2IDENote: SolveIntentParams['createMidenP2IDENote']) => Promise<unknown>;
   onClearQuote: () => void;
   pendingQuote: CrossChainQuote | null;
   isFetchingQuote: boolean;
@@ -65,7 +68,8 @@ export function IntentForm({
   intentNonce,
   intentUserAddress,
 }: Props) {
-  const { requestSend, waitForTransaction } = useMidenFiWallet();
+  const { requestTransaction, waitForTransaction } = useMidenFiWallet();
+  const { client, runExclusive } = useMiden();
   const { syncHeight } = useSyncState();
 
   const [selectedAssetId, setSelectedAssetId] = useState('');
@@ -103,10 +107,8 @@ export function IntentForm({
   const evmTransactionHash = evmCompletedStatus?.transactionHash;
   const evmTxChainId = evmCompletedStatus?.chainId ?? destinationChainIdNum;
 
-  const midenScanBase =
-    (import.meta as any).env?.VITE_MIDENSCAN_URL || 'https://testnet.midenscan.com';
   const midenNoteUrl = localMidenNoteId
-    ? `${midenScanBase}/note/${localMidenNoteId}`
+    ? midenscanNoteUrl(localMidenNoteId)
     : undefined;
 
   const explorerTxUrl = (() => {
@@ -197,41 +199,44 @@ export function IntentForm({
   const handleConfirm = () => {
     if (!pendingQuote) return;
 
-    const createMidenP2IDNote: SolveIntentParams['createMidenP2IDNote'] = async (
+    const createMidenP2IDENote: SolveIntentParams['createMidenP2IDENote'] = async (
       faucetIdParam,
       amountParam,
       allocatorId,
+      recallBlocks,
+      bindingAttachmentFelts,
     ) => {
       setConfirmStatus('Resource lock required — creating P2IDE note on Miden…');
       try {
         if (!midenAccountId) {
           throw new Error('Missing Miden account id');
         }
-        if (!requestSend) {
-          throw new Error('Miden wallet adapter is not connected');
+        if (!requestTransaction || !waitForTransaction || !client) {
+          throw new Error('Connect a Miden wallet that supports custom transactions and confirmation');
         }
 
-        const normalizedAmount = BigInt(amountParam);
-        if (normalizedAmount > BigInt(Number.MAX_SAFE_INTEGER)) {
-          throw new Error('Amount too large for wallet adapter send');
-        }
-
-        const payload = new SendTransaction(
-          midenAccountId,
-          allocatorId,
-          faucetIdParam,
-          'public',
-          Number(normalizedAmount),
+        const { request, expectedNoteId } = await runExclusive(async () => {
+          const head = await client.syncState();
+          const note = createEpochCollateralNote({
+            sender: midenAccountId, allocator: allocatorId, faucet: faucetIdParam,
+            amount: BigInt(amountParam), currentBlock: head.blockNum(),
+            recallBlocks, bindingAttachmentFelts,
+          });
+          const builder = await client.feeAwareTransactionRequestBuilder(AccountId.fromHex(midenAccountId));
+          return {
+            expectedNoteId: note.id().toString(),
+            request: builder.withOwnOutputNotes(new NoteArray([note])).build(),
+          };
+        });
+        const txId = await requestTransaction(
+          Transaction.createCustomTransaction(midenAccountId, allocatorId, request),
         );
-        const txId = await requestSend(payload);
 
-        // Prefer adapter waitForTransaction to get the output note id.
-        if (!waitForTransaction) {
-          throw new Error('Miden wallet adapter is missing waitForTransaction');
-        }
+        // Wait for the wallet to confirm the collateral before submitting it to Epoch.
         const finalized = await waitForTransaction(txId, 120_000);
-        const first = finalized.outputNotes?.[0];
-        const noteId = first ? first.id().toString() : '';
+        // A fee-paying transaction also creates a TX_FEE note. Match our exact
+        // collateral note instead of assuming outputNotes[0] is the payment.
+        const noteId = finalized.outputNotes?.find(note => note.id().toString() === expectedNoteId)?.id().toString();
         if (!noteId) {
           throw new Error(`Could not read output note id for tx ${txId}`);
         }
@@ -245,7 +250,7 @@ export function IntentForm({
     void toast.promise(
       (async () => {
         setConfirmStatus('Submitting intent…');
-        const result = await onConfirmIntent(createMidenP2IDNote);
+        const result = await onConfirmIntent(createMidenP2IDENote);
         if (result && typeof result === 'object' && 'error' in result && (result as { error?: string }).error) {
           throw new Error((result as { error: string }).error);
         }

--- a/examples/bridging-app/src/components/crosschain/WithdrawConsume.tsx
+++ b/examples/bridging-app/src/components/crosschain/WithdrawConsume.tsx
@@ -12,9 +12,9 @@ interface Props {
  * Post-withdraw informational panel.
  *
  * The Epoch allocator delivers bridged funds as a P2ID note addressed to the
- * user's Miden wallet account. The Miden Wallet consumes that note when it
- * detects it, so this panel reports delivery and links to Midenscan instead of
- * initiating a second transaction from the page.
+ * user's Miden wallet account. Its consumption is handled by the wallet and
+ * requires native fees, so this panel reports delivery and links to Midenscan
+ * instead of initiating a second transaction from the page.
  */
 export function WithdrawConsume({ noteId }: Props) {
   if (!noteId) return null;
@@ -26,10 +26,10 @@ export function WithdrawConsume({ noteId }: Props) {
         <p className="mt-1 text-sm leading-relaxed text-neutral-600">
           The allocator delivered the bridged funds as a <strong>P2ID note</strong> to your Miden
           wallet account. In Miden's actor model the note must be{' '}
-          <em>consumed</em> before it becomes spendable balance — but the Miden Wallet auto-consumes
-          incoming notes on detection, so no action is required here. Open your wallet to confirm
-          the new balance; the bridged USDC is ready to use as the source for another
-          Miden&nbsp;→&nbsp;EVM bridge or any other Miden transaction.
+          <em>consumed</em> before it becomes spendable balance. Wallet auto-consumption depends
+          on your wallet settings and sufficient native MIDEN to pay the consumption fee.
+          A USDC note does not itself fund that native fee. Open your wallet to confirm
+          consumption and the new balance before spending the bridged funds.
         </p>
       </div>
 
@@ -54,7 +54,7 @@ export function WithdrawConsume({ noteId }: Props) {
 
       <p className="text-[11px] text-neutral-500 italic">
         If your wallet does not show the credited balance, the note may still be propagating
-        through testnet — refresh the wallet after a few seconds. Some wallet builds let you
+        through the network — refresh the wallet after a few seconds. Some wallet builds let you
         disable auto-consume; in that case, consume the note manually from the wallet's Notes tab.
       </p>
     </div>

--- a/examples/bridging-app/src/components/crosschain/WithdrawForm.tsx
+++ b/examples/bridging-app/src/components/crosschain/WithdrawForm.tsx
@@ -8,6 +8,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { SelectContent, SelectItem, SelectRoot, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { MIDEN_USDC_FAUCET_ID } from '@/config';
 
 // EVM-side token decimals + the Miden-side faucet account ID for each known
 // token. The Epoch test ERC-20s on Sepolia are 18-decimal (verified on-chain);
@@ -27,7 +28,7 @@ const SEPOLIA_TOKENS: ReadonlyArray<{
     symbol: 'USDC',
     address: '0x2BB4FfD7E2c6D432b697554Efd77fA13bdbefd69',
     decimals: 18,
-    midenFaucetId: '0x0a7d175ed63ec5200fb2ced86f6aa5',
+    midenFaucetId: MIDEN_USDC_FAUCET_ID,
   },
   { symbol: 'USDT', address: '0xc04d2869665Be874881133943523723Be5782720', decimals: 18 },
   { symbol: 'Custom', address: '', decimals: 18 },

--- a/examples/bridging-app/src/components/layout/Header.tsx
+++ b/examples/bridging-app/src/components/layout/Header.tsx
@@ -1,3 +1,5 @@
+import { MIDEN_NETWORK } from '@/config';
+
 export function Header() {
   return (
     <header className="sticky top-0 z-10 border-b border-neutral-200 bg-neutral-100/85 px-6 py-4 backdrop-blur-md">
@@ -9,7 +11,7 @@ export function Header() {
           M
         </div>
         <h1 className="text-xl font-semibold tracking-tight text-neutral-900">Miden × Epoch</h1>
-        <span className="ui-chip">Testnet</span>
+        <span className="ui-chip">Miden {MIDEN_NETWORK}</span>
       </div>
     </header>
   );

--- a/examples/bridging-app/src/config.ts
+++ b/examples/bridging-app/src/config.ts
@@ -2,7 +2,15 @@
 export const APP_NAME = "Miden x Epoch Bridge";
 
 // Miden SDK configuration — override via environment variables.
+export const MIDEN_NETWORK = import.meta.env.VITE_MIDEN_NETWORK || "testnet";
+if (!["devnet", "testnet", "local"].includes(MIDEN_NETWORK)) {
+  throw new Error("VITE_MIDEN_NETWORK must be devnet, testnet, or local");
+}
 export const MIDEN_RPC_URL =
-  import.meta.env.VITE_MIDEN_RPC_URL ?? "testnet";
+  import.meta.env.VITE_MIDEN_RPC_URL || MIDEN_NETWORK;
 export const MIDEN_PROVER =
-  (import.meta.env.VITE_MIDEN_PROVER as "devnet" | "testnet" | "local") ?? "testnet";
+  (import.meta.env.VITE_MIDEN_PROVER || MIDEN_NETWORK) as "devnet" | "testnet" | "local";
+
+// Faucet IDs change across networks and resets. Configure the allocator-approved
+// asset for the selected network.
+export const MIDEN_USDC_FAUCET_ID = import.meta.env.VITE_MIDEN_USDC_FAUCET_ID?.trim();

--- a/examples/bridging-app/src/hooks/useEpochIntent.ts
+++ b/examples/bridging-app/src/hooks/useEpochIntent.ts
@@ -61,9 +61,9 @@ export function useEpochIntent() {
     }
   }, [sdk, address]);
 
-  /** Step 2: execute the stored quote by creating the P2ID note and submitting the intent. */
+  /** Step 2: execute the stored quote by creating the P2IDE note and submitting the intent. */
   const confirmIntent = useCallback(async (
-    createMidenP2IDNote: SolveIntentParams['createMidenP2IDNote'],
+    createMidenP2IDENote: SolveIntentParams['createMidenP2IDENote'],
   ) => {
     if (!sdk) throw new Error('Epoch SDK not ready');
     if (!pendingQuote) throw new Error('Fetch a quote first');
@@ -75,7 +75,7 @@ export function useEpochIntent() {
         ...pendingQuote.params,
         collateralType: CollateralType.Miden,
         midenSourceAccount: pendingQuote.params.midenAccountId,
-        createMidenP2IDNote,
+        createMidenP2IDENote,
         preFetchedQuote: pendingQuote,
       });
       if (result?.error) {
@@ -99,7 +99,7 @@ export function useEpochIntent() {
   /** Direct-bridge path: skip quote, call buildCrossChainIntent with explicit midenAmount. */
   const submitDirectIntent = useCallback(async (
     params: CrossChainIntentParams,
-    createMidenP2IDNote: SolveIntentParams['createMidenP2IDNote'],
+    createMidenP2IDENote: SolveIntentParams['createMidenP2IDENote'],
   ) => {
     if (!sdk) throw new Error('Epoch SDK not ready');
     setIsLoading(true);
@@ -110,7 +110,7 @@ export function useEpochIntent() {
         ...params,
         collateralType: CollateralType.Miden,
         midenSourceAccount: params.midenAccountId,
-        createMidenP2IDNote,
+        createMidenP2IDENote,
       });
       setIntentResult(result);
       return result;

--- a/examples/bridging-app/src/lib/__tests__/network.test.ts
+++ b/examples/bridging-app/src/lib/__tests__/network.test.ts
@@ -1,0 +1,35 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+beforeEach(() => {
+  for (const key of ['VITE_MIDEN_NETWORK', 'VITE_MIDEN_RPC_URL', 'VITE_MIDEN_PROVER', 'VITE_MIDENSCAN_URL', 'VITE_MIDEN_USDC_FAUCET_ID']) {
+    vi.stubEnv(key, undefined);
+  }
+  vi.resetModules();
+});
+
+afterEach(() => { vi.unstubAllEnvs(); vi.resetModules(); });
+
+describe('bridge network configuration', () => {
+  it('defaults RPC, prover, and explorer to testnet', async () => {
+    const config = await import('../../config');
+    const explorers = await import('../explorers');
+    expect(config.MIDEN_NETWORK).toBe('testnet');
+    expect(config.MIDEN_RPC_URL).toBe('testnet');
+    expect(config.MIDEN_PROVER).toBe('testnet');
+    expect(config.MIDEN_USDC_FAUCET_ID).toBeUndefined();
+    expect(explorers.midenscanNoteUrl('abc')).toBe('https://testnet.midenscan.com/note/abc');
+  });
+
+  it('uses explicitly selected devnet and explorer override', async () => {
+    vi.stubEnv('VITE_MIDEN_NETWORK', 'devnet');
+    vi.stubEnv('VITE_MIDENSCAN_URL', 'https://example.com/');
+    vi.stubEnv('VITE_MIDEN_USDC_FAUCET_ID', '0xapproved');
+    const config = await import('../../config');
+    const explorers = await import('../explorers');
+    expect(config.MIDEN_NETWORK).toBe('devnet');
+    expect(config.MIDEN_RPC_URL).toBe('devnet');
+    expect(config.MIDEN_PROVER).toBe('devnet');
+    expect(config.MIDEN_USDC_FAUCET_ID).toBe('0xapproved');
+    expect(explorers.midenscanNoteUrl('abc')).toBe('https://example.com/note/abc');
+  });
+});

--- a/examples/bridging-app/src/lib/explorers.ts
+++ b/examples/bridging-app/src/lib/explorers.ts
@@ -2,9 +2,13 @@
 // row using `chainId === MIDEN_CHAIN_ID` (999_999_999); everything else is an
 // EVM chain mapped here.
 
+import { MIDEN_NETWORK } from '../config';
+
 export const MIDEN_CHAIN_ID = 999_999_999;
 
-export const MIDENSCAN_BASE = 'https://testnet.midenscan.com';
+export const MIDENSCAN_BASE = (
+  import.meta.env.VITE_MIDENSCAN_URL || `https://${MIDEN_NETWORK}.midenscan.com`
+).replace(/\/+$/, '');
 
 const EVM_EXPLORERS: Record<number, string> = {
   1: 'https://etherscan.io',

--- a/examples/bridging-app/src/providers.tsx
+++ b/examples/bridging-app/src/providers.tsx
@@ -10,7 +10,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { RainbowKitProvider, lightTheme } from "@rainbow-me/rainbowkit";
 import "@rainbow-me/rainbowkit/styles.css";
 import { Toaster } from "sonner";
-import { APP_NAME, MIDEN_RPC_URL, MIDEN_PROVER } from "@/config";
+import { APP_NAME, MIDEN_NETWORK, MIDEN_RPC_URL, MIDEN_PROVER } from "@/config";
 import { wagmiConfig } from "@/config/wagmi";
 
 // Provider chain for the bridging-app:
@@ -43,7 +43,8 @@ export function AppProviders({ children }: { children: ReactNode }) {
         <RainbowKitProvider theme={rkTheme}>
           <MidenFiSignerProvider
             appName={APP_NAME}
-            network={WalletAdapterNetwork.Testnet}
+            network={MIDEN_NETWORK === "local" ? WalletAdapterNetwork.Localnet :
+              MIDEN_NETWORK === "devnet" ? WalletAdapterNetwork.Devnet : WalletAdapterNetwork.Testnet}
             allowedPrivateData={AllowedPrivateData.Assets}
             autoConnect
           >

--- a/examples/bridging-app/src/services/__tests__/epoch-collateral.test.ts
+++ b/examples/bridging-app/src/services/__tests__/epoch-collateral.test.ts
@@ -1,0 +1,47 @@
+// @vitest-environment node
+import { describe, expect, it, vi } from 'vitest';
+
+// The native export omits the typed-array normalization that the browser
+// binding accepts. Adapt only its input container; all validation, note
+// construction, and serialization still execute in the real native SDK.
+vi.mock('@miden-sdk/miden-sdk', async importOriginal => {
+  const sdk = await importOriginal<typeof import('@miden-sdk/miden-sdk')>();
+  return {
+    ...sdk,
+    NoteAttachment: new Proxy(sdk.NoteAttachment, {
+      construct(target, args) {
+        return Reflect.construct(target, args.map(value => value instanceof BigUint64Array ? Array.from(value) : value));
+      },
+    }),
+  };
+});
+import { createEpochCollateralNote } from '../epoch-collateral';
+
+const params = {
+  sender: '0xfc442ceb5d7303b15da44080c20044',
+  allocator: '0xfc442ceb5d7303b15da44080c20044',
+  faucet: '0xfc90f0f4da30e51168453b60eafed7',
+  amount: 1_000_000n,
+  currentBlock: 51_337,
+  recallBlocks: 2_000,
+  bindingAttachmentFelts: [1n, 2n, 3n, 4n, 5n],
+};
+
+describe('Epoch collateral with the real v0.16 SDK', () => {
+  it('builds and serializes a public P2IDE note without publishing it', () => {
+    const note = createEpochCollateralNote(params);
+    expect(note.serialize().length).toBeGreaterThan(0);
+    expect(note.assets().fungibleAssets()[0].amount()).toBe(1_000_000n);
+    const attachmentValues = note.attachments()[0].toWords().flatMap(word => Array.from(word.toU64s()));
+    expect(attachmentValues).toEqual([1n, 2n, 3n, 4n, 5n, 0n, 0n, 0n]);
+    expect(note.recipient().storage().items().map(felt => felt.asInt())).toContain(53_337n);
+  });
+  it('rejects an obsolete pre-v0.16 faucet account ID', () => {
+    expect(() => createEpochCollateralNote({ ...params, faucet: '0x0a7d175ed63ec5200fb2ced86f6aa5' })).toThrow();
+  });
+  it('requires a positive recall window and mandate attachment', () => {
+    expect(() => createEpochCollateralNote({ ...params, recallBlocks: 0 })).toThrow(/reclaim/);
+    expect(() => createEpochCollateralNote({ ...params, bindingAttachmentFelts: [] })).toThrow(/attachment/);
+    expect(() => createEpochCollateralNote({ ...params, bindingAttachmentFelts: [1n << 64n] })).toThrow(/canonical/);
+  });
+});

--- a/examples/bridging-app/src/services/epoch-bridge.ts
+++ b/examples/bridging-app/src/services/epoch-bridge.ts
@@ -57,16 +57,16 @@ export function formatQuoteTokenIn(
 }
 
 /**
- * Cross-chain bridge architecture using P2ID notes:
+ * Cross-chain bridge architecture using reclaimable P2IDE collateral notes:
  *
- * 1. User creates a P2ID note on Miden targeting the trusted allocator service
- * 2. The allocator service (holding the P2ID note) builds an Epoch intent via SIO
+ * 1. User creates a mandate-bound P2IDE note targeting the trusted allocator
+ * 2. The allocator service validates the note and routes the intent via SIO
  * 3. SIO solver fulfills the intent on the destination EVM chain
- * 4. On successful execution, the allocator consumes the P2ID note (claiming the Miden funds)
- * 5. If the intent fails/expires, the P2ID note can be recalled by the user
+ * 4. On successful execution, the allocator consumes the note (claiming the Miden funds)
+ * 5. After the reclaim height, the user can recall an unconsumed collateral note
  *
- * This keeps funds locked in a P2ID note (not custodied) until the cross-chain
- * intent is fulfilled — privacy-preserving on the Miden side, trustless on EVM side.
+ * The allocator is a trusted participant: the note's reclaim path does not by
+ * itself enforce EVM settlement or prevent the target from consuming the note.
  */
 
 const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
@@ -74,24 +74,16 @@ const ZERO_HASH = '0x00000000000000000000000000000000000000000000000000000000000
 
 function normalizeMidenIdToHex(id: string): string {
   const raw = (id ?? '').trim();
-  if (!raw) return raw;
+  if (!raw) throw new Error('A Miden account or faucet ID is required');
 
   // Already hex.
   if (raw.startsWith('0x') || raw.startsWith('0X')) {
-    try {
-      return AccountId.fromHex(raw).toString();
-    } catch {
-      return raw;
-    }
+    return AccountId.fromHex(raw).toString();
   }
 
   // Plain hex without 0x.
   if (/^[0-9a-fA-F]+$/.test(raw) && raw.length % 2 === 0) {
-    try {
-      return AccountId.fromHex(`0x${raw}`).toString();
-    } catch {
-      return raw;
-    }
+    return AccountId.fromHex(`0x${raw}`).toString();
   }
 
   // Bech32 (address or account). Wallet adapter often returns `mtst..._...`.
@@ -105,8 +97,8 @@ function normalizeMidenIdToHex(id: string): string {
 
   try {
     return AccountId.fromBech32(raw).toString();
-  } catch {
-    return raw;
+  } catch (cause) {
+    throw new Error(`Invalid Miden account or faucet ID: ${raw}`, { cause });
   }
 }
 
@@ -344,7 +336,7 @@ export async function buildCrossChainIntent(
   params: CrossChainIntentParams & {
     collateralType?: CollateralType;
     midenSourceAccount?: string;
-    createMidenP2IDNote?: SolveIntentParams['createMidenP2IDNote'];
+    createMidenP2IDENote?: SolveIntentParams['createMidenP2IDENote'];
     /** Pre-fetched quote from getCrossChainQuote — skips getTaskData step. */
     preFetchedQuote?: CrossChainQuote;
   },
@@ -374,7 +366,7 @@ export async function buildCrossChainIntent(
       collateralType: (params.collateralType ?? 'miden') as CollateralType,
       midenFaucetId: midenFaucetIdHex,
       midenSourceAccount: midenSourceHex,
-      createMidenP2IDNote: params.createMidenP2IDNote,
+      createMidenP2IDENote: params.createMidenP2IDENote,
     });
 
     console.log('[EpochBridge] SDK.solveIntent() response:', solveResult);

--- a/examples/bridging-app/src/services/epoch-collateral.ts
+++ b/examples/bridging-app/src/services/epoch-collateral.ts
@@ -1,0 +1,34 @@
+import { AccountId, FungibleAsset, Note, NoteAssets, NoteAttachment, NoteType } from '@miden-sdk/miden-sdk';
+
+/** Build the public, reclaimable note required by the current Epoch allocator. */
+export function createEpochCollateralNote(params: {
+  sender: string;
+  allocator: string;
+  faucet: string;
+  amount: bigint;
+  currentBlock: number;
+  recallBlocks: number;
+  bindingAttachmentFelts: bigint[];
+}): Note {
+  if (!Number.isSafeInteger(params.currentBlock) || params.currentBlock < 0 ||
+      !Number.isSafeInteger(params.recallBlocks) || params.recallBlocks <= 0 ||
+      params.currentBlock + params.recallBlocks > 0xffff_ffff) {
+    throw new Error('Invalid Epoch reclaim window');
+  }
+  if (params.amount <= 0n) throw new Error('Epoch collateral amount must be positive');
+  if (params.bindingAttachmentFelts.length === 0) {
+    throw new Error('Epoch mandate-binding attachment is required');
+  }
+  if (params.bindingAttachmentFelts.some(value => value < 0n || value >= 18_446_744_069_414_584_321n)) {
+    throw new Error('Epoch attachment values must be canonical field elements');
+  }
+  return Note.createP2IDENote(
+    AccountId.fromHex(params.sender),
+    AccountId.fromHex(params.allocator),
+    new NoteAssets([new FungibleAsset(AccountId.fromHex(params.faucet), params.amount)]),
+    params.currentBlock + params.recallBlocks,
+    null,
+    NoteType.Public,
+    new NoteAttachment(BigUint64Array.from(params.bindingAttachmentFelts)),
+  );
+}

--- a/examples/bridging-app/yarn.lock
+++ b/examples/bridging-app/yarn.lock
@@ -341,21 +341,22 @@
   resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.9.2.tgz#ff9221b9f58b4dfe61e619a7788734bd63f6898b"
   integrity sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==
 
-"@epoch-protocol/epoch-commons-sdk@^0.1.11":
-  version "0.1.11"
-  resolved "https://registry.yarnpkg.com/@epoch-protocol/epoch-commons-sdk/-/epoch-commons-sdk-0.1.11.tgz#09cd5de0739b63e5550004e3c9407a1060a7ad08"
-  integrity sha512-4UvhAHpL/llcrONfuyffoZtnaCNf6D60A/gfHbz1tkpcfrq8pPynZbRL1jknU4YdOYQ+K+ZL4NaQb4mFOnS8QQ==
+"@epoch-protocol/epoch-commons-sdk@^0.1.19":
+  version "0.1.19"
+  resolved "https://registry.yarnpkg.com/@epoch-protocol/epoch-commons-sdk/-/epoch-commons-sdk-0.1.19.tgz#c6cab788f16582db707579a23e61284eddb24973"
+  integrity sha512-M1ZSzK5LQyTWFPx4gHLVVOaAFHT23DKKP3c2G3cPsavmnyckxFayoIXIS9UyMTDn1g0QPeoL5R1YmKBmP7HE8Q==
   dependencies:
     ethers "^6.0.0"
     viem "2.42.0"
 
-"@epoch-protocol/epoch-intents-sdk@^1.0.23":
-  version "1.0.23"
-  resolved "https://registry.yarnpkg.com/@epoch-protocol/epoch-intents-sdk/-/epoch-intents-sdk-1.0.23.tgz#ad8656bf26376c9772f2cc5a04bd76ee2f813854"
-  integrity sha512-vWKc4BGD4+ihirV89nNssagQZGyeCHcfU9T3eXtAbkiloXbX9IcT6h75QBajjoSvIqxGFU1hkJlYN4YZN2zElQ==
+"@epoch-protocol/epoch-intents-sdk@1.0.38":
+  version "1.0.38"
+  resolved "https://registry.yarnpkg.com/@epoch-protocol/epoch-intents-sdk/-/epoch-intents-sdk-1.0.38.tgz#c2a8e902253a77d61b5b96545502fc6ac7acf56d"
+  integrity sha512-DS/JltAxR1cb5relGrssrj6EenIaVfWw/y4n4BkmiAODG/jhEf4qHFacn+ydZnJaQCxKjNdAvdNmbUYqevNW4g==
   dependencies:
-    "@epoch-protocol/epoch-commons-sdk" "^0.1.11"
-    viem "^2.29.2"
+    "@epoch-protocol/epoch-commons-sdk" "^0.1.19"
+    "@metamask/smart-accounts-kit" "^1.6.0"
+    viem "^2.31.4"
 
 "@esbuild/aix-ppc64@0.25.12":
   version "0.25.12"
@@ -709,6 +710,41 @@
   dependencies:
     "@lit-labs/ssr-dom-shim" "^1.5.0"
 
+"@metamask/7715-permission-types@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@metamask/7715-permission-types/-/7715-permission-types-1.0.0.tgz#aa5f6f881c77c8aca6788ac22eadc210ff82e838"
+  integrity sha512-KhdKsT35pmBNTNpYcp+14gECPxmP4bX2eLA56riDr6pCjf6U7kEqPBoN6gz1CULNywEMp+p9UIMpdiTzFCyelg==
+  dependencies:
+    "@metamask/delegation-core" "^2.2.1"
+    "@metamask/utils" "^11.4.0"
+
+"@metamask/abi-utils@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@metamask/abi-utils/-/abi-utils-3.0.0.tgz#2eab9cb895922b94305364d9111b6dde724f6f9b"
+  integrity sha512-a/l0DiSIr7+CBYVpHygUa3ztSlYLFCQMsklLna+t6qmNY9+eIO5TedNxhyIyvaJ+4cN7TLy0NQFbp9FV3X2ktg==
+  dependencies:
+    "@metamask/superstruct" "^3.1.0"
+    "@metamask/utils" "^11.0.1"
+
+"@metamask/delegation-abis@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@metamask/delegation-abis/-/delegation-abis-1.1.0.tgz#b34dd3d796c08e3262b23b46458977dc3d68f235"
+  integrity sha512-n7XgRAM+pKUqmw4X+nAxM9a9HTBGe049WCAbpnHV6WoT6JnHhurMSUiqpAwMh69RhEykBtJPYSVPTVlJu6pEPg==
+
+"@metamask/delegation-core@^2.2.1":
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/@metamask/delegation-core/-/delegation-core-2.2.1.tgz#1691ec33114274cc57de9ee56a903495231671df"
+  integrity sha512-fpB25AgmBxTJYhHj92tFS4dJe63x6wz71c8dPTwUin12dAvFMWM3PH+rm4C34iPb5ZrQzkAPi4e9z2njmwEZUA==
+  dependencies:
+    "@metamask/abi-utils" "^3.0.0"
+    "@metamask/utils" "^11.4.0"
+    "@noble/hashes" "^1.8.0"
+
+"@metamask/delegation-deployments@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@metamask/delegation-deployments/-/delegation-deployments-1.4.0.tgz#e83d01239fbfcf6c7423419204bbdd575c2de111"
+  integrity sha512-QuO4Fiz3GsP7nwcUpXFEVTxmRGBTkriYeZ7DBLxUAqbUQx7Kg630eR1SgvTn/eBMkmXB2tZJW9am/iGuAcySlw==
+
 "@metamask/eth-json-rpc-provider@^1.0.0":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@metamask/eth-json-rpc-provider/-/eth-json-rpc-provider-1.0.1.tgz#3fd5316c767847f4ca107518b611b15396a5a32c"
@@ -805,6 +841,14 @@
   resolved "https://registry.yarnpkg.com/@metamask/safe-event-emitter/-/safe-event-emitter-3.1.2.tgz#bfac8c7a1a149b5bbfe98f59fbfea512dfa3bad4"
   integrity sha512-5yb2gMI1BDm0JybZezeoX/3XhPDOtTbcFvpTXM9kxsoZjPZFh4XciqRbpD6N86HYZqWDhEaKUDuOyR0sQHEjMA==
 
+"@metamask/scure-bip39@^2.0.3":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@metamask/scure-bip39/-/scure-bip39-2.1.1.tgz#071ddbaea7afe13886996c3bec22f472d79a4d34"
+  integrity sha512-1K8aBsAqr6+8jWhguVl06n8e+zjV9sUnys+5PLyVU4mb8LbulQ60F6cq7iQys3xX/yCwKt1+7c7j2nuTEpW+ZQ==
+  dependencies:
+    "@noble/hashes" "~1.3.2"
+    "@scure/base" "~1.1.3"
+
 "@metamask/sdk-analytics@0.0.5":
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/@metamask/sdk-analytics/-/sdk-analytics-0.0.5.tgz#ea10b15730d015af1da2225c8fe4fcf85b3fa77b"
@@ -857,6 +901,19 @@
     util "^0.12.4"
     uuid "^8.3.2"
 
+"@metamask/smart-accounts-kit@^1.6.0":
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/@metamask/smart-accounts-kit/-/smart-accounts-kit-1.7.0.tgz#d22ac321376a0db4fea79fad4e38e2a95d5fe256"
+  integrity sha512-zypiFPDkJ12fpXENmPIqFQr4H35b3LttwIhB+PfQpP9sGHWKUIz0CnhSurkl6vZ6GyKC+RNcl0Kq0QyPqSExXQ==
+  dependencies:
+    "@metamask/7715-permission-types" "^1.0.0"
+    "@metamask/delegation-abis" "^1.1.0"
+    "@metamask/delegation-core" "^2.2.1"
+    "@metamask/delegation-deployments" "^1.4.0"
+    "@metamask/utils" "^11.4.0"
+    openapi-fetch "^0.13.5"
+    ox "0.8.1"
+
 "@metamask/superstruct@^3.0.0", "@metamask/superstruct@^3.1.0":
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/@metamask/superstruct/-/superstruct-3.2.1.tgz#fca933017c5b78529f8f525560cef32c57e889d2"
@@ -868,6 +925,24 @@
   integrity sha512-0nF2CWjWQr/m0Y2t2lJnBTU1/CZPPTvKvcESLplyWe/tyeb8zFOi/FeneDmaFnML6LYRIGZU6f+xR0jKAIUZfw==
   dependencies:
     "@ethereumjs/tx" "^4.2.0"
+    "@metamask/superstruct" "^3.1.0"
+    "@noble/hashes" "^1.3.1"
+    "@scure/base" "^1.1.3"
+    "@types/debug" "^4.1.7"
+    "@types/lodash" "^4.17.20"
+    debug "^4.3.4"
+    lodash "^4.17.21"
+    pony-cause "^2.1.10"
+    semver "^7.5.4"
+    uuid "^9.0.1"
+
+"@metamask/utils@^11.4.0":
+  version "11.12.1"
+  resolved "https://registry.yarnpkg.com/@metamask/utils/-/utils-11.12.1.tgz#b62c3adfd3d8ee81d52cd9cadcb2ba2863f22c09"
+  integrity sha512-X97J5AEcaKDTIAfKb4X93ZTLfvOahzDVadlveQW+7OZ7yhXjMxXoFmhX2d9UKv48iS2Dxq9kbGJ1lUfphu9ebQ==
+  dependencies:
+    "@ethereumjs/tx" "^4.2.0"
+    "@metamask/scure-bip39" "^2.0.3"
     "@metamask/superstruct" "^3.1.0"
     "@noble/hashes" "^1.3.1"
     "@scure/base" "^1.1.3"
@@ -920,49 +995,66 @@
     semver "^7.5.4"
     uuid "^9.0.1"
 
-"@miden-sdk/miden-sdk@0.14.4":
-  version "0.14.4"
-  resolved "https://registry.yarnpkg.com/@miden-sdk/miden-sdk/-/miden-sdk-0.14.4.tgz#be7496e6d2622b7f478768972f9896536db154cb"
-  integrity sha512-Qt+3NfGRCyHP5zcD+m9bBqQz01zuAwZRUBkls09mi+tOPVT17sFWKLglQEtKdr3gPAFHLwz2Ja4Hp4adUKfLuA==
+"@miden-sdk/miden-sdk@0.16.0":
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/@miden-sdk/miden-sdk/-/miden-sdk-0.16.0.tgz#a54e095b3fc2aa36ebf249b24eeb9f280b4fbc75"
+  integrity sha512-APdct6zmuoGRPQaZ3kf2ovpUQ1a9C8VxV2MrJcGS3DelupiV34WBNNvIXhGE+I6DnSV9t2NzAHvokPVYhUq+kQ==
   dependencies:
-    "@rollup/plugin-typescript" "^12.3.0"
     dexie "^4.0.1"
     glob "^11.0.0"
+  optionalDependencies:
+    "@miden-sdk/node-darwin-arm64" "0.16.0"
+    "@miden-sdk/node-darwin-x64" "0.16.0"
+    "@miden-sdk/node-linux-x64-gnu" "0.16.0"
 
-"@miden-sdk/miden-wallet-adapter-base@0.14.3", "@miden-sdk/miden-wallet-adapter-base@^0.14.3":
-  version "0.14.3"
-  resolved "https://registry.yarnpkg.com/@miden-sdk/miden-wallet-adapter-base/-/miden-wallet-adapter-base-0.14.3.tgz#3ab7960d314e467a3f1d5bfbd70583fc93e647ab"
-  integrity sha512-SfoIMnzP4OD4u6I8GyYvlbghXuXInw6vkQMmE+s8xTcshEiZk38MbVmmlPTtSFAhz7Z+K3nAOsW84EMn83d52A==
+"@miden-sdk/miden-wallet-adapter-base@0.16.0":
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/@miden-sdk/miden-wallet-adapter-base/-/miden-wallet-adapter-base-0.16.0.tgz#ce020b7507aa0d1fd9015e66186b16d0734bcb43"
+  integrity sha512-rQF/eaRL2bfQTV5C8p7TRo2vMzkUeViQ77/gczWEuXaWrKh7qIxQEhIo3ksQGAQhMFt1tix985cjZg+rmc/okQ==
   dependencies:
     eventemitter3 "^5.0.1"
 
-"@miden-sdk/miden-wallet-adapter-miden@^0.14.3":
-  version "0.14.3"
-  resolved "https://registry.yarnpkg.com/@miden-sdk/miden-wallet-adapter-miden/-/miden-wallet-adapter-miden-0.14.3.tgz#8718028f1a27bc843c43b581e3197cdee169ba2d"
-  integrity sha512-amZsYB41XZ/RyMgokygU99VqGwwWd+bmHbHPbOnoOMMHvPlskc+9Zn2IowNE13qzjzOfn4BhWG2jQErrg8m12g==
+"@miden-sdk/miden-wallet-adapter-miden@0.16.0":
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/@miden-sdk/miden-wallet-adapter-miden/-/miden-wallet-adapter-miden-0.16.0.tgz#142fa7090adb4856f3995b01f32d784458678181"
+  integrity sha512-UlTh2ycLCgL1fDJH5FZ1PweErtMvPDMUvKoO7HYWnP0TZmoNUmmG2ptROEukOKznAP+fJXrY1Iqwl+K2YDOI2Q==
   dependencies:
-    "@miden-sdk/miden-wallet-adapter-base" "^0.14.3"
-    nanoid "^5.0.9"
+    "@miden-sdk/miden-wallet-adapter-base" "0.16.0"
 
-"@miden-sdk/miden-wallet-adapter-react@0.14.3":
-  version "0.14.3"
-  resolved "https://registry.yarnpkg.com/@miden-sdk/miden-wallet-adapter-react/-/miden-wallet-adapter-react-0.14.3.tgz#bb654000fd96ef3b4e568d78ec320da26cf397f6"
-  integrity sha512-PqweUFoWf6YJaVx1FW2s6gc6vp6oz2pey0wmMzYpjxH24TZMQ+hooRYhql7FgGkfYo1VMQkXlVzCLyymgmn8SQ==
+"@miden-sdk/miden-wallet-adapter-react@0.16.0":
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/@miden-sdk/miden-wallet-adapter-react/-/miden-wallet-adapter-react-0.16.0.tgz#5d455ced0df968f68d38b56ae61c47239dee4c59"
+  integrity sha512-Ev1FpBd8MGUPqX74LT7BoMxt8oXCC3virhHxy9p418bMD+eBK7jji32u91wdLWc3XiCHIcTXSeO9AGRNwdMBlg==
   dependencies:
-    "@miden-sdk/miden-wallet-adapter-base" "^0.14.3"
-    "@miden-sdk/miden-wallet-adapter-miden" "^0.14.3"
+    "@miden-sdk/miden-wallet-adapter-base" "0.16.0"
+    "@miden-sdk/miden-wallet-adapter-miden" "0.16.0"
 
-"@miden-sdk/react@0.14.4":
-  version "0.14.4"
-  resolved "https://registry.yarnpkg.com/@miden-sdk/react/-/react-0.14.4.tgz#6bb6e05572f6a4a63806e580bffc6156658e52f4"
-  integrity sha512-ASTcH1nge7hgH9OcV22nb1nrB9ccdkTsgVIioY+6y2wt0NcnTwu9RGrq8heJu4VyPcnl0g0LVFPcubvkmzXyjw==
+"@miden-sdk/node-darwin-arm64@0.16.0":
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/@miden-sdk/node-darwin-arm64/-/node-darwin-arm64-0.16.0.tgz#0ce84fa029899820674557b8b92690d25fb21b0c"
+  integrity sha512-uxwzouQkVG91/pU9o0wajLqzq2yqdZSttzzHmQtpl2hlpyFZJ8lucMwMFKOLCzU04+87PutBiUQ18Xfir2et6w==
+
+"@miden-sdk/node-darwin-x64@0.16.0":
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/@miden-sdk/node-darwin-x64/-/node-darwin-x64-0.16.0.tgz#1f2aa253398984cda42a1bfd6888a7ba512c1b11"
+  integrity sha512-vqKtB5xw8iE5OkmEE31KMVuTWxJ006EwrFFSBFEsZNuGGWHyZXlpSqCA3y3azstu2RX3FEYoViBFPwu0fLJVzg==
+
+"@miden-sdk/node-linux-x64-gnu@0.16.0":
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/@miden-sdk/node-linux-x64-gnu/-/node-linux-x64-gnu-0.16.0.tgz#2618859bfc526a0ec67e79eaaa4d9290ad675aff"
+  integrity sha512-+gFdLiRcAcv77QX3n4/0BoAecho9lbMxQR87sKH8oIIwP70+1ux0DFCE2Uf1nR8RK/rsbSSk/57R+0QBRY1kgw==
+
+"@miden-sdk/react@0.16.0":
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/@miden-sdk/react/-/react-0.16.0.tgz#c2ecc5d68425acbb17d03c13b6f1e193a8470f57"
+  integrity sha512-p4Blni66CPcZnyt1GNGh2I+OfbmIBQPSOqahsEzjfaZcP6P6k3XhhNt/sqxsoTr08QvVoxpwhXyosKyJNLQBvA==
   dependencies:
     zustand "^5.0.0"
 
-"@miden-sdk/vite-plugin@0.14.4":
-  version "0.14.4"
-  resolved "https://registry.yarnpkg.com/@miden-sdk/vite-plugin/-/vite-plugin-0.14.4.tgz#b6d4b45f60120c2c65ba5afdf47cef9ec7e8077d"
-  integrity sha512-E9y0dJVsrWzgoB06y9+8MibOjzoS37apBwbTa9AEloaFPPOxsJnlrprZG2dbm2xwhc3HQNzVRI9NkJ1ijFpALQ==
+"@miden-sdk/vite-plugin@0.16.0":
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/@miden-sdk/vite-plugin/-/vite-plugin-0.16.0.tgz#83f3c2b1b78cd02967ac5ee89aed1f8ac4f53a2f"
+  integrity sha512-5aBPdx0aYpyYKwhm49ftaoc0scxvGCrr2FPzVzrp6hIWr9QzE1AA4nMeA/qXewBK05mK4B4/7jhV8KwTC/+D1w==
 
 "@napi-rs/wasm-runtime@^1.1.4":
   version "1.1.4"
@@ -1016,7 +1108,7 @@
   dependencies:
     "@noble/hashes" "1.8.0"
 
-"@noble/curves@^1.6.0", "@noble/curves@^1.9.7", "@noble/curves@~1.9.0":
+"@noble/curves@^1.6.0", "@noble/curves@^1.9.1", "@noble/curves@^1.9.7", "@noble/curves@~1.9.0":
   version "1.9.7"
   resolved "https://registry.yarnpkg.com/@noble/curves/-/curves-1.9.7.tgz#79d04b4758a43e4bca2cbdc62e7771352fa6b951"
   integrity sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==
@@ -1059,6 +1151,11 @@
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.8.0.tgz#cee43d801fcef9644b11b8194857695acd5f815a"
   integrity sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==
+
+"@noble/hashes@~1.3.2":
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.3.3.tgz#39908da56a4adc270147bb07968bf3b16cfe1699"
+  integrity sha512-V7/fPHgl+jsVPXqqeOzT8egNj2iBIVt+ECeMMG8TdcnTikP3oaBtUVqpT/gYCR68aEBJSF+XbYUxStjbFMqIIA==
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
@@ -1968,27 +2065,10 @@
   resolved "https://registry.yarnpkg.com/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.16.tgz#bc27c8f906309b57c6c10eddb21043fd8e86b87e"
   integrity sha512-45+YtqxLYKDWQouLKCrpIZhke+nXxhsw+qAHVzHDVwttyBlHNBVs2K25rDXrZzhpTp9w1FlAlvweV1H++fdZoA==
 
-"@rollup/plugin-typescript@^12.3.0":
-  version "12.3.0"
-  resolved "https://registry.yarnpkg.com/@rollup/plugin-typescript/-/plugin-typescript-12.3.0.tgz#cc51b830973bc14c9456fe6532f322f2a40f5f12"
-  integrity sha512-7DP0/p7y3t67+NabT9f8oTBFE6gGkto4SA6Np2oudYmZE/m1dt8RB0SjL1msMxFpLo631qjRCcBlAbq1ml/Big==
-  dependencies:
-    "@rollup/pluginutils" "^5.1.0"
-    resolve "^1.22.1"
-
 "@rollup/plugin-virtual@^3.0.2":
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/@rollup/plugin-virtual/-/plugin-virtual-3.0.2.tgz#17e17eeecb4c9fa1c0a6e72c9e5f66382fddbb82"
   integrity sha512-10monEYsBp3scM4/ND4LNH5Rxvh3e/cVeL3jWTgZ2SrQ+BmUoQcopVQvnaMcOnykb1VkxUFuDAN+0FnpTFRy2A==
-
-"@rollup/pluginutils@^5.1.0":
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/@rollup/pluginutils/-/pluginutils-5.3.0.tgz#57ba1b0cbda8e7a3c597a4853c807b156e21a7b4"
-  integrity sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==
-  dependencies:
-    "@types/estree" "^1.0.0"
-    estree-walker "^2.0.2"
-    picomatch "^4.0.2"
 
 "@rollup/rollup-android-arm-eabi@4.60.2":
   version "4.60.2"
@@ -2141,7 +2221,7 @@
   resolved "https://registry.yarnpkg.com/@scure/base/-/base-1.2.6.tgz#ca917184b8231394dd8847509c67a0be522e59f6"
   integrity sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==
 
-"@scure/base@~1.1.6":
+"@scure/base@~1.1.3", "@scure/base@~1.1.6":
   version "1.1.9"
   resolved "https://registry.yarnpkg.com/@scure/base/-/base-1.1.9.tgz#e5e142fbbfe251091f9c5f1dd4c834ac04c3dbd1"
   integrity sha512-8YKhl8GHiNI/pU2VMaofa2Tor7PJRAjwQLBBuilkJ9L5+13yVbC7JO/wS7piioAvPSwR3JKM1IJ/u4xQzbcXKg==
@@ -3479,6 +3559,11 @@ abitype@^1.0.6, abitype@^1.0.9, abitype@^1.2.3:
   resolved "https://registry.yarnpkg.com/abitype/-/abitype-1.2.4.tgz#8aab72949bcad4107031862ae998e5bd20eec76e"
   integrity sha512-dpKH+N27vRjarMVTFFkeY445VTKftzGWpL0FiT7xmVmzQRKazZexzC5uHG0f6XKsVLAuUlndnbGau6lRejClxg==
 
+abitype@^1.0.8:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/abitype/-/abitype-1.3.0.tgz#39de89010dd7390ece44d5242a3aa80901cc193d"
+  integrity sha512-fk6Te+bojIFrMvMZrnOO+SxCB+RUksTGOzq/60ZRvs1L+BVzvi2bqt9L3W/17ZLdZsyM1FuYf65P5nlmoiH1Bg==
+
 abort-controller@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/abort-controller/-/abort-controller-3.0.0.tgz#eaf54d53b62bae4138e809ca225c8439a6efb392"
@@ -4413,11 +4498,6 @@ estraverse@^5.1.0, estraverse@^5.2.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.3.0.tgz#2eea5290702f26ab8fe5370370ff86c965d21123"
   integrity sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==
-
-estree-walker@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-2.0.2.tgz#52f010178c2a4c117a7757cfe942adb7d2da4cac"
-  integrity sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==
 
 estree-walker@^3.0.3:
   version "3.0.3"
@@ -5419,11 +5499,6 @@ nanoid@^3.3.11:
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.11.tgz#4f4f112cefbe303202f2199838128936266d185b"
   integrity sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==
 
-nanoid@^5.0.9:
-  version "5.1.9"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-5.1.9.tgz#aac959acf7d685269fb1be7f70a90d9db0848948"
-  integrity sha512-ZUvP7KeBLe3OZ1ypw6dI/TzYJuvHP77IM4Ry73waSQTLn8/g8rpdjfyVAh7t1/+FjBtG4lCP42MEbDxOsRpBMw==
-
 natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
@@ -5549,6 +5624,20 @@ ox@0.14.20:
     abitype "^1.2.3"
     eventemitter3 "5.0.1"
 
+ox@0.14.44:
+  version "0.14.44"
+  resolved "https://registry.yarnpkg.com/ox/-/ox-0.14.44.tgz#58cda086c7e2d4c3ba39f08a33778c47de5e2dee"
+  integrity sha512-O54qXXHEk4ySamMSyBpI0AeBegS5frxU6+LA6Jb9Sf6kMOxcTNaxYmwZfpOu22DIQsdKfgQxHq8EsAGaoBQScA==
+  dependencies:
+    "@adraffy/ens-normalize" "^1.11.0"
+    "@noble/ciphers" "^1.3.0"
+    "@noble/curves" "1.9.1"
+    "@noble/hashes" "^1.8.0"
+    "@scure/bip32" "^1.7.0"
+    "@scure/bip39" "^1.6.0"
+    abitype "^1.2.3"
+    eventemitter3 "5.0.1"
+
 ox@0.6.7:
   version "0.6.7"
   resolved "https://registry.yarnpkg.com/ox/-/ox-0.6.7.tgz#afd53f2ecef68b8526660e9d29dee6e6b599a832"
@@ -5573,6 +5662,20 @@ ox@0.6.9:
     "@scure/bip32" "^1.5.0"
     "@scure/bip39" "^1.4.0"
     abitype "^1.0.6"
+    eventemitter3 "5.0.1"
+
+ox@0.8.1:
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/ox/-/ox-0.8.1.tgz#c1328e4c890583b9c19d338126aef4b796d53543"
+  integrity sha512-e+z5epnzV+Zuz91YYujecW8cF01mzmrUtWotJ0oEPym/G82uccs7q0WDHTYL3eiONbTUEvcZrptAKLgTBD3u2A==
+  dependencies:
+    "@adraffy/ens-normalize" "^1.11.0"
+    "@noble/ciphers" "^1.3.0"
+    "@noble/curves" "^1.9.1"
+    "@noble/hashes" "^1.8.0"
+    "@scure/bip32" "^1.7.0"
+    "@scure/bip39" "^1.6.0"
+    abitype "^1.0.8"
     eventemitter3 "5.0.1"
 
 ox@0.9.6:
@@ -6134,7 +6237,7 @@ resolve-from@^4.0.0:
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
   integrity sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==
 
-resolve@^1.1.7, resolve@^1.22.1, resolve@^1.22.8:
+resolve@^1.1.7, resolve@^1.22.8:
   version "1.22.12"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.12.tgz#f5b2a680897c69c238a13cd16b15671f8b73549f"
   integrity sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==
@@ -6827,7 +6930,7 @@ viem@2.42.0:
     ox "0.9.6"
     ws "8.18.3"
 
-viem@>=2.29.0, viem@^2.1.1, viem@^2.27.2, viem@^2.29.2, viem@^2.31.7, viem@^2.45.2, viem@^2.47.0:
+viem@>=2.29.0, viem@^2.1.1, viem@^2.27.2, viem@^2.31.7, viem@^2.45.2, viem@^2.47.0:
   version "2.49.0"
   resolved "https://registry.yarnpkg.com/viem/-/viem-2.49.0.tgz#97d44fd91ad6782ef7925bec17ba613e03f4034b"
   integrity sha512-vaasyOBFiCWYtw9JD8iRoaHPppk14kQH140qgVmrxkDEgv4qTX9Hwi6F+wF+s3Y7SStV5OtnN2ulJev+NQ7KDw==
@@ -6840,6 +6943,20 @@ viem@>=2.29.0, viem@^2.1.1, viem@^2.27.2, viem@^2.29.2, viem@^2.31.7, viem@^2.45
     isows "1.0.7"
     ox "0.14.20"
     ws "8.18.3"
+
+viem@^2.31.4:
+  version "2.56.3"
+  resolved "https://registry.yarnpkg.com/viem/-/viem-2.56.3.tgz#d76da19f71a9e70863c1288b2836903bc43b3425"
+  integrity sha512-vUObq3GO7D3lz9gPNEE/xd5jIUnMbeVDWewh252o54pDEDlW4pDe6FEd/qTGL5RyK52cGHMM7kQ3wjxhilEvkQ==
+  dependencies:
+    "@noble/curves" "1.9.1"
+    "@noble/hashes" "1.8.0"
+    "@scure/bip32" "1.7.0"
+    "@scure/bip39" "1.6.0"
+    abitype "1.2.3"
+    isows "1.0.7"
+    ox "0.14.44"
+    ws "8.21.0"
 
 vite-plugin-top-level-await@^1.6.0:
   version "1.6.0"
@@ -7033,6 +7150,11 @@ ws@8.18.3, ws@~8.18.3:
   version "8.18.3"
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.18.3.tgz#b56b88abffde62791c639170400c93dcb0c95472"
   integrity sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==
+
+ws@8.21.0:
+  version "8.21.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.21.0.tgz#012e413fc07429945121b0c153158c4343086951"
+  integrity sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==
 
 ws@^7.5.1:
   version "7.5.10"

--- a/masm/accounts/auth/no_auth.masm
+++ b/masm/accounts/auth/no_auth.masm
@@ -1,6 +1,37 @@
 use miden::protocol::native_account
+use miden::standards::fee
 
+# CONSTANTS
+# =================================================================================================
+
+const POST_FEE_CYCLES = 1024
+
+# PUBLIC INTERFACE
+# =================================================================================================
+
+#! Pays the native transaction fee and increments the account nonce without a signature.
+#!
+#! Inputs:  [AUTH_ARGS, pad(12)]
+#! Outputs: [pad(16)]
+#!
+#! Where:
+#! - AUTH_ARGS contains unused authentication arguments.
+#!
+#! Panics if:
+#! - the account cannot pay the transaction fee from its native asset balance.
+#!
+#! Invocation: call
 @auth_script
-pub proc auth__basic
+pub proc auth__basic(auth_args: word)
+    dropw
+    # => [pad(16)]
+
+    exec.fee::native_conversion_info
+    # => [CONVERSION_INFO, pad(16)]
+
+    push.POST_FEE_CYCLES exec.fee::pay_fee drop
+    # => [pad(16)]
+
     exec.native_account::incr_nonce drop
+    # => [pad(16)]
 end

--- a/masm/accounts/count_reader.masm
+++ b/masm/accounts/count_reader.masm
@@ -1,26 +1,51 @@
-use miden::protocol::active_account
 use miden::protocol::native_account
 use miden::protocol::tx
-use miden::core::word
 use miden::core::sys
+use {AccountId, AccountProcedureRoot} from miden::protocol::types
 
-# The storage slot where the copied count is stored.
+# CONSTANTS
+# =================================================================================================
+
 const COUNT_READER_SLOT = word("miden::tutorials::count_reader")
 
-# => [account_id_suffix, account_id_prefix, PROC_HASH(4), foreign_procedure_inputs(16)]
-pub proc copy_count
+# PUBLIC INTERFACE
+# =================================================================================================
+
+#! Copies the count returned by the foreign counter into this account's storage.
+#!
+#! Inputs:  [foreign_account_id_{suffix,prefix}, FOREIGN_PROC_ROOT, pad(10)]
+#! Outputs: [pad(16)]
+#!
+#! Where:
+#! - foreign_account_id_{suffix,prefix} identifies the public counter account.
+#! - FOREIGN_PROC_ROOT is the root of its get_count procedure.
+#!
+#! Invocation: call
+@account_procedure
+@locals(6)
+pub proc copy_count(foreign_account_id: AccountId, foreign_proc_root: AccountProcedureRoot)
+    # save the foreign target while preparing its sixteen zero inputs
+    loc_store.4 loc_store.5 loc_storew_le.0 dropw
+    # => [pad(16)]
+
+    padw padw padw padw
+    # => [foreign_procedure_inputs(16), pad(16)]
+
+    padw loc_loadw_le.0 loc_load.5 loc_load.4
+    # => [foreign_account_id_suffix, foreign_account_id_prefix, FOREIGN_PROC_ROOT, foreign_procedure_inputs(16), pad(16)]
+
     exec.tx::execute_foreign_procedure
-    # => [count, pad(12)]
+    # => [[count, 0, 0, 0], pad(28)]
 
     push.COUNT_READER_SLOT[0..2]
-    # [slot_id_prefix, slot_id_suffix, count, pad(12)]
+    # => [slot_id_suffix, slot_id_prefix, [count, 0, 0, 0], pad(28)]
 
     exec.native_account::set_item
-    # => [OLD_VALUE, pad(12)]
+    # => [OLD_VALUE, pad(28)]
 
-    dropw dropw dropw dropw
-    # => []
+    dropw
+    # => [pad(28)]
 
     exec.sys::truncate_stack
-    # => []
+    # => [pad(16)]
 end

--- a/masm/accounts/counter.masm
+++ b/masm/accounts/counter.masm
@@ -1,32 +1,50 @@
 use miden::protocol::active_account
 use miden::protocol::native_account
-use miden::core::word
 use miden::core::sys
+
+# CONSTANTS
+# =================================================================================================
 
 const COUNTER_SLOT = word("miden::tutorials::counter")
 
-#! Inputs:  []
-#! Outputs: [count]
-pub proc get_count
+# PUBLIC INTERFACE
+# =================================================================================================
+
+#! Returns the current count.
+#!
+#! Inputs:  [pad(16)]
+#! Outputs: [count, pad(15)]
+#!
+#! Invocation: call
+@account_procedure
+pub proc get_count() -> felt
     push.COUNTER_SLOT[0..2] exec.active_account::get_item
-    # => [count]
+    # => [[count, 0, 0, 0], pad(16)]
 
     exec.sys::truncate_stack
-    # => [count]
+    # => [count, pad(15)]
 end
 
-#! Inputs:  []
-#! Outputs: []
-pub proc increment_count
+#! Increments the current count by one.
+#!
+#! Inputs:  [pad(16)]
+#! Outputs: [pad(16)]
+#!
+#! Invocation: call
+@account_procedure
+pub proc increment_count()
     push.COUNTER_SLOT[0..2] exec.active_account::get_item
-    # => [count]
+    # => [[count, 0, 0, 0], pad(16)]
 
     add.1
-    # => [count+1]
+    # => [[count + 1, 0, 0, 0], pad(16)]
 
     push.COUNTER_SLOT[0..2] exec.native_account::set_item
-    # => []
+    # => [OLD_VALUE, pad(16)]
+
+    dropw
+    # => [pad(16)]
 
     exec.sys::truncate_stack
-    # => []
+    # => [pad(16)]
 end

--- a/masm/accounts/mapping_example_contract.masm
+++ b/masm/accounts/mapping_example_contract.masm
@@ -1,43 +1,64 @@
 use miden::protocol::active_account
 use miden::protocol::native_account
-use miden::core::word
 use miden::core::sys
+use {StorageMapKey} from miden::protocol::types
+
+# CONSTANTS
+# =================================================================================================
 
 const MAP_SLOT = word("miden::tutorials::mapping::map")
 
-# Inputs: [KEY, VALUE]
-# Outputs: []
-pub proc write_to_map
-    # The storage map is in the mapping slot.
-    push.MAP_SLOT[0..2]
-    # => [slot_id_prefix, slot_id_suffix, KEY, VALUE]
+# PUBLIC INTERFACE
+# =================================================================================================
 
-    # Setting the key value pair in the map
+#! Stores VALUE under KEY in the mapping.
+#!
+#! Inputs:  [KEY, VALUE, pad(8)]
+#! Outputs: [pad(16)]
+#!
+#! Invocation: call
+@account_procedure
+pub proc write_to_map(key: StorageMapKey, value: word)
+    # the storage map is in the mapping slot
+    push.MAP_SLOT[0..2]
+    # => [slot_id_suffix, slot_id_prefix, KEY, VALUE, pad(8)]
+
+    # set the key-value pair in the map
     exec.native_account::set_map_item
-    # => [OLD_VALUE]
+    # => [OLD_VALUE, pad(12)]
 
     dropw
-    # => []
+    # => [pad(16)]
 end
 
-# Inputs: [KEY]
-# Outputs: [VALUE]
-pub proc get_value_in_map
-    # The storage map is in the mapping slot.
+#! Returns the VALUE stored under KEY in the mapping.
+#!
+#! Inputs:  [KEY, pad(12)]
+#! Outputs: [VALUE, pad(12)]
+#!
+#! Invocation: call
+@account_procedure
+pub proc get_value_in_map(key: StorageMapKey) -> word
+    # the storage map is in the mapping slot
     push.MAP_SLOT[0..2]
-    # => [slot_id_prefix, slot_id_suffix, KEY]
+    # => [slot_id_suffix, slot_id_prefix, KEY, pad(12)]
 
     exec.active_account::get_map_item
-    # => [VALUE]
+    # => [VALUE, pad(12)]
 end
 
-# Inputs: []
-# Outputs: [CURRENT_ROOT]
-pub proc get_current_map_root
-    # Getting the current root from the mapping slot.
+#! Returns the CURRENT_ROOT of the mapping.
+#!
+#! Inputs:  [pad(16)]
+#! Outputs: [CURRENT_ROOT, pad(12)]
+#!
+#! Invocation: call
+@account_procedure
+pub proc get_current_map_root() -> word
+    # get the current root from the mapping slot
     push.MAP_SLOT[0..2] exec.active_account::get_item
-    # => [CURRENT_ROOT]
+    # => [CURRENT_ROOT, pad(16)]
 
     exec.sys::truncate_stack
-    # => [CURRENT_ROOT]
+    # => [CURRENT_ROOT, pad(12)]
 end

--- a/masm/accounts/oracle_reader.masm
+++ b/masm/accounts/oracle_reader.masm
@@ -1,38 +1,42 @@
-# The oracle account ID, procedure hash, and pair ID below reference
-# Pragma's Miden v0.15 testnet deployment (https://github.com/astraly-labs/pragma-miden).
-# Pragma's addresses change between testnet iterations (their README is the
-# source of truth), so if the oracle is redeployed these values must be updated:
-# the oracle account id, the `get_median` procedure root, and (if a different
-# feed) the faucet pair id.
+# the Rust runner replaces these placeholders with values from a compatible
+# pragma deployment before compiling this component.
 
 use miden::protocol::tx
 
-# Fetches the current price from the `get_median`
-# procedure from the Pragma oracle
-# => []
-pub proc get_price
+# PUBLIC INTERFACE
+# =================================================================================================
+
+#! Queries the configured Pragma oracle's median price through a foreign procedure.
+#!
+#! Inputs:  [pad(16)]
+#! Outputs: [pad(16)]
+#!
+#! Panics if:
+#! - the configured oracle procedure or its required foreign state is unavailable.
+#!
+#! Invocation: call
+@account_procedure
+pub proc get_price()
     # `execute_foreign_procedure` requires exactly 16 foreign procedure inputs.
     # `get_median` only reads the first four, so the rest are zero padding.
     padw padw padw
-    # => [PAD(12)]
+    # => [pad(28)]
 
-    # BTC/USD pair: faucet id prefix `1`, suffix `0`, amount `0`
-    push.0.0.0.1
-    # => [pair_prefix, pair_suffix, amount, 0, PAD(12)]
+    # requested pair: faucet ID prefix/suffix, amount `0`.
+    push.0.0.{pair_suffix}.{pair_prefix}
+    # => [pair_prefix, pair_suffix, amount, 0, pad(28)]
 
-    # This is the procedure root of the `get_median` procedure
-    push.0xaa3a12d4e9de2dad37c50dba93809b9c17226d512e642d3d620c77088a85da71
-    # => [GET_MEDIAN_HASH, FOREIGN_INPUTS(16)]
+    # this is the procedure root of the `get_median` procedure.
+    push.{get_median_proc_root}
+    # => [GET_MEDIAN_HASH, foreign_procedure_inputs(16), pad(16)]
 
-    # The Pragma oracle account id: prefix then suffix, leaving suffix on top
-    push.8850886096234572817.9093477099503364096
-    # => [oracle_id_suffix, oracle_id_prefix, GET_MEDIAN_HASH, FOREIGN_INPUTS(16)]
+    # the Pragma oracle account id: prefix then suffix, leaving suffix on top.
+    push.{oracle_id_prefix}.{oracle_id_suffix}
+    # => [oracle_id_suffix, oracle_id_prefix, GET_MEDIAN_HASH, foreign_procedure_inputs(16), pad(16)]
 
     exec.tx::execute_foreign_procedure
-    # => [is_tracked, median_price, amount, PAD(13)]
-
-    debug.stack
-    # => [is_tracked, median_price, amount, PAD(13)]
+    # => [is_tracked, median_price, amount, pad(29)]
 
     dropw dropw dropw dropw
+    # => [pad(16)]
 end

--- a/masm/notes/hash_preimage_note.masm
+++ b/masm/notes/hash_preimage_note.masm
@@ -1,47 +1,57 @@
 use miden::protocol::active_note
-use miden::standards::wallets::basic->wallet
+use miden::standards::wallets::basic as wallet
 
 # CONSTANTS
 # =================================================================================================
 
-const EXPECTED_DIGEST_PTR=0
+const EXPECTED_DIGEST_PTR = 0
 
 # ERRORS
 # =================================================================================================
 
-const ERROR_DIGEST_MISMATCH="Expected digest does not match computed digest"
+const ERROR_DIGEST_MISMATCH = "Expected digest does not match computed digest"
 
-#! Inputs (arguments):  [HASH_PREIMAGE_SECRET]
-#! Outputs: []
+# PUBLIC INTERFACE
+# =================================================================================================
+
+#! Consumes the note's assets when the secret hashes to its stored digest.
 #!
-#! Note storage is assumed to be as follows:
-#!  => EXPECTED_DIGEST
+#! Inputs:  [HASH_PREIMAGE_SECRET, pad(12)]
+#! Outputs: [pad(16)]
+#!
+#! Where:
+#! - HASH_PREIMAGE_SECRET is the four-felt secret supplied as note arguments.
+#!
+#! Panics if:
+#! - the supplied secret does not match the digest stored in the note.
+#!
+#! Invocation: dyncall
 @note_script
-pub proc main
-    # => HASH_PREIMAGE_SECRET
-    # Hashing the secret number
+pub proc main(hash_preimage_secret: word)
+    # => [HASH_PREIMAGE_SECRET, pad(12)]
+    # hashing the secret number
     hash
-    # => [DIGEST]
+    # => [DIGEST, pad(12)]
 
-    # Writing the note storage to memory.
+    # writing the note storage to memory.
     # get_storage leaves only [num_storage_items], so drop a single element
     # here, not two, to keep the computed DIGEST intact.
     push.EXPECTED_DIGEST_PTR exec.active_note::get_storage drop
 
-    # Pad stack and load expected digest from memory (LE: mem[addr] ends up on top)
+    # pad stack and load expected digest from memory (LE: mem[addr] ends up on top)
     padw push.EXPECTED_DIGEST_PTR mem_loadw_le
-    # => [EXPECTED_DIGEST, DIGEST]
+    # => [EXPECTED_DIGEST, DIGEST, pad(12)]
 
-    # Assert that the note input matches the digest
-    # Will fail if the two hashes do not match
+    # assert that the note input matches the digest
+    # will fail if the two hashes do not match
     assert_eqw.err=ERROR_DIGEST_MISMATCH
-    # => []
+    # => [pad(16)]
 
     # ---------------------------------------------------------------------------------------------
-    # If the check is successful, we allow for the asset to be consumed
+    # if the check is successful, we allow for the asset to be consumed
     # ---------------------------------------------------------------------------------------------
 
-    # Add all assets from the note to the account
-    exec.wallet::add_assets_to_account
-    # => []
+    # add all assets from the note to the account
+    exec.wallet::move_note_assets_to_account
+    # => [pad(16)]
 end

--- a/masm/notes/iterative_output_note.masm
+++ b/masm/notes/iterative_output_note.masm
@@ -1,102 +1,128 @@
 use miden::protocol::active_note
 use miden::protocol::note
-use miden::protocol::output_note
 use miden::core::sys
-use miden::standards::wallets::basic->wallet
+use miden::standards::wallets::basic as wallet
+use miden::standards::note::note_creator
 
-# Memory Addresses
-# get_assets writes: ASSET_KEY at ASSET_KEY_PTR, ASSET_VALUE at ASSET_KEY_PTR+4 (ASSET_SIZE=8)
-const ASSET_KEY_PTR=0
-const ASSET_VALUE_PTR=4
-const ASSET_HALF_VALUE_PTR=8    # half-amount ASSET_VALUE stored here
-const ACCOUNT_ID_PREFIX=12      # storage: [prefix, suffix, tag, 0]
-const TAG=14                    # = ACCOUNT_ID_PREFIX + 2
+# CONSTANTS
+# =================================================================================================
 
-#! Inputs:  []
-#! Outputs: []
+# get_initial_assets writes the eight-felt asset as ASSET_ID followed by ASSET_VALUE
+const ASSET_ID_PTR = 0
+const ASSET_VALUE_PTR = 4
+const ASSET_HALF_VALUE_PTR = 8
+const ACCOUNT_ID_PREFIX = 12      # storage: [prefix, suffix, tag, 0]
+const TAG = 14                    # ACCOUNT_ID_PREFIX + 2
+
+# PUBLIC INTERFACE
+# =================================================================================================
+
+#! Receives this note's assets and creates a successor with half its fungible amount.
+#!
+#! This example expects exactly one fungible asset with a positive, even amount. Field division
+#! by two is not integer rounding, so an odd amount does not produce a valid half-amount transfer.
+#! Any account exposing the wallet and note-creator procedures may consume the note; the account
+#! ID in storage is copied into the successor's storage and does not restrict consumption.
+#!
+#! Inputs:  [ARGS, pad(12)]
+#! Outputs: [pad(16)]
+#!
+#! Where:
+#! - ARGS contains unused note arguments.
+#! - note storage contains a copied account ID and the successor's note tag.
+#!
+#! Panics if:
+#! - the account cannot receive the note's assets or move the computed half amount to the successor.
+#!
+#! Invocation: dyncall
 @note_script
-pub proc main
-    # Drop word if user accidentally pushes note_args
+pub proc main(args: word)
+    # discard the unused note arguments
     dropw
-    # => []
-
-    # Get asset contained in note into memory (ASSET_KEY at 0, ASSET_VALUE at 4)
-    # get_assets leaves [num_assets] on the stack in v0.15; drop it.
-    push.ASSET_KEY_PTR exec.active_note::get_assets drop
-    # => []
-
-    # Load ASSET_VALUE and compute half amount
-    padw push.ASSET_VALUE_PTR mem_loadw_le
-    # => [av0, av1, av2, av3]  (av0 = amount for fungible asset, av1/av2/av3 = 0)
-
-    # Halve the amount (av0 is the amount for fungible assets)
-    push.2 div
-    # => [av0/2, av1, av2, av3]
-
-    # Store as ASSET_HALF_VALUE
-    mem_storew_le.ASSET_HALF_VALUE_PTR dropw
-    # => []
-
-    # Receive all assets from note into the account wallet
-    exec.wallet::add_assets_to_account
-    # => []
-
-    # Push script hash
-    exec.active_note::get_script_root
-    # => [SCRIPT_HASH]
-
-    # Get the current note serial number
-    exec.active_note::get_serial_number
-    # => [SERIAL_NUM, SCRIPT_HASH]
-
-    # Increment the last element of the serial number by 1
-    # (serial_num[3] is at depth 3; matches Rust: serial_num[3] + 1)
-    swap.3 push.1 add swap.3
-    # => [SERIAL_NUM+1, SCRIPT_HASH]
-
-    # Load note storage into memory for recipient construction.
-    # get_storage consumes dest_ptr and leaves only [num_storage_items],
-    # so re-push the storage_ptr for the recipient call rather than swapping.
-    push.ACCOUNT_ID_PREFIX
-    exec.active_note::get_storage
-    # => [num_storage_items, SERIAL_NUM+1, SCRIPT_HASH]
-
-    push.ACCOUNT_ID_PREFIX
-    # => [storage_ptr, num_storage_items, SERIAL_NUM+1, SCRIPT_HASH]
-
-    # v0.15 renamed note::build_recipient -> note::compute_and_store_recipient
-    # (arg shape [storage_ptr, num_storage_items, SERIAL_NUM, SCRIPT_ROOT]).
-    exec.note::compute_and_store_recipient
-    # => [RECIPIENT]
-
-    # Push note type to stack (public note = 1)
-    push.1
-    # => [note_type, RECIPIENT]
-
-    # Load tag from memory
-    mem_load.TAG
-    # => [tag, note_type, RECIPIENT]
-
-    exec.output_note::create
-    # => [note_idx]
-
-    # Build [ASSET_KEY, ASSET_HALF_VALUE, note_idx] for move_asset_to_note
-    # Inputs: [ASSET_KEY, ASSET_VALUE, note_idx, pad(7)]
-
-    # Push ASSET_HALF_VALUE (note_idx moves to depth 4)
-    padw push.ASSET_HALF_VALUE_PTR mem_loadw_le
-    # => [ASSET_HALF_VALUE, note_idx]
-
-    # Push ASSET_KEY (ASSET_HALF_VALUE moves to depth 4, note_idx to depth 8)
-    padw push.ASSET_KEY_PTR mem_loadw_le
-    # => [ASSET_KEY, ASSET_HALF_VALUE, note_idx]
-
-    call.wallet::move_asset_to_note
     # => [pad(16)]
 
+    # get asset contained in note into memory (ASSET_ID at 0, ASSET_VALUE at 4)
+    # get_initial_assets leaves [num_assets] on the stack; drop it.
+    push.ASSET_ID_PTR exec.active_note::get_initial_assets drop
+    # => [pad(16)]
+
+    # load ASSET_VALUE and compute half amount
+    padw push.ASSET_VALUE_PTR mem_loadw_le
+    # => [[amount, 0, 0, 0], pad(16)]
+
+    # halve the even fungible amount
+    push.2 div
+    # => [[amount / 2, 0, 0, 0], pad(16)]
+
+    # store as ASSET_HALF_VALUE
+    mem_storew_le.ASSET_HALF_VALUE_PTR dropw
+    # => [pad(16)]
+
+    # receive all assets from note into the account wallet
+    exec.wallet::move_note_assets_to_account
+    # => [pad(16)]
+
+    # push script hash
+    exec.active_note::get_script_root
+    # => [SCRIPT_ROOT, pad(16)]
+
+    # get the current note serial number
+    exec.active_note::get_serial_number
+    # => [SERIAL_NUM, SCRIPT_ROOT, pad(16)]
+
+    # increment the last element of the serial number by 1
+    # (serial_num[3] is at depth 3; matches Rust: serial_num[3] + 1)
+    swap.3 push.1 add swap.3
+    # => [NEXT_SERIAL_NUM, SCRIPT_ROOT, pad(16)]
+
+    # load note storage into memory for recipient construction
+    push.ACCOUNT_ID_PREFIX
+    exec.active_note::get_storage
+    # => [num_storage_items, NEXT_SERIAL_NUM, SCRIPT_ROOT, pad(16)]
+
+    push.ACCOUNT_ID_PREFIX
+    # => [storage_ptr, num_storage_items, NEXT_SERIAL_NUM, SCRIPT_ROOT, pad(16)]
+
+    # argument shape: [storage_ptr, num_storage_items, SERIAL_NUM, SCRIPT_ROOT].
+    exec.note::compute_and_store_recipient
+    # => [RECIPIENT, pad(16)]
+
+    # push note type to stack (public note = 1)
+    push.1
+    # => [note_type, RECIPIENT, pad(16)]
+
+    # load tag from memory
+    mem_load.TAG
+    # => [tag, note_type, RECIPIENT, pad(16)]
+
+    # note creation from a note script must call the account's note-creator procedure.
+    # pad the stack for the account procedure call convention.
+    push.0 movdn.6 push.0 movdn.6 padw padw swapdw
+    # => [tag, note_type, RECIPIENT, pad(26)]
+
+    call.note_creator::create_note
+    # => [note_idx, pad(31)]
+
+    movdn.15 dropw dropw dropw drop drop drop
+    # => [note_idx, pad(16)]
+
+    # build [ASSET_ID, ASSET_HALF_VALUE, note_idx] for move_asset_to_note
+    # inputs: [ASSET_ID, ASSET_VALUE, note_idx, pad(7)]
+
+    # push ASSET_HALF_VALUE (note_idx moves to depth 4)
+    padw push.ASSET_HALF_VALUE_PTR mem_loadw_le
+    # => [ASSET_HALF_VALUE, note_idx, pad(16)]
+
+    # push ASSET_ID (ASSET_HALF_VALUE moves to depth 4, note_idx to depth 8)
+    padw push.ASSET_ID_PTR mem_loadw_le
+    # => [ASSET_ID, ASSET_HALF_VALUE, note_idx, pad(16)]
+
+    call.wallet::move_asset_to_note
+    # => [pad(25)]
+
     dropw dropw dropw dropw
-    # => []
+    # => [pad(16)]
 
     exec.sys::truncate_stack
-    # => []
+    # => [pad(16)]
 end

--- a/masm/notes/network_increment_note.masm
+++ b/masm/notes/network_increment_note.masm
@@ -1,8 +1,19 @@
 use external_contract::counter_contract
 
-#! Inputs:  []
-#! Outputs: []
+#! Increments the network counter when this note is consumed.
+#!
+#! Inputs:  [ARGS, pad(12)]
+#! Outputs: [pad(16)]
+#!
+#! Where:
+#! - ARGS contains unused note script arguments.
+#!
+#! Invocation: dyncall
 @note_script
-pub proc main
+pub proc main(args: word)
+    dropw
+    # => [pad(16)]
+
     call.counter_contract::increment_count
+    # => [pad(16)]
 end

--- a/masm/scripts/counter_script.masm
+++ b/masm/scripts/counter_script.masm
@@ -1,5 +1,19 @@
 use external_contract::counter_contract
 
-begin
+#! Increments the counter.
+#!
+#! Inputs:  [ARGS, pad(12)]
+#! Outputs: [pad(16)]
+#!
+#! Where:
+#! - ARGS contains unused transaction script arguments.
+#!
+#! Invocation: dyncall
+@transaction_script
+pub proc main(args: word)
+    dropw
+    # => [pad(16)]
+
     call.counter_contract::increment_count
+    # => [pad(16)]
 end

--- a/masm/scripts/mapping_example_script.masm
+++ b/masm/scripts/mapping_example_script.masm
@@ -1,25 +1,40 @@
 use miden_by_example::mapping_example_contract
 use miden::core::sys
 
-begin
+#! Writes a mapping entry, reads it, and returns the current map root.
+#!
+#! Inputs:  [ARGS, pad(12)]
+#! Outputs: [CURRENT_ROOT, pad(12)]
+#!
+#! Where:
+#! - ARGS contains unused transaction script arguments.
+#! - CURRENT_ROOT is the mapping's Merkle root after the write.
+#!
+#! Invocation: dyncall
+@transaction_script
+pub proc main(args: word) -> word
+    dropw
+    # => [pad(16)]
+
     push.1.2.3.4
     push.0.0.0.0
-    # => [KEY, VALUE]
+    # => [KEY, VALUE, pad(16)]
 
     call.mapping_example_contract::write_to_map
-    # => []
+    # => [pad(24)]
 
     push.0.0.0.0
-    # => [KEY]
+    # => [KEY, pad(24)]
 
     call.mapping_example_contract::get_value_in_map
-    # => [VALUE]
+    # => [VALUE, pad(24)]
 
     dropw
-    # => []
+    # => [pad(24)]
 
     call.mapping_example_contract::get_current_map_root
-    # => [CURRENT_ROOT]
+    # => [CURRENT_ROOT, pad(20)]
 
     exec.sys::truncate_stack
+    # => [CURRENT_ROOT, pad(12)]
 end

--- a/masm/scripts/oracle_reader_script.masm
+++ b/masm/scripts/oracle_reader_script.masm
@@ -1,5 +1,19 @@
 use external_contract::oracle_reader
 
-begin
-    exec.oracle_reader::get_price
+#! Queries the configured oracle through the reader account.
+#!
+#! Inputs:  [ARGS, pad(12)]
+#! Outputs: [pad(16)]
+#!
+#! Where:
+#! - ARGS contains unused transaction script arguments.
+#!
+#! Invocation: dyncall
+@transaction_script
+pub proc main(args: word)
+    dropw
+    # => [pad(16)]
+
+    call.oracle_reader::get_price
+    # => [pad(16)]
 end

--- a/masm/scripts/reader_script.masm
+++ b/masm/scripts/reader_script.masm
@@ -1,8 +1,18 @@
 use external_contract::count_reader_contract
 use miden::core::sys
 
-begin
-    padw padw padw padw
+#! Copies a public counter through the reader account.
+#!
+#! Inputs:  [ARGS, pad(12)]
+#! Outputs: [pad(16)]
+#!
+#! Where:
+#! - ARGS contains unused transaction script arguments.
+#!
+#! Invocation: dyncall
+@transaction_script
+pub proc main(args: word)
+    dropw
     # => [pad(16)]
 
     push.{get_count_proc_hash}
@@ -15,8 +25,8 @@ begin
     # => [account_id_suffix, account_id_prefix, GET_COUNT_HASH, pad(16)]
 
     call.count_reader_contract::copy_count
-    # => []
+    # => [pad(22)]
 
     exec.sys::truncate_stack
-    # => []
+    # => [pad(16)]
 end

--- a/rust-client/Cargo.lock
+++ b/rust-client/Cargo.lock
@@ -19,28 +19,28 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aead"
-version = "0.5.2"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+checksum = "1973cfbc1a2daf9cf550e74e1f088c28e7f7d8c1e1418fb6c9dc5184b7e84c99"
 dependencies = [
- "crypto-common",
- "generic-array",
+ "crypto-common 0.2.2",
+ "inout",
 ]
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "alloy-primitives"
-version = "1.5.7"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3b431b4e72cd8bd0ec7a50b4be18e73dab74de0dba180eef171055e5d5926e"
+checksum = "f007e257069855bdf21d27762fd3f3705a613f805c9a08309bf353503f081d71"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -49,47 +49,56 @@ dependencies = [
  "itoa",
  "paste",
  "ruint",
- "rustc-hash",
- "sha3",
+ "sha3 0.11.0",
+]
+
+[[package]]
+name = "alloy-rlp"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24671b1f62edcf0f9b62994c7bf72cd621a04a4b99f5020ece1a647b40e2f103"
+dependencies = [
+ "arrayvec",
+ "bytes",
 ]
 
 [[package]]
 name = "alloy-sol-macro"
-version = "1.5.7"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab81bab693da9bb79f7a95b64b394718259fdd7e41dceeced4cad57cb71c4f6a"
+checksum = "b5655c38d5f84955bf727b2eeb62fddd91ebb98fd1d7ae6eb77f73ea88f9b9cf"
 dependencies = [
  "alloy-sol-macro-expander",
  "alloy-sol-macro-input",
- "proc-macro-error2",
+ "proc-macro-error3",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "alloy-sol-macro-expander"
-version = "1.5.7"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "489f1620bb7e2483fb5819ed01ab6edc1d2f93939dce35a5695085a1afd1d699"
+checksum = "6277c780e07b76951e09a59788dde230d1582612324177d11a43a61e21a6bb83"
 dependencies = [
  "alloy-sol-macro-input",
  "const-hex",
  "heck",
- "indexmap",
- "proc-macro-error2",
+ "indexmap 2.14.0",
+ "proc-macro-error3",
  "proc-macro2",
  "quote",
- "sha3",
- "syn 2.0.117",
+ "sha3 0.11.0",
+ "syn 2.0.119",
  "syn-solidity",
 ]
 
 [[package]]
 name = "alloy-sol-macro-input"
-version = "1.5.7"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56cef806ad22d4392c5fc83cf8f2089f988eb99c7067b4e0c6f1971fc1cca318"
+checksum = "9762b2ad3e5a0c09886de54fe549ab0056681df843cb082e2df7e1c0eb270d30"
 dependencies = [
  "const-hex",
  "dunce",
@@ -97,15 +106,15 @@ dependencies = [
  "macro-string",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
  "syn-solidity",
 ]
 
 [[package]]
 name = "alloy-sol-types"
-version = "1.5.7"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64612d29379782a5dde6f4b6570d9c756d734d760c0c94c254d361e678a6591f"
+checksum = "d96e74d6213180f78dbdccddce8af02a639c160c94b0a543fa35c77c58b8a7fc"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-macro",
@@ -113,9 +122,9 @@ dependencies = [
 
 [[package]]
 name = "android_system_properties"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+checksum = "ae221649c9976a6f6c56ae1facf410f3ddb33cc661c4b7b61020a912d4237fbc"
 dependencies = [
  "libc",
 ]
@@ -172,40 +181,288 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
-name = "arrayref"
-version = "0.3.9"
+name = "ark-ff"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
-
-[[package]]
-name = "arrayvec"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
-
-[[package]]
-name = "ascii-canvas"
-version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef1e3e699d84ab1b0911a1010c5c106aa34ae89aeac103be5ce0c3859db1e891"
+checksum = "6b3235cc41ee7a12aaaf2c575a2ad7b46713a8a50bda2fc3b003a04845c05dd6"
 dependencies = [
- "term",
+ "ark-ff-asm 0.3.0",
+ "ark-ff-macros 0.3.0",
+ "ark-serialize 0.3.0",
+ "ark-std 0.3.0",
+ "derivative",
+ "num-bigint 0.4.8",
+ "num-traits",
+ "paste",
+ "rustc_version 0.3.3",
+ "zeroize",
 ]
 
 [[package]]
-name = "async-trait"
-version = "0.1.89"
+name = "ark-ff"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+checksum = "ec847af850f44ad29048935519032c33da8aa03340876d351dfab5660d2966ba"
+dependencies = [
+ "ark-ff-asm 0.4.2",
+ "ark-ff-macros 0.4.2",
+ "ark-serialize 0.4.2",
+ "ark-std 0.4.0",
+ "derivative",
+ "digest 0.10.7",
+ "itertools 0.10.5",
+ "num-bigint 0.4.8",
+ "num-traits",
+ "paste",
+ "rustc_version 0.4.1",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a177aba0ed1e0fbb62aa9f6d0502e9b46dad8c2eab04c14258a1212d2557ea70"
+dependencies = [
+ "ark-ff-asm 0.5.0",
+ "ark-ff-macros 0.5.0",
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
+ "arrayvec",
+ "digest 0.10.7",
+ "educe",
+ "itertools 0.13.0",
+ "num-bigint 0.4.8",
+ "num-traits",
+ "paste",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7a806ac6c8307b929df4645776290a50ee2aac754ad09d8bdf73391309e43af"
+dependencies = [
+ "ark-ff-asm 0.6.0",
+ "ark-ff-macros 0.6.0",
+ "ark-serialize 0.6.0",
+ "ark-std 0.6.0",
+ "digest 0.10.7",
+ "educe",
+ "num-bigint 0.4.8",
+ "num-traits",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db02d390bf6643fb404d3d22d31aee1c4bc4459600aef9113833d17e786c6e44"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed4aa4fe255d0bc6d79373f7e31d2ea147bcf486cba1be5ba7ea85abdb92348"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62945a2f7e6de02a31fe400aa489f0e0f5b2502e69f95f853adb82a96c7a6b60"
+dependencies = [
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1479009684adc073dff49a1025d3a7065b317a9ead25aaaca38cdc70058ba8a2"
+dependencies = [
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "ark-ff-macros"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db2fd794a08ccb318058009eefdf15bcaaaaf6f8161eb3345f907222bac38b20"
+dependencies = [
+ "num-bigint 0.4.8",
+ "num-traits",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-ff-macros"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7abe79b0e4288889c4574159ab790824d0033b9fdcb2a112a3182fac2e514565"
+dependencies = [
+ "num-bigint 0.4.8",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-ff-macros"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09be120733ee33f7693ceaa202ca41accd5653b779563608f1234f78ae07c4b3"
+dependencies = [
+ "num-bigint 0.4.8",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "ark-ff-macros"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a0691ed21ef00ef89c1e9bda832eba493dda3ec2f8d892fb25b705f73f06bb8"
+dependencies = [
+ "num-bigint 0.4.8",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "ark-serialize"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d6c2b318ee6e10f8c2853e73a83adc0ccb88995aa978d8a3408d492ab2ee671"
+dependencies = [
+ "ark-std 0.3.0",
+ "digest 0.9.0",
+]
+
+[[package]]
+name = "ark-serialize"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
+dependencies = [
+ "ark-std 0.4.0",
+ "digest 0.10.7",
+ "num-bigint 0.4.8",
+]
+
+[[package]]
+name = "ark-serialize"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f4d068aaf107ebcd7dfb52bc748f8030e0fc930ac8e360146ca54c1203088f7"
+dependencies = [
+ "ark-std 0.5.0",
+ "arrayvec",
+ "digest 0.10.7",
+ "num-bigint 0.4.8",
+]
+
+[[package]]
+name = "ark-serialize"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a74dd304fd536fb95d0a328e72be759209cc496a9da094c5bc56e5fea4f9e86b"
+dependencies = [
+ "ark-serialize-derive",
+ "ark-std 0.6.0",
+ "digest 0.10.7",
+ "num-bigint 0.4.8",
+ "serde_with",
+]
+
+[[package]]
+name = "ark-serialize-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f153690697a2b91e5e1251ff98411ee5371500a111a0fd317a70e588eb300f9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1df2c09229cbc5a028b1d70e00fdb2acee28b1055dfb5ca73eea49c5a25c4e7c"
+dependencies = [
+ "num-traits",
+ "rand 0.8.7",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
+dependencies = [
+ "num-traits",
+ "rand 0.8.7",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "246a225cc6131e9ee4f24619af0f19d67761fff15d7ccc22e42b80846e69449a"
+dependencies = [
+ "num-traits",
+ "rand 0.8.7",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "367c9c827ed431bff6868b7aa926e05b16eb46603cc8b6e768e4a5553fa1d155"
+dependencies = [
+ "num-traits",
+ "rand 0.8.7",
+]
+
+[[package]]
+name = "arrayvec"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
+
+[[package]]
+name = "async-trait"
+version = "0.1.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -215,10 +472,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
-name = "autocfg"
-version = "1.5.0"
+name = "auto_impl"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "ffdcb70bdbc4d478427380519163274ac86e52916e10f0a8889adf0f96d3fee7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "backtrace"
@@ -246,9 +514,9 @@ dependencies = [
 
 [[package]]
 name = "base16ct"
-version = "0.2.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+checksum = "fd307490d624467aa6f74b0eabb77633d1f758a7b25f12bceb0b22e08d9726f6"
 
 [[package]]
 name = "base64"
@@ -275,42 +543,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
 
 [[package]]
-name = "bincode"
-version = "1.3.3"
+name = "bitflags"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "bit-set"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
-dependencies = [
- "bit-vec",
-]
-
-[[package]]
-name = "bit-vec"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
+
+[[package]]
+name = "bitvec"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddcec3d12c579d40898fe0a9a358a803c23e9c52ca3c425707f81c9436211837"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
 
 [[package]]
 name = "blake3"
-version = "1.8.4"
+version = "1.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d2d5991425dfd0785aed03aedcf0b321d61975c9b5b3689c774a2610ae0b51e"
+checksum = "6d9e454fc11f76977dc803893aff6304ed33d6a26efae8696573bea74baa27ae"
 dependencies = [
- "arrayref",
  "arrayvec",
  "cc",
  "cfg-if",
@@ -325,6 +586,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -349,23 +619,38 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.117",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
 ]
 
 [[package]]
 name = "build-rs"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe808acca98fccf920154ee7833e791bfb683299be4aae7ec222ddffad8cd4f8"
+checksum = "87a490fb7ec2896b97a4c721c03a2b2dc5c2b9b75b2a57ca396db4470dea0381"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "byte-slice-cast"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7575182f7272186991736b70173b0ea045398f984bf5ebbb3804736ce1330c9d"
 
 [[package]]
 name = "byteorder"
@@ -375,15 +660,15 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cc"
-version = "1.2.60"
+version = "1.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+checksum = "0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -398,52 +683,65 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
-name = "chacha20"
-version = "0.9.1"
+name = "cfg_aliases"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
+
+[[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures 0.2.17",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
 name = "chacha20poly1305"
-version = "0.10.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+checksum = "9b89e1c441e926b9c82a8d023f6e1b7ae0adcfaa7d621814e4d60789bac751cb"
 dependencies = [
  "aead",
  "chacha20",
  "cipher",
  "poly1305",
- "zeroize",
 ]
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
+ "serde",
  "wasm-bindgen",
  "windows-link",
 ]
 
 [[package]]
 name = "cipher"
-version = "0.4.4"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
 dependencies = [
- "crypto-common",
+ "block-buffer 0.12.1",
+ "crypto-common 0.2.2",
  "inout",
- "zeroize",
 ]
+
+[[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "codegen"
@@ -451,7 +749,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "573800db6c3319bc125ddbf9b9cb001ad1602957f53642ba8d09ff3ddd4da7f1"
 dependencies = [
- "indexmap",
+ "indexmap 2.14.0",
 ]
 
 [[package]]
@@ -462,9 +760,9 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "const-hex"
-version = "1.18.1"
+version = "1.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "531185e432bb31db1ecda541e9e7ab21468d4d844ad7505e0546a49b4945d49b"
+checksum = "33e2a781ebdf4467d1428dc4593067825fb646f6871475098d8577421af73558"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
@@ -474,9 +772,30 @@ dependencies = [
 
 [[package]]
 name = "const-oid"
-version = "0.9.6"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
+name = "const_format"
+version = "0.2.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4481a617ad9a412be3b97c5d403fef8ed023103368908b9c50af598ff467cc1e"
+dependencies = [
+ "const_format_proc_macros",
+ "konst",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d57c2eccfb16dbac1f4e61e206105db5820c9d26c3c472bc17c774259ef7744"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
 
 [[package]]
 name = "constant_time_eq"
@@ -510,6 +829,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpubits"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -535,9 +860,9 @@ checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -545,18 +870,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crunchy"
@@ -566,12 +891,15 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.5.5"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+checksum = "1a52aa3fcda4e6302a9f48734f234d35d4721b96f8fe07d073f07ce9df4f0271"
 dependencies = [
- "generic-array",
- "rand_core 0.6.4",
+ "cpubits",
+ "ctutils",
+ "hybrid-array",
+ "num-traits",
+ "rand_core 0.10.1",
  "subtle",
  "zeroize",
 ]
@@ -583,20 +911,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
- "rand_core 0.6.4",
  "typenum",
 ]
 
 [[package]]
-name = "curve25519-dalek"
-version = "4.1.3"
+name = "crypto-common"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+ "subtle",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5eed333089e2e1c1ac8c6c0398e5e2497b4c9926ca6d0365ed1e099afa5bc23"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
+ "cpufeatures 0.3.0",
  "curve25519-dalek-derive",
- "digest",
+ "digest 0.11.3",
  "fiat-crypto",
  "rustc_version 0.4.1",
  "subtle",
@@ -611,7 +958,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -634,7 +981,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -645,7 +992,7 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -679,13 +1026,64 @@ dependencies = [
 ]
 
 [[package]]
-name = "der"
-version = "0.7.10"
+name = "defmt"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
+dependencies = [
+ "defmt-parser",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror",
+]
+
+[[package]]
+name = "der"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a69dedd701da44b0536442edf09c81a64b0ab97a7a4a5e3d1971f00027cbc63d"
 dependencies = [
  "const-oid",
  "zeroize",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -707,8 +1105,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version 0.4.1",
- "syn 2.0.117",
+ "syn 2.0.119",
  "unicode-xid",
+]
+
+[[package]]
+name = "digest"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -717,10 +1124,31 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
  "const-oid",
- "crypto-common",
- "subtle",
+ "crypto-common 0.2.2",
+ "ctutils",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -736,24 +1164,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
-name = "ecdsa"
-version = "0.16.9"
+name = "dyn-clone"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "ecdsa"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0681a4fc24c767085329728d8dfba959af91228aa4610cca4f8ce317ba46ae0"
 dependencies = [
  "der",
- "digest",
+ "digest 0.11.3",
  "elliptic-curve",
  "rfc6979",
  "signature",
  "spki",
+ "zeroize",
 ]
 
 [[package]]
 name = "ed25519"
-version = "2.2.3"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+checksum = "29fcf32e6c73d1079f83ab4d782de2d81620346a5f38c6237a86a22f8368980a"
 dependencies = [
  "pkcs8",
  "signature",
@@ -761,58 +1196,83 @@ dependencies = [
 
 [[package]]
 name = "ed25519-dalek"
-version = "2.2.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+checksum = "6ebaa1a2bf1290ab3bfe5a7b771d050ebffab2711c19a81691c683a5144a25de"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
  "serde",
- "sha2",
+ "sha2 0.11.0",
+ "signature",
  "subtle",
  "zeroize",
 ]
 
 [[package]]
-name = "either"
-version = "1.15.0"
+name = "educe"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "1d7bc049e1bd8cdeb31b68bbd586a9464ecf9f3944af3958a7a9d0f8b9799417"
+dependencies = [
+ "enum-ordinalize",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "either"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "252afb9ae5eaa683babdc6a068b3f5726eb19e05070c731f9b2a23a7c3e8ed34"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.13.8"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+checksum = "9d65aa39b3a5c1c9c1b745c9a019234bb7a21b77abcb4f4d266d706e2d577d65"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "digest",
+ "crypto-common 0.2.2",
+ "digest 0.11.3",
  "ff",
- "generic-array",
  "group",
  "hkdf",
+ "hybrid-array",
  "pkcs8",
- "rand_core 0.6.4",
+ "rand_core 0.10.1",
  "sec1",
  "subtle",
  "zeroize",
 ]
 
 [[package]]
-name = "ena"
-version = "0.14.4"
+name = "enum-ordinalize"
+version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eabffdaee24bd1bf95c5ef7cec31260444317e72ea56c4c91750e8b7ee58d5f1"
+checksum = "89dd01549b09589510cf0647475075d12071456586d70f5c75c98ae2a5537677"
 dependencies = [
- "log",
+ "enum-ordinalize-derive",
+]
+
+[[package]]
+name = "enum-ordinalize-derive"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a65863d15a4ce2888bd2f0f543cc963d3879c3a022c8ee43f6141d479a3ac815"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "env_filter"
-version = "1.0.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
+checksum = "900d271a03799a1ee8d1ca9b19893b48ca674a9284fefcfb85f05e74ed314217"
 dependencies = [
  "log",
  "regex",
@@ -820,9 +1280,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.11.10"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
+checksum = "de671bd27a75a797dc9ae289ba1e77276e75e2026408aab65185384e2d5cd3f6"
 dependencies = [
  "anstream",
  "anstyle",
@@ -872,31 +1332,53 @@ checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fastrand"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
+
+[[package]]
+name = "fastrlp"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139834ddba373bbdd213dffe02c8d110508dcf1726c2be27e8d1f7d7e1856418"
+dependencies = [
+ "arrayvec",
+ "auto_impl",
+ "bytes",
+]
+
+[[package]]
+name = "fastrlp"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce8dba4714ef14b8274c371879b175aa55b16b30f269663f19d576f380018dc4"
+dependencies = [
+ "arrayvec",
+ "auto_impl",
+ "bytes",
+]
 
 [[package]]
 name = "ff"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+checksum = "a1f686ab92a9fb0eaf188f6c6c87b89490baa6fdb0db4544ba4dc47f7942489f"
 dependencies = [
- "rand_core 0.6.4",
+ "rand_core 0.10.1",
  "subtle",
 ]
 
 [[package]]
 name = "fiat-crypto"
-version = "0.2.9"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+checksum = "64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24"
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.9"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
 
 [[package]]
 name = "fixed-hash"
@@ -904,6 +1386,9 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
 dependencies = [
+ "byteorder",
+ "rand 0.8.7",
+ "rustc-hex",
  "static_assertions",
 ]
 
@@ -915,14 +1400,11 @@ checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flume"
-version = "0.11.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+checksum = "5e139bc46ca777eb5efaf62df0ab8cc5fd400866427e56c68b22e414e53bd3be"
 dependencies = [
- "futures-core",
- "futures-sink",
- "nanorand",
- "spin 0.9.8",
+ "spin 0.9.9",
 ]
 
 [[package]]
@@ -938,19 +1420,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
-name = "fs-err"
-version = "3.3.0"
+name = "foldhash"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73fde052dbfc920003cfd2c8e2c6e6d4cc7c1091538c3a24226cec0665ab08c0"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "fs-err"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b91aa448ca50d7e79433bdf3ee8d99215430d2ec02ade5aefab2a073a1822e8a"
 dependencies = [
  "autocfg",
 ]
 
 [[package]]
-name = "futures"
-version = "0.3.32"
+name = "funty"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
+
+[[package]]
+name = "futures"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a31d2a3fbaaeb2af2368bbdd904aa8e812d3c04a1ee10d3171f52d556e5d0a3"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -963,9 +1466,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+checksum = "b1f9e3d69d39e4862ffed03ed071a76f9a13ba1d9109d355b0f0aa6b15e393c4"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -973,15 +1476,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+checksum = "031b47cf1a3c6cc8bc2fc76cd437f521619387907d469316e7c0bc278f1f5432"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -990,38 +1493,38 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+checksum = "53c0fa8157de1303bfffdaa1cc2a673bfffb60102f76b0ef4441659124373fed"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+checksum = "1944426bf7d03f1d14f708785e4b33efd750b36d48a157b836b3efc15ede8e1d"
 
 [[package]]
 name = "futures-task"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+checksum = "cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd"
 
 [[package]]
 name = "futures-util"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1036,9 +1539,9 @@ dependencies = [
 
 [[package]]
 name = "generator"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f04ae4152da20c76fe800fa48659201d5cf627c5149ca0b707b69d7eef6cf9"
+checksum = "b3b854b0e584ead1a33f18b2fcad7cf7be18b3875c78816b753639aa501513ae"
 dependencies = [
  "cc",
  "cfg-if",
@@ -1057,7 +1560,6 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
- "zeroize",
 ]
 
 [[package]]
@@ -1089,16 +1591,15 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
  "r-efi 6.0.0",
- "wasip2",
- "wasip3",
+ "rand_core 0.10.1",
  "wasm-bindgen",
 ]
 
@@ -1110,9 +1611,9 @@ checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "glob"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
 name = "gloo-timers"
@@ -1128,20 +1629,20 @@ dependencies = [
 
 [[package]]
 name = "group"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+checksum = "7fd1a1c7a5206c5b7a3f5a0d7ccd3ff85d0c8f5133d62a02680255b0004af5f4"
 dependencies = [
  "ff",
- "rand_core 0.6.4",
+ "rand_core 0.10.1",
  "subtle",
 ]
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "839c0e8a181239723652be9062bb56ca5bf5f64011f73b623f6f4fc59086a228"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1149,7 +1650,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1158,18 +1659,27 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "hashlink"
@@ -1200,27 +1710,27 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hkdf"
-version = "0.12.4"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+checksum = "4aaa26c720c68b866f2c96ef5c1264b3e6f473fe5d4ce61cd44bbe913e553018"
 dependencies = [
  "hmac",
 ]
 
 [[package]]
 name = "hmac"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
- "digest",
+ "digest 0.11.3",
 ]
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
 dependencies = [
  "bytes",
  "itoa",
@@ -1228,9 +1738,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
 dependencies = [
  "bytes",
  "http",
@@ -1238,9 +1748,9 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.3"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+checksum = "23169fe34a5fbcdd3f3862e78fb9b6fccd5f02a6dc6f732547005d45631ce71c"
 dependencies = [
  "bytes",
  "futures-core",
@@ -1262,10 +1772,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
-name = "hyper"
-version = "1.9.0"
+name = "hybrid-array"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
+dependencies = [
+ "subtle",
+ "typenum",
+ "zeroize",
+]
+
+[[package]]
+name = "hyper"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1281,6 +1802,22 @@ dependencies = [
  "smallvec",
  "tokio",
  "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1302,13 +1839,16 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
+ "base64",
  "bytes",
  "futures-channel",
  "futures-util",
  "http",
  "http-body",
  "hyper",
+ "ipnet",
  "libc",
+ "percent-encoding",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -1341,16 +1881,134 @@ dependencies = [
 ]
 
 [[package]]
-name = "id-arena"
+name = "icu_collections"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+checksum = "fa68d21081c4a05d5a901a1c62add574c77048b6a1c67be3b50ce0b60d4ca513"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d56e28588da92eee5c3201a6eff33fabdd49b62269c8938d4ff050ce4d900deb"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f9cf5f235641ed274641dd81c3f28d870e276763d0797aeeab72317b1c646f"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1563da1ed3e0b3bf3d74c9b85917ac9c56464d2f57242270c09c9e752f8021a0"
+
+[[package]]
+name = "icu_properties"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e7ca276ad3145661a65914e6daf131ca5120cd3dcee8f8f3214b8875184a148"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e590f038c1464a96894fd6d10127e90a8be4509f56ff7ecef851b15cee0b7caa"
+
+[[package]]
+name = "icu_provider"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d27bbb9d3abbefac45d55f647c9de1d44aafcd1186eb91879afef17c396c3e73"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
 
 [[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
+name = "impl-codec"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba6a270039626615617f3f36d15fc827041df3b78c439da2cadfa47455a77f2f"
+dependencies = [
+ "parity-scale-codec",
+]
+
+[[package]]
+name = "impl-trait-for-tuples"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0eb5a3343abf848c0984fe4604b2b105da9539376e24fc0a3b0007411ae4fd9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "indenter"
@@ -1360,24 +2018,41 @@ checksum = "964de6e86d545b246d84badc0fef527924ace5134f30641c203ef52ba83f58d5"
 
 [[package]]
 name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+ "serde",
+]
+
+[[package]]
+name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
 
 [[package]]
 name = "inout"
-version = "0.1.4"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
 dependencies = [
- "generic-array",
+ "hybrid-array",
 ]
+
+[[package]]
+name = "ipnet"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
 
 [[package]]
 name = "is_ci"
@@ -1393,9 +2068,36 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
 dependencies = [
  "either",
 ]
@@ -1408,102 +2110,116 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.23"
+version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a3546dc96b6d42c5f24902af9e2538e82e39ad350b0c766eb3fbf2d8f3d8359"
+checksum = "668b7183bd07af9a4885f5c35b0cc5c83c4607a913c16b7e17291832910d2dcc"
 dependencies = [
+ "defmt",
+ "jiff-core",
  "jiff-static",
+ "jiff-tzdb-platform",
  "log",
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
+ "windows-link",
+]
+
+[[package]]
+name = "jiff-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7feca88439efe53da3754500c1851dedf3cb36c524dd5cf8225cc0794de95d09"
+dependencies = [
+ "defmt",
 ]
 
 [[package]]
 name = "jiff-static"
-version = "0.2.23"
+version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
+checksum = "3a69dcb3a21cfb32ce1cd056169337ca284af0766dd766e7878819b251a49204"
 dependencies = [
+ "jiff-core",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "142bd39932ad231f10513df9ab62661fead8719872150b7ad02a2df79f4e141e"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
 ]
 
 [[package]]
 name = "jobserver"
-version = "0.1.34"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "libc",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.95"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
 dependencies = [
  "cfg-if",
  "futures-util",
- "once_cell",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "k256"
-version = "0.13.4"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
+checksum = "93f50113171a713f4a4231ef82eb26703607139b35dcb56241f0ceab2ae1f7d8"
 dependencies = [
- "cfg-if",
+ "cpubits",
  "ecdsa",
  "elliptic-curve",
- "once_cell",
- "sha2",
- "signature",
+ "primeorder",
+ "sha2 0.11.0",
+ "wnaf",
 ]
 
 [[package]]
 name = "keccak"
-version = "0.1.6"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
+checksum = "ffd9697dc4a9a62e2da93389f34400b77a28f0287711263cabb203b3ccb9c0e4"
 dependencies = [
- "cpufeatures 0.2.17",
+ "cfg-if",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
-name = "lalrpop"
-version = "0.22.2"
+name = "konst"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba4ebbd48ce411c1d10fb35185f5a51a7bfa3d8b24b4e330d30c9e3a34129501"
+checksum = "128133ed7824fcd73d6e7b17957c5eb7bacb885649bd8c69708b2331a10bcefb"
 dependencies = [
- "ascii-canvas",
- "bit-set",
- "ena",
- "itertools",
- "lalrpop-util",
- "petgraph 0.7.1",
- "regex",
- "regex-syntax",
- "sha3",
- "string_cache",
- "term",
- "unicode-xid",
- "walkdir",
+ "konst_macro_rules",
 ]
 
 [[package]]
-name = "lalrpop-util"
-version = "0.22.2"
+name = "konst_macro_rules"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5baa5e9ff84f1aefd264e6869907646538a52147a755d494517a8007fb48733"
-dependencies = [
- "rustversion",
-]
+checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
 
 [[package]]
 name = "lazy_static"
@@ -1512,16 +2228,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
-
-[[package]]
 name = "libc"
-version = "0.2.185"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libm"
@@ -1547,6 +2257,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
+name = "litemap"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d9d19d1d6efa0109d2f65ff4c85cddd50bd572e5a00127ab10987290bcefae"
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1557,9 +2273,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "logos"
@@ -1567,7 +2283,16 @@ version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff472f899b4ec2d99161c51f60ff7075eeb3097069a36050d8037a6325eb8154"
 dependencies = [
- "logos-derive",
+ "logos-derive 0.15.1",
+]
+
+[[package]]
+name = "logos"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2c55a318a87600ea870ff8c2012148b44bf18b74fad48d0f835c38c7d07c5f"
+dependencies = [
+ "logos-derive 0.16.1",
 ]
 
 [[package]]
@@ -1583,7 +2308,21 @@ dependencies = [
  "quote",
  "regex-syntax",
  "rustc_version 0.4.1",
- "syn 2.0.117",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "logos-codegen"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58b3ffaa284e1350d017a57d04ada118c4583cf260c8fb01e0fe28a2e9cf8970"
+dependencies = [
+ "fnv",
+ "proc-macro2",
+ "quote",
+ "regex-automata",
+ "regex-syntax",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1592,7 +2331,16 @@ version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "605d9697bcd5ef3a42d38efc51541aa3d6a4a25f7ab6d1ed0da5ac632a26b470"
 dependencies = [
- "logos-codegen",
+ "logos-codegen 0.15.1",
+]
+
+[[package]]
+name = "logos-derive"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52d3a9855747c17eaf4383823f135220716ab49bea5fbea7dd42cc9a92f8aa31"
+dependencies = [
+ "logos-codegen 0.16.1",
 ]
 
 [[package]]
@@ -1609,14 +2357,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "macro-string"
-version = "0.1.4"
+name = "lru-slab"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b27834086c65ec3f9387b096d66e99f221cf081c2b738042aa252bcd41204e3"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "macro-string"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59a9dbbfc75d2688ed057456ce8a3ee3f48d12eec09229f560f3643b9f275653"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1630,16 +2384,17 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "miden-ace-codegen"
-version = "0.23.4"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd45076fe4fef71f0f8b30aa0f018eb39c3086eeb5f3cafc0e12d60cd28339e"
+checksum = "1219d5caa6fcb00a96e1ec0ffc66bc03d86fc3e6367d5d8021e7ed420973d64e"
 dependencies = [
+ "miden-constraint-compiler",
  "miden-core",
  "miden-crypto",
  "thiserror",
@@ -1647,37 +2402,38 @@ dependencies = [
 
 [[package]]
 name = "miden-agglayer"
-version = "0.15.3"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ead17cc16651de0fea5fc3ea67109ad449c7bb274ca8ff91c5b25e2be4a0c9f8"
+checksum = "3664d9d786b69d3ddef13eda4a2d8eb1138ad381ddb740367167fe721dd9cb76"
 dependencies = [
  "alloy-sol-types",
  "fs-err",
  "miden-assembly",
  "miden-core",
+ "miden-core-lib",
  "miden-crypto",
+ "miden-mast-package",
+ "miden-package-registry",
  "miden-protocol",
+ "miden-protocol-build-utils",
  "miden-standards",
  "miden-utils-sync",
- "primitive-types",
- "regex",
  "serde",
  "serde_json",
  "thiserror",
- "walkdir",
 ]
 
 [[package]]
 name = "miden-air"
-version = "0.23.4"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69f1a80330b3e3d3f98e08817dc6a5e3d90d11ab5e88aa9c0dad5d3b4202598b"
+checksum = "20a825f5e8b687969ad32107a669b9ae254ba780c18f2e43869407aa010bc5e8"
 dependencies = [
  "miden-ace-codegen",
  "miden-core",
  "miden-crypto",
- "miden-lifted-stark",
  "miden-utils-indexing",
+ "p3-field",
  "proptest",
  "thiserror",
  "tracing",
@@ -1685,9 +2441,9 @@ dependencies = [
 
 [[package]]
 name = "miden-assembly"
-version = "0.23.4"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8582d184360be35eb2111a99245f556f43e1066ed09192fbcd0f218c466862a5"
+checksum = "3f1487a11b83df90e74469fdf61ee0b27831562972c3a4689e0c9bb7b0158ba5"
 dependencies = [
  "env_logger",
  "log",
@@ -1703,15 +2459,13 @@ dependencies = [
 
 [[package]]
 name = "miden-assembly-syntax"
-version = "0.23.4"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffa307bc2cbd1f0cb74ed58981823f400a433900fb8f963762331fbb8389d5dc"
+checksum = "e77f0289745bb1887147ee67acfb47e14443579b7c7d0655660599f62545bc34"
 dependencies = [
- "aho-corasick",
  "env_logger",
- "lalrpop",
- "lalrpop-util",
  "log",
+ "miden-assembly-syntax-cst",
  "miden-core",
  "miden-debug-types",
  "miden-utils-diagnostics",
@@ -1727,10 +2481,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "miden-block-prover"
-version = "0.15.3"
+name = "miden-assembly-syntax-cst"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "292ded918a0ddd056dc34db471f0bef6ac7991467d513ba505a4fcc0b1ecfac4"
+checksum = "7f41c6c73726eb40149ca2d174c5dd5ac9fcbcd738d851bc4c7ddb7b7f6d4561"
+dependencies = [
+ "miden-debug-types",
+ "miden-rowan",
+ "miden-utils-diagnostics",
+ "thiserror",
+]
+
+[[package]]
+name = "miden-block-prover"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "286198b93e8ada957dc89fa920fdd442066c02bb0f28efbe0172fce03119545f"
 dependencies = [
  "miden-protocol",
  "thiserror",
@@ -1738,9 +2504,9 @@ dependencies = [
 
 [[package]]
 name = "miden-client"
-version = "0.15.2"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6eb783623b8f55d013833c4eef35190f44da3629d0d13a13693285004f8d3fe2"
+checksum = "c9862fde2ef60a6a1f1066834c9920f50973a2012465c451ec64381fea4654fc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1750,18 +2516,19 @@ dependencies = [
  "gloo-timers",
  "hex",
  "miden-agglayer",
+ "miden-assembly-syntax",
  "miden-node-proto-build",
  "miden-note-transport-proto-build",
+ "miden-processor",
  "miden-protocol",
- "miden-remote-prover-client",
  "miden-standards",
  "miden-testing",
  "miden-tx",
- "miden-tx-batch-prover",
+ "miden-tx-batch",
  "miette",
  "prost",
  "prost-types",
- "rand 0.9.4",
+ "rand 0.10.2",
  "serde",
  "serde_json",
  "tempfile",
@@ -1778,9 +2545,9 @@ dependencies = [
 
 [[package]]
 name = "miden-client-sqlite-store"
-version = "0.15.2"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efb7f78f6ce83e114c49c601aa563df2863ebebea471023d70c3577177356b39"
+checksum = "b1bdb490a10753418209cf9efcb8d923b3b0a39105b9cba987e9674dd1528b66"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1793,13 +2560,24 @@ dependencies = [
  "rusqlite_migration",
  "thiserror",
  "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "miden-constraint-compiler"
+version = "0.29.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec5809dc0c9bc973f90cdb76116bfc3f5463d1e1ef9ce73a671141ba9f6d89a"
+dependencies = [
+ "miden-core",
+ "miden-crypto",
 ]
 
 [[package]]
 name = "miden-core"
-version = "0.23.4"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80657c32850817f5f67dcf114866495a4b055531778b7c26d0602646ce777eb8"
+checksum = "e8727b184f044ca41e61c9c2c345336d0e570f29c041bb49575520aade3c8f2d"
 dependencies = [
  "derive_more",
  "log",
@@ -1809,36 +2587,47 @@ dependencies = [
  "miden-utils-core-derive",
  "miden-utils-indexing",
  "miden-utils-sync",
- "num-derive",
- "num-traits",
  "proptest",
- "proptest-derive",
  "serde",
  "thiserror",
 ]
 
 [[package]]
 name = "miden-core-lib"
-version = "0.23.4"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16410655f32f98537afc9ddf57b71cb6d1ca9d980da5f4eea164cafcaf891b2e"
+checksum = "e48b2c62c2c0144717e4219cb42aaf427d58ccd730a18ba97f2e37387a3c3193"
 dependencies = [
  "env_logger",
  "fs-err",
  "miden-assembly",
+ "miden-assembly-syntax",
  "miden-core",
+ "miden-core-lib-codegen",
  "miden-crypto",
+ "miden-mast-package",
  "miden-package-registry",
+ "miden-precompiles",
  "miden-processor",
  "miden-utils-sync",
  "thiserror",
 ]
 
 [[package]]
-name = "miden-crypto"
-version = "0.25.1"
+name = "miden-core-lib-codegen"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35198bebd353cddc25ad4aafb5f4ef9e71b283d71c787b8938c575c16974135d"
+checksum = "a0a0787b5fd63be0e6f5ee96bc531c075e96c0a787b3608fbaf60db0d82c47ed"
+dependencies = [
+ "miden-core",
+ "miden-precompiles",
+]
+
+[[package]]
+name = "miden-crypto"
+version = "0.29.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8202e1536816c254332798e27f5d46f4940766e01322826553b77489b78ce44d"
 dependencies = [
  "blake3",
  "cc",
@@ -1865,14 +2654,12 @@ dependencies = [
  "p3-maybe-rayon",
  "p3-symmetric",
  "p3-util",
- "rand 0.9.4",
- "rand_chacha",
- "rand_core 0.9.5",
- "rand_hc",
+ "rand 0.10.2",
+ "rand_chacha 0.10.0",
  "rayon",
  "serde",
- "sha2",
- "sha3",
+ "sha2 0.11.0",
+ "sha3 0.12.0",
  "subtle",
  "thiserror",
  "x25519-dalek",
@@ -1880,19 +2667,19 @@ dependencies = [
 
 [[package]]
 name = "miden-crypto-derive"
-version = "0.25.1"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9068c6554db0e051f62913575de9949841a46b96ae92d4b7d28e1fed5d8f052b"
+checksum = "dcdc897827882684b76ac4b45cae93885cc252ee69c578e6b8ce0e3954043674"
 dependencies = [
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "miden-debug-types"
-version = "0.23.4"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "956708ccb2f643db398b4b3d4f8d0baf199b1bfb5e34c8be1cd1bc811c005e8e"
+checksum = "da1533b6a269126a48dbcb14ce22c3e31be0d0284b516b84f0954261c79f1756"
 dependencies = [
  "memchr",
  "miden-crypto",
@@ -1905,22 +2692,23 @@ dependencies = [
  "serde",
  "serde_spanned",
  "thiserror",
+ "zerocopy",
 ]
 
 [[package]]
 name = "miden-field"
-version = "0.25.1"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "379a39db52cd932a95d4017a18b712ee53ed0f86cfedf8c63ed72d687a18a191"
+checksum = "8d9c9b62982fcb18fa1b6c3bcaefc7956da30859d5e881a7f88f77dcf972db99"
 dependencies = [
  "miden-serde-utils",
- "num-bigint",
+ "num-bigint 0.5.1",
  "p3-challenger",
  "p3-field",
  "p3-goldilocks",
  "p3-util",
  "paste",
- "rand 0.10.1",
+ "rand 0.10.2",
  "serde",
  "subtle",
  "thiserror",
@@ -1937,11 +2725,12 @@ dependencies = [
 
 [[package]]
 name = "miden-lifted-air"
-version = "0.25.1"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "789e0e469d1731012d8a018057317f31580611535c20d2a47c022213228cb733"
+checksum = "8314dec43170ef8549a7a00ae6dd016975d772c9bdf03c06fb8a69d39fed300f"
 dependencies = [
  "p3-air",
+ "p3-challenger",
  "p3-field",
  "p3-matrix",
  "p3-util",
@@ -1950,9 +2739,9 @@ dependencies = [
 
 [[package]]
 name = "miden-lifted-stark"
-version = "0.25.1"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f62cca91182917b22a47e150028b7c785df620a15b2974a39c64e2b1b7a889d3"
+checksum = "48166c2c8ee308ecbaea6ec8db07981973ff42f99bb39c09b914c30510942a9b"
 dependencies = [
  "miden-lifted-air",
  "miden-stark-transcript",
@@ -1965,7 +2754,7 @@ dependencies = [
  "p3-maybe-rayon",
  "p3-symmetric",
  "p3-util",
- "rand 0.10.1",
+ "rand 0.10.2",
  "serde",
  "thiserror",
  "tracing",
@@ -1973,15 +2762,20 @@ dependencies = [
 
 [[package]]
 name = "miden-mast-package"
-version = "0.23.4"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f37c21836b40785ce297d363c57740d4e33edcc411f84185a524eddadd5f53c7"
+checksum = "3e99190edc3ae5a8be14aa77aa38df7a06d28455f8e9c02f4486a653f92e21cc"
 dependencies = [
+ "hashbrown 0.17.1",
+ "log",
  "miden-assembly-syntax",
  "miden-core",
  "miden-debug-types",
+ "miden-utils-indexing",
+ "rustc-hash",
  "serde",
  "thiserror",
+ "zerocopy",
 ]
 
 [[package]]
@@ -2000,9 +2794,9 @@ dependencies = [
  "rustc_version 0.2.3",
  "rustversion",
  "serde_json",
- "spin 0.9.8",
+ "spin 0.9.9",
  "strip-ansi-escapes",
- "syn 2.0.117",
+ "syn 2.0.119",
  "textwrap",
  "thiserror",
  "trybuild",
@@ -2017,14 +2811,14 @@ checksum = "86a905f3ea65634dd4d1041a4f0fd0a3e77aa4118341d265af1a94339182222f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "miden-node-proto-build"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef3b301741cedd6d0b532583690bc21dbf856d4e14218c591f3924bc905c660a"
+checksum = "724a79e7663157e73de1fc19fcd6e30c7cee4e4c4189d44477922a3969797acb"
 dependencies = [
  "build-rs",
  "codegen",
@@ -2036,9 +2830,9 @@ dependencies = [
 
 [[package]]
 name = "miden-note-transport-proto-build"
-version = "0.4.1"
+version = "0.5.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7399c2999453c781601f16d82f328ecc695f9375e2415a05147449990f32f71f"
+checksum = "5a9d736051a42941788c6534caf8cf779b388c0ae72c9d5f0d729d2a9872d833"
 dependencies = [
  "fs-err",
  "miette",
@@ -2048,9 +2842,9 @@ dependencies = [
 
 [[package]]
 name = "miden-package-registry"
-version = "0.23.4"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ece6064beb0582d1c64ba30d0c548c4b7a45f87abae6d69e22fd49c8b343258"
+checksum = "5a4b2c12e20f45e74c24ef88819c1ba36724519ce3b76d367a72e1d958df62b8"
 dependencies = [
  "miden-assembly-syntax",
  "miden-core",
@@ -2063,15 +2857,50 @@ dependencies = [
 ]
 
 [[package]]
-name = "miden-processor"
-version = "0.23.4"
+name = "miden-precompiles"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea972ca9e45dbf26aa396367e8508db0f7292adea6f6ddf8d39d0e334285fe2b"
+checksum = "823d3e418adcbe5a8cea6843f2a167f6f5b521ab827075261974b807ef979ccf"
 dependencies = [
- "itertools",
+ "miden-core",
+ "miden-crypto",
+]
+
+[[package]]
+name = "miden-precompiles-prover"
+version = "0.29.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "467e9fb8d805d8c4621af093a31f0a2465eefd68d63208b49f5663eaf030f89f"
+dependencies = [
+ "miden-ace-codegen",
+ "miden-air",
+ "miden-core",
+ "miden-crypto",
+ "miden-lifted-air",
+ "miden-lifted-stark",
+ "miden-precompiles",
+ "miden-serde-utils",
+ "ruint",
+ "serde",
+ "serde-wincode",
+ "thiserror",
+ "tracing",
+ "wincode",
+]
+
+[[package]]
+name = "miden-processor"
+version = "0.29.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a350061ef4f412639475c5bd8d68ae665ce9fd34ffc768c6082acd3972f791c"
+dependencies = [
+ "hashbrown 0.17.1",
+ "itertools 0.15.0",
  "miden-air",
  "miden-core",
  "miden-debug-types",
+ "miden-mast-package",
+ "miden-precompiles",
  "miden-utils-diagnostics",
  "miden-utils-indexing",
  "paste",
@@ -2082,9 +2911,9 @@ dependencies = [
 
 [[package]]
 name = "miden-project"
-version = "0.23.4"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5320e7e5b562359bd6161ac752dfe43dd4f69bb06e87f94a21a27bb656e5a20d"
+checksum = "dbfb83107a2016867e3650e0b34bb8bc356ab2a039dce1992b808bab73da7385"
 dependencies = [
  "miden-assembly-syntax",
  "miden-core",
@@ -2099,13 +2928,13 @@ dependencies = [
 
 [[package]]
 name = "miden-protocol"
-version = "0.15.3"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66340243e37da5936cb278a8dd11037813f1dc6731c2fc866703b76ed465ebc3"
+checksum = "46b3c270a0fabe3618006176f1b9600e9b5b59a53a8e26ce6afcf65f1b02cb16"
 dependencies = [
  "bech32",
  "fs-err",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "miden-assembly",
  "miden-assembly-syntax",
  "miden-core",
@@ -2113,89 +2942,96 @@ dependencies = [
  "miden-crypto",
  "miden-crypto-derive",
  "miden-mast-package",
+ "miden-package-registry",
  "miden-processor",
+ "miden-protocol-build-utils",
  "miden-utils-sync",
  "miden-verifier",
- "rand 0.9.4",
- "rand_chacha",
+ "rand 0.10.2",
+ "rand_chacha 0.10.0",
  "rand_xoshiro",
  "regex",
  "semver 1.0.28",
  "serde",
  "thiserror",
  "toml",
+]
+
+[[package]]
+name = "miden-protocol-build-utils"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffb3076db13d4b6d12bf01d96ffc3fea400f415fce26467d81081400dcdc59c9"
+dependencies = [
+ "fs-err",
+ "miden-assembly",
+ "miden-core",
+ "miden-mast-package",
+ "miden-package-registry",
+ "miden-project",
+ "regex",
  "walkdir",
 ]
 
 [[package]]
 name = "miden-prover"
-version = "0.23.4"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a91bcc00840b01126cd54e3b68ce3235def2ed48803f2eeb36a035d6951fbc1"
+checksum = "65268275b38d5add4cb2542b2e2f2047047a96d6f7bac3b43678e78e36d51794"
 dependencies = [
- "bincode",
  "miden-air",
  "miden-core",
  "miden-crypto",
+ "miden-precompiles-prover",
  "miden-processor",
  "serde",
+ "serde-wincode",
  "tracing",
 ]
 
 [[package]]
-name = "miden-remote-prover-client"
-version = "0.15.0"
+name = "miden-rowan"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2acdb9494689feeec0f60e3b61901b5eb2362b49b993b4cbc3eb75ad83514dd"
+checksum = "c13695bf99aabaa21d6572b807c66bb26251aa3d9b75e828b3c99b97a3b1ce7e"
 dependencies = [
- "build-rs",
- "fs-err",
- "getrandom 0.4.2",
- "miden-node-proto-build",
- "miden-protocol",
- "miden-tx",
- "miette",
- "prost",
- "thiserror",
- "tokio",
- "tonic",
- "tonic-prost",
- "tonic-prost-build",
- "tonic-web-wasm-client",
+ "hashbrown 0.17.1",
+ "rustc-hash",
 ]
 
 [[package]]
 name = "miden-serde-utils"
-version = "0.25.1"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d78cd1d4fcad937312e544f7d53423485e453598aa4fb989d2b6374027a8c136"
+checksum = "e1f37aa58c6ec69c19ed0edbdba0322c2112356fbbc131a42b5994462a2b794d"
 dependencies = [
  "p3-field",
  "p3-goldilocks",
+ "wincode",
 ]
 
 [[package]]
 name = "miden-standards"
-version = "0.15.3"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7c7146b028e637f4079b5bdefeefc54d7d6e47a805451fa0a18859d19efa2ff"
+checksum = "6be6c71d2114157431f3d5860450b189e902a1fdf3351c8a7d91be8906fd35ce"
 dependencies = [
  "bon",
- "fs-err",
  "miden-assembly",
  "miden-core-lib",
+ "miden-package-registry",
  "miden-protocol",
- "rand 0.9.4",
- "regex",
+ "miden-protocol-build-utils",
+ "primitive-types 0.14.0",
+ "rand 0.10.2",
  "thiserror",
- "walkdir",
 ]
 
 [[package]]
 name = "miden-stark-transcript"
-version = "0.25.1"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05901db2e30d3954243960fe21cea7fbec39f97c27774b56fd5031c28c4881ba"
+checksum = "5b3238f74844f9826a9ee41d39b1d726426fd298a5aba16c34346471d7d184db"
 dependencies = [
  "p3-challenger",
  "p3-field",
@@ -2205,9 +3041,9 @@ dependencies = [
 
 [[package]]
 name = "miden-stateful-hasher"
-version = "0.25.1"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faeb47a90c55c5d45051d23cf691588804dd531995b4582c79108b64e445a905"
+checksum = "88a5545db3e83e041e365c7bb1ba5b8c5953b45a7ad32d698d3b4c30e45727a8"
 dependencies = [
  "p3-field",
  "p3-symmetric",
@@ -2215,12 +3051,12 @@ dependencies = [
 
 [[package]]
 name = "miden-testing"
-version = "0.15.3"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4096fc44a4c88f37405be284e25efdce194d6051e9472ae136ab9249659433c"
+checksum = "dba121f560380c4cf70ba422098feedc512d897f41130163255a7dfd94c9aab3"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.15.0",
  "miden-block-prover",
  "miden-core-lib",
  "miden-crypto",
@@ -2228,41 +3064,45 @@ dependencies = [
  "miden-protocol",
  "miden-standards",
  "miden-tx",
- "miden-tx-batch-prover",
- "rand 0.9.4",
- "rand_chacha",
+ "miden-tx-batch",
+ "rand 0.10.2",
+ "rand_chacha 0.10.0",
  "thiserror",
 ]
 
 [[package]]
 name = "miden-tx"
-version = "0.15.3"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94092b45bc0abc656af25473c9807d1e6cee8e682c58d3b1186f0bd0fb6471fb"
+checksum = "9dcc3e4708af1d15dc13baec1162fd9c1b9663fd4eeac1c2d2f79ef4202d018c"
 dependencies = [
+ "bon",
+ "miden-agglayer",
  "miden-processor",
  "miden-protocol",
  "miden-prover",
  "miden-standards",
+ "thiserror",
+]
+
+[[package]]
+name = "miden-tx-batch"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5db9201b5b56c96dbed1cd5540e7344530a83348fe82e31cabce2b0d963c1dbe"
+dependencies = [
+ "miden-processor",
+ "miden-protocol",
+ "miden-prover",
  "miden-verifier",
  "thiserror",
 ]
 
 [[package]]
-name = "miden-tx-batch-prover"
-version = "0.15.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60add2b40559352661bc86970541f88ffcf98c528f301295f9dc3bf15481b46"
-dependencies = [
- "miden-protocol",
- "miden-tx",
-]
-
-[[package]]
 name = "miden-utils-core-derive"
-version = "0.23.4"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0b1ee4662beb049a824e11bb21f95a79746c52874967983c9999f1b19a2f471"
+checksum = "d0e529fda0dc73e1fdb56d0c29ca92780a4f3d766cf5bf2bc688b95b0f8a8623"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2271,11 +3111,10 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-diagnostics"
-version = "0.23.4"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fdc1cd4eda372e1c4b99b9c3677e9b1f87a4d2e362a9f4b8f904273d395efc9"
+checksum = "197029df3c899525204f4a1f7e5b6e82c69427489b36032ae56fbcf53f9d6b2f"
 dependencies = [
- "miden-crypto",
  "miden-debug-types",
  "miden-miette",
  "tracing",
@@ -2283,11 +3122,11 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-indexing"
-version = "0.23.4"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c31444125649f4dad9cde647f614309b6be4f918fed276ada4eb99c01e8b9ca7"
+checksum = "5b87e9b3f949c27e56dc390d9c9e679f2886e6ea6adfbc7158de7f377c1b6940"
 dependencies = [
- "miden-crypto",
+ "miden-serde-utils",
  "proptest",
  "serde",
  "thiserror",
@@ -2295,9 +3134,9 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-sync"
-version = "0.23.4"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "807c8ae625b7652ae7246b225c907c05da72927c31a0fd71c835c4f80931e92e"
+checksum = "e9e911afc22a03dcf439a0d1d20a67631169a6757100230b257c57e546dd5c3a"
 dependencies = [
  "lock_api",
  "loom",
@@ -2307,24 +3146,26 @@ dependencies = [
 
 [[package]]
 name = "miden-verifier"
-version = "0.23.4"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec5556dac919a1c13edeb2bd7181fc6a4c2ce52764a3e518bcdcd9ed48e5b38e"
+checksum = "6aaf6b63aa6300832a302207f3e93932faae299679e75a0c993de6b1c02f5cde"
 dependencies = [
- "bincode",
  "miden-air",
  "miden-core",
  "miden-crypto",
+ "miden-precompiles",
+ "miden-precompiles-prover",
+ "miden-serde-utils",
  "serde",
+ "serde-wincode",
  "thiserror",
- "tracing",
 ]
 
 [[package]]
 name = "midenc-hir-type"
-version = "0.6.1"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ff0511aa2201f7098995e38a3c97a319d379c3b2d26fb83677b21b71f61a7b4"
+checksum = "f72909a4bae8dca4bbd34c28dcbcdff595afc47e48c312a683108f7452bd270b"
 dependencies = [
  "miden-formatting",
  "miden-serde-utils",
@@ -2361,7 +3202,7 @@ checksum = "db5b29714e950dbb20d5e6f74f9dcec4edbcc1067bb7f8ed198c097b8c1a818b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2375,9 +3216,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
  "wasi",
@@ -2389,21 +3230,6 @@ name = "multimap"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
-
-[[package]]
-name = "nanorand"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
-dependencies = [
- "getrandom 0.2.17",
-]
-
-[[package]]
-name = "new_debug_unreachable"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nu-ansi-term"
@@ -2420,7 +3246,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
 dependencies = [
- "num-bigint",
+ "num-bigint 0.4.8",
  "num-complex",
  "num-integer",
  "num-iter",
@@ -2430,9 +3256,19 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.6"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93e7820bc0a80a0238e650327316f929ba18d5be054b647490a3a6a339f3e7c0"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -2448,32 +3284,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-derive"
-version = "0.4.2"
+name = "num-conv"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
-version = "0.1.46"
+version = "0.1.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+checksum = "7ce2d95d4b3734dc35aa2f45e1aa22cd416814592a4f9d9205e11affd5b8e10b"
 dependencies = [
  "num-traits",
 ]
 
 [[package]]
 name = "num-iter"
-version = "0.1.45"
+version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+checksum = "c92800bd69a1eac91786bcfe9da64a897eb72911b8dc3095decbd07429e8048b"
 dependencies = [
- "autocfg",
  "num-integer",
  "num-traits",
 ]
@@ -2484,7 +3314,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
 dependencies = [
- "num-bigint",
+ "num-bigint 0.4.8",
  "num-integer",
  "num-traits",
 ]
@@ -2535,12 +3365,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
-name = "opaque-debug"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
-
-[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2554,9 +3378,9 @@ checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
 name = "p3-air"
-version = "0.5.3"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c824e8d7c7ddf208b742eac8d48e0b2d52d22fa013578a7762bf6931dbab1f46"
+checksum = "ddb1be05c0d6f691afe0c9f468018a9a37cfa904dee78a8081ec96eb3cdd88e8"
 dependencies = [
  "p3-field",
  "p3-matrix",
@@ -2565,9 +3389,9 @@ dependencies = [
 
 [[package]]
 name = "p3-blake3"
-version = "0.5.3"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2733229a713bd83ccf5eb749e8f8e7380c1052674394a25c0422a772204a20af"
+checksum = "6f202f5fbcceb6f56f783d98efb5de27e5a171470e3364de97b0923b39c87ab5"
 dependencies = [
  "blake3",
  "p3-symmetric",
@@ -2576,9 +3400,9 @@ dependencies = [
 
 [[package]]
 name = "p3-challenger"
-version = "0.5.3"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8972ccd1d5dc90e46cdb1f2ab4ee2bae49b3917e5e98aa533f0c2b779c010445"
+checksum = "84d5d5e1ecf2c80b09b48ce870e8abd08b643454101c5dc9d0fd71bfbd78224d"
 dependencies = [
  "p3-field",
  "p3-maybe-rayon",
@@ -2590,42 +3414,42 @@ dependencies = [
 
 [[package]]
 name = "p3-dft"
-version = "0.5.3"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17771aca44632f9cc11f2718d7ea7ec06794946c4190ef3a985bfc893f14c18a"
+checksum = "4321a952da2721ecd85ca593ea189798dfb4e439a2cc1378ce1442091880f173"
 dependencies = [
- "itertools",
+ "itertools 0.15.0",
  "p3-field",
  "p3-matrix",
  "p3-maybe-rayon",
  "p3-util",
- "spin 0.10.0",
+ "spin 0.12.3",
  "tracing",
 ]
 
 [[package]]
 name = "p3-field"
-version = "0.5.3"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f3eb24d0591fd4d282d89cbe4e4efba5571c699375006f80b2cbf53ce83461c"
+checksum = "53db75d38e04fc255826f388eca9d05976733dc9754aa3db411bc9ea1a37c1a0"
 dependencies = [
- "itertools",
- "num-bigint",
+ "itertools 0.15.0",
+ "num-bigint 0.5.1",
  "p3-maybe-rayon",
  "p3-util",
  "paste",
- "rand 0.10.1",
+ "rand 0.10.2",
  "serde",
  "tracing",
 ]
 
 [[package]]
 name = "p3-goldilocks"
-version = "0.5.3"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5751c6591a0d2397d726620c2c29a7436ec6c5e19d2ed74ca5d078d4fbb18eb5"
+checksum = "d03b3f31080df31be723b876709246f8f1e532e1c5b82efb5281d705c8304c63"
 dependencies = [
- "num-bigint",
+ "num-bigint 0.5.1",
  "p3-challenger",
  "p3-dft",
  "p3-field",
@@ -2635,15 +3459,16 @@ dependencies = [
  "p3-symmetric",
  "p3-util",
  "paste",
- "rand 0.10.1",
+ "rand 0.10.2",
  "serde",
+ "spin 0.12.3",
 ]
 
 [[package]]
 name = "p3-keccak"
-version = "0.5.3"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a7df174ff0c19a8742eb4698eaa1667c5f858d018e2faf09c55f1f24a6f9c3"
+checksum = "ae50c8c37eb847c660298fb275e53c025c49b2623a8cfabf67f5322258b2b4db"
 dependencies = [
  "p3-symmetric",
  "p3-util",
@@ -2652,49 +3477,49 @@ dependencies = [
 
 [[package]]
 name = "p3-matrix"
-version = "0.5.3"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea9c94c0714944e7b8a9a62e6340b1e3e1d3f8ecfd3e35c08798360200e73eff"
+checksum = "473eb920c446a6f4536e0d3528fbdca2a23c0e24e1d0d7767452e6d385dd335c"
 dependencies = [
- "itertools",
+ "itertools 0.15.0",
  "p3-field",
  "p3-maybe-rayon",
  "p3-util",
- "rand 0.10.1",
+ "rand 0.10.2",
  "serde",
  "tracing",
 ]
 
 [[package]]
 name = "p3-maybe-rayon"
-version = "0.5.3"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eebc233a34b1ab0273f35b4052fa2eeb3114b22ba4575bd7da00716e878ffb77"
+checksum = "e6fddfd435f96394769414cf5590b77058aa506659bf20d6592e9d1989e04440"
 dependencies = [
  "rayon",
 ]
 
 [[package]]
 name = "p3-mds"
-version = "0.5.3"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b5441fa8116246ec9e6c835f15273cb27777ca572960ec87476b67fef13e01e"
+checksum = "551ba0ab2cccd89f85a99450224898aff224e323bbf61f777ba6344f0896ef10"
 dependencies = [
  "p3-dft",
  "p3-field",
  "p3-symmetric",
  "p3-util",
- "rand 0.10.1",
+ "rand 0.10.2",
 ]
 
 [[package]]
 name = "p3-monty-31"
-version = "0.5.3"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8724f330ea6d19dd4f2436aa0f88b5fcbf88f0f55ca7fccd3fea8b736dbcddad"
+checksum = "871f635f7340cd0868b17e43e0c98fefdafdaed90469d0725caf6d8372a2a47c"
 dependencies = [
- "itertools",
- "num-bigint",
+ "itertools 0.15.0",
+ "num-bigint 0.5.1",
  "p3-dft",
  "p3-field",
  "p3-matrix",
@@ -2705,43 +3530,44 @@ dependencies = [
  "p3-symmetric",
  "p3-util",
  "paste",
- "rand 0.10.1",
+ "rand 0.10.2",
  "serde",
- "spin 0.10.0",
+ "spin 0.12.3",
  "tracing",
 ]
 
 [[package]]
 name = "p3-poseidon1"
-version = "0.5.3"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04e2a562fea210baae390a32f9ecf0dd8724ae3f4352d1c8e413077b6f00a162"
+checksum = "8d0d304e9a1f29c0d66534aa84e69528e2118351fdce08dcf5898af4e0fecc32"
 dependencies = [
  "p3-field",
+ "p3-mds",
  "p3-symmetric",
- "rand 0.10.1",
+ "rand 0.10.2",
 ]
 
 [[package]]
 name = "p3-poseidon2"
-version = "0.5.3"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06394851c161d17e4aa4ad2aad5557d32f14cadd1dc838f965d8e1821a63b8c5"
+checksum = "43eb8a73a26d14becaed1c67c3e8a047e4311d7909b402383c82ca9643ba17c6"
 dependencies = [
  "p3-field",
  "p3-mds",
  "p3-symmetric",
  "p3-util",
- "rand 0.10.1",
+ "rand 0.10.2",
 ]
 
 [[package]]
 name = "p3-symmetric"
-version = "0.5.3"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ac1a276d421f8ef3361bb7d8c39a02c93c6b3f10eeaa559cc4c50222f9a5b82"
+checksum = "2015ea80cad969b6aabf27a04884286fe1354393b166d968ee0d80a95126b2a4"
 dependencies = [
- "itertools",
+ "itertools 0.15.0",
  "p3-field",
  "p3-util",
  "serde",
@@ -2749,13 +3575,40 @@ dependencies = [
 
 [[package]]
 name = "p3-util"
-version = "0.5.3"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d08a58162a4c264269ef454f0b28dcda89939490eecacb2b2cf5b00f719b80f6"
+checksum = "6c5466fc40e6df89d3b291a2eff16b33e68e8571207790370137ec18090aadab"
 dependencies = [
  "rayon",
  "serde",
- "transpose",
+]
+
+[[package]]
+name = "parity-scale-codec"
+version = "3.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799781ae679d79a948e13d4824a40970bfa500058d245760dd857301059810fa"
+dependencies = [
+ "arrayvec",
+ "bitvec",
+ "byte-slice-cast",
+ "const_format",
+ "impl-trait-for-tuples",
+ "parity-scale-codec-derive",
+ "rustversion",
+ "serde",
+]
+
+[[package]]
+name = "parity-scale-codec-derive"
+version = "3.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34b4653168b563151153c9e4c08ebed57fb8262bebfa79711552fa983c623e7a"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2788,19 +3641,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pastey"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
-name = "petgraph"
-version = "0.7.1"
+name = "pest"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
+checksum = "5a07a60cc7a4d00c91f95c685609d1d2f79050e6804b70ebedd7650f0b839bcf"
 dependencies = [
- "fixedbitset",
- "indexmap",
+ "memchr",
+ "ucd-trie",
 ]
 
 [[package]]
@@ -2811,36 +3670,27 @@ checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
 dependencies = [
  "fixedbitset",
  "hashbrown 0.15.5",
- "indexmap",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
-dependencies = [
- "siphasher",
+ "indexmap 2.14.0",
 ]
 
 [[package]]
 name = "pin-project"
-version = "1.1.11"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.11"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2851,9 +3701,9 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkcs8"
-version = "0.10.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+checksum = "451913da69c775a56034ea8d9003d27ee8948e12443eae7c038ba100a4f21cb7"
 dependencies = [
  "der",
  "spki",
@@ -2861,26 +3711,25 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
 
 [[package]]
 name = "poly1305"
-version = "0.8.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+checksum = "6e2d0073b297041425c7c3df6eb4792d598a15323fe63346852b092eca02904c"
 dependencies = [
- "cpufeatures 0.2.17",
- "opaque-debug",
+ "cpufeatures 0.3.0",
  "universal-hash",
 ]
 
 [[package]]
 name = "portable-atomic"
-version = "1.13.1"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
 
 [[package]]
 name = "portable-atomic-util"
@@ -2892,6 +3741,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "potential_utf"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d83eb9bc6d8e5cf568e7a1101d60ee05e81ed50ea106026f3d18deeb046d7661"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2901,19 +3765,50 @@ dependencies = [
 ]
 
 [[package]]
-name = "precomputed-hash"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
-
-[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.117",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "primefield"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c555a6e4eb7d4e158fcb028c835c3b8642206ddc279b5c6b202ef9a8bdb592f4"
+dependencies = [
+ "crypto-bigint",
+ "crypto-common 0.2.2",
+ "ff",
+ "rand_core 0.10.1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c9f42978c78a00e3d68f69fc03e57a234debae69da4020a4fb588fcdcd07b06"
+dependencies = [
+ "elliptic-curve",
+ "primefield",
+ "serdect",
+ "wnaf",
+]
+
+[[package]]
+name = "primitive-types"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b34d9fd68ae0b74a41b21c03c2f62847aa0ffea044eee893b4c140b37e244e2"
+dependencies = [
+ "fixed-hash",
+ "impl-codec",
+ "uint 0.9.5",
 ]
 
 [[package]]
@@ -2923,7 +3818,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "721a1da530b5a2633218dc9f75713394c983c352be88d2d7c9ee85e2c4c21794"
 dependencies = [
  "fixed-hash",
- "uint",
+ "uint 0.10.1",
 ]
 
 [[package]]
@@ -2933,37 +3828,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93980406f12d9f8140ed5abe7155acb10bb1e69ea55c88960b9c2f117445ef96"
 dependencies = [
  "equivalent",
- "indexmap",
+ "indexmap 2.14.0",
  "serde",
 ]
 
 [[package]]
-name = "proc-macro-error-attr2"
-version = "2.0.0"
+name = "proc-macro-crate"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit",
+]
+
+[[package]]
+name = "proc-macro-error-attr3"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82366fd7d8b7a440d66d13418820c69df9b3908bcb1a0476d7f5ce5d12f5a04d"
 dependencies = [
  "proc-macro2",
  "quote",
 ]
 
 [[package]]
-name = "proc-macro-error2"
-version = "2.0.1"
+name = "proc-macro-error3"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+checksum = "b511283ea8a74b4b39447b128c5d00f03a356b7424554b13e298a5550100d9ac"
 dependencies = [
- "proc-macro-error-attr2",
+ "proc-macro-error-attr3",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
@@ -2974,10 +3878,10 @@ version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "num-traits",
- "rand 0.9.4",
- "rand_chacha",
+ "rand 0.9.5",
+ "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",
  "unarray",
@@ -2991,14 +3895,14 @@ checksum = "fb6dc647500e84a25a85b100e76c85b8ace114c209432dc174f20aac11d4ed6c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "prost"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
+checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -3006,45 +3910,45 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
+checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
  "heck",
- "itertools",
+ "itertools 0.14.0",
  "log",
  "multimap",
- "petgraph 0.8.3",
+ "petgraph",
  "prettyplease",
  "prost",
  "prost-types",
  "pulldown-cmark",
  "pulldown-cmark-to-cmark",
  "regex",
- "syn 2.0.117",
+ "syn 2.0.119",
  "tempfile",
 ]
 
 [[package]]
 name = "prost-derive"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
+checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "prost-reflect"
-version = "0.16.3"
+version = "0.16.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b89455ef41ed200cafc47c76c552ee7792370ac420497e551f16123a9135f76e"
+checksum = "01b80ea363c31af2de2b92e3c07ed1156628f7838c4afb4df75ee78a37fedbd1"
 dependencies = [
- "logos",
+ "logos 0.16.1",
  "miette",
  "prost",
  "prost-types",
@@ -3052,9 +3956,9 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
+checksum = "f94967dc7688f3054c7fac87473ffae4cc4c3904800e2d9f5b857246d8963b0a"
 dependencies = [
  "prost",
 ]
@@ -3080,7 +3984,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "072eee358134396a4643dff81cfff1c255c9fbd3fb296be14bdb6a26f9156366"
 dependencies = [
- "logos",
+ "logos 0.15.1",
  "miette",
  "prost-types",
  "thiserror",
@@ -3092,7 +3996,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f5df7e552bc7edd075f5783a87fbfc21d6a546e32c16985679c488c18192d83"
 dependencies = [
- "indexmap",
+ "indexmap 2.14.0",
  "log",
  "priority-queue",
  "rustc-hash",
@@ -3102,29 +4006,85 @@ dependencies = [
 
 [[package]]
 name = "pulldown-cmark"
-version = "0.13.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c3a14896dfa883796f1cb410461aef38810ea05f2b2c33c5aded3649095fdad"
+checksum = "e9f068eba8e7071c5f9511831b44f32c740d5adf574e990f946ddb53db2f314e"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "memchr",
  "unicase",
 ]
 
 [[package]]
 name = "pulldown-cmark-to-cmark"
-version = "22.0.0"
+version = "22.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50793def1b900256624a709439404384204a5dc3a6ec580281bfaac35e882e90"
+checksum = "ab1ad36992cead65f02aa399a373a42730922f1525d988172634fdefdecb8a60"
 dependencies = [
  "pulldown-cmark",
 ]
 
 [[package]]
-name = "quote"
-version = "1.0.45"
+name = "quinn"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04759210543be93709136e28212294a659ef5001836ff4eab4d663e4529bba83"
+dependencies = [
+ "bytes",
+ "getrandom 0.4.3",
+ "lru-slab",
+ "rand 0.10.2",
+ "rand_pcg",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
@@ -3142,31 +4102,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
-name = "rand"
-version = "0.8.6"
+name = "radium"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
+name = "rand"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
  "rand_core 0.6.4",
 ]
 
 [[package]]
 name = "rand"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
- "rand_chacha",
+ "rand_chacha 0.9.0",
  "rand_core 0.9.5",
 ]
 
 [[package]]
 name = "rand"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
+ "chacha20",
+ "getrandom 0.4.3",
  "rand_core 0.10.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -3177,6 +4157,16 @@ checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e6af7f3e25ded52c41df4e0b1af2d047e45896c2f3281792ed68a1c243daedb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -3204,12 +4194,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
-name = "rand_hc"
-version = "0.3.2"
+name = "rand_pcg"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b363d4f6370f88d62bf586c80405657bde0f0e1b8945d47d2ad59b906cb4f54"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
 dependencies = [
- "rand_core 0.6.4",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -3223,11 +4213,11 @@ dependencies = [
 
 [[package]]
 name = "rand_xoshiro"
-version = "0.7.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
+checksum = "662effc7698e08ea324d3acccf8d9d7f7bf79b9785e270a174ea36e56900c91d"
 dependencies = [
- "rand_core 0.9.5",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -3256,14 +4246,34 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e440fb4e4b4147295338efb76001ab9e4efc0e5839df2c47fc5ac2381d365c3"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92ecd8964f8453721699a1ed72037b0db49ce2f5a5138486ee89bed6f67cdf3a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3273,9 +4283,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3284,18 +4294,56 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
+
+[[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
 
 [[package]]
 name = "rfc6979"
-version = "0.4.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+checksum = "b4a459cddafb3fe76b31fd8f1108007566c40301feb64dc7b54656eb7388172b"
 dependencies = [
+ "crypto-bigint",
  "hmac",
- "subtle",
 ]
 
 [[package]]
@@ -3313,14 +4361,38 @@ dependencies = [
 ]
 
 [[package]]
-name = "ruint"
-version = "1.17.2"
+name = "rlp"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c141e807189ad38a07276942c6623032d3753c8859c146104ac2e4d68865945a"
+checksum = "bb919243f34364b6bd2fc10ef797edbfa75f33c252e7998527479c6d6b47e1ec"
 dependencies = [
+ "bytes",
+ "rustc-hex",
+]
+
+[[package]]
+name = "ruint"
+version = "1.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5e99bff0393163bb25029a6af25d3d8d202ba5b5438a74d1bd8789f5c822970"
+dependencies = [
+ "alloy-rlp",
+ "ark-ff 0.3.0",
+ "ark-ff 0.4.2",
+ "ark-ff 0.5.0",
+ "ark-ff 0.6.0",
+ "bytes",
+ "fastrlp 0.3.1",
+ "fastrlp 0.4.0",
+ "num-bigint 0.4.8",
+ "num-integer",
+ "num-traits",
+ "parity-scale-codec",
+ "primitive-types 0.12.2",
  "proptest",
- "rand 0.8.6",
- "rand 0.9.4",
+ "rand 0.8.7",
+ "rand 0.9.5",
+ "rlp",
  "ruint-macro",
  "serde_core",
  "valuable",
@@ -3339,7 +4411,7 @@ version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "165ca6e57b20e1351573e3729b958bc62f0e48025386970b6e4d29e7a7e71f3f"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",
@@ -3361,24 +4433,34 @@ dependencies = [
 name = "rust-client"
 version = "0.1.0"
 dependencies = [
+ "hex",
  "miden-client",
  "miden-client-sqlite-store",
  "miden-protocol",
- "rand 0.9.4",
+ "rand 0.10.2",
+ "reqwest",
+ "serde",
+ "sha2 0.10.9",
  "tokio",
 ]
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
+checksum = "b74b56ffa8bb2830709a538c2cbcae9aa062db0d2a42563bfb09bdaae44020eb"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
+
+[[package]]
+name = "rustc-hex"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
 
 [[package]]
 name = "rustc_version"
@@ -3387,6 +4469,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 dependencies = [
  "semver 0.9.0",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
+dependencies = [
+ "semver 0.11.0",
 ]
 
 [[package]]
@@ -3404,7 +4495,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -3413,9 +4504,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.38"
+version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
  "log",
  "once_cell",
@@ -3428,9 +4519,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
 dependencies = [
  "openssl-probe",
  "rustls-pki-types",
@@ -3440,18 +4531,19 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "0527518605e68109d875e248ea259b6758801cf165e4b2c2733ae3b51f12535a"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -3460,9 +4552,15 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"
@@ -3483,6 +4581,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "687274d293b6cdc6e73e0fee520bf2049650090d7164f87672d212a3c530cf4a"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "scoped-tls"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3496,14 +4618,14 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sec1"
-version = "0.7.3"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+checksum = "d56d437c2f19203ce5f7122e507831de96f3d2d4d3be5af44a0b0a09d8a80e4d"
 dependencies = [
  "base16ct",
+ "ctutils",
  "der",
- "generic-array",
- "pkcs8",
+ "hybrid-array",
  "subtle",
  "zeroize",
 ]
@@ -3514,7 +4636,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -3537,7 +4659,16 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 dependencies = [
- "semver-parser",
+ "semver-parser 0.7.0",
+]
+
+[[package]]
+name = "semver"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
+dependencies = [
+ "semver-parser 0.10.3",
 ]
 
 [[package]]
@@ -3557,10 +4688,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
-name = "serde"
-version = "1.0.228"
+name = "semver-parser"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "9900206b54a3527fdc7b8a938bffd94a568bac4f4aa8113b209df75a09c0dec2"
+dependencies = [
+ "pest",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -3579,30 +4719,41 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_core"
-version = "1.0.228"
+name = "serde-wincode"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "9aa9d3a86c66cf10ce79df36f555a5a4c8d72a82515d9ea8ca420e02c925c30f"
+dependencies = [
+ "serde",
+ "thiserror",
+ "wincode",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",
@@ -3613,13 +4764,13 @@ dependencies = [
 
 [[package]]
 name = "serde_repr"
-version = "0.1.20"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+checksum = "8d3b1629de253c70a0508c3899572da79ca359fdab27c7920ff00406df418906"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -3632,6 +4783,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_with"
+version = "3.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee78f1fbe43ac4a0e47aadb3dbd357b69eb0d3793e948624cd03dd2750ab1c0a"
+dependencies = [
+ "base64",
+ "bs58",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.14.0",
+ "jiff",
+ "schemars 0.9.0",
+ "schemars 1.2.2",
+ "serde_core",
+ "serde_json",
+ "time",
+]
+
+[[package]]
+name = "serdect"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66cf8fedced2fcf12406bcb34223dffb92eaf34908ede12fed414c82b7f00b3e"
+dependencies = [
+ "base16ct",
+ "serde",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3639,17 +4832,39 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
 name = "sha3"
-version = "0.10.9"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77fd7028345d415a4034cf8777cd4f8ab1851274233b45f84e3d955502d93874"
+checksum = "be176f1a57ce4e3d31c1a166222d9768de5954f811601fb7ca06fc8203905ce1"
 dependencies = [
- "digest",
+ "digest 0.11.3",
  "keccak",
+]
+
+[[package]]
+name = "sha3"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc9bad02c26382724b2d2692c6f179285e4b54eeecd7968f52a50059c3c11759"
+dependencies = [
+ "digest 0.11.3",
+ "keccak",
+ "sponge-cursor",
 ]
 
 [[package]]
@@ -3663,25 +4878,19 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signature"
-version = "2.2.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+checksum = "28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5"
 dependencies = [
- "digest",
- "rand_core 0.6.4",
+ "digest 0.11.3",
+ "rand_core 0.10.1",
 ]
-
-[[package]]
-name = "siphasher"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "slab"
@@ -3691,24 +4900,24 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "smawk"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
+checksum = "e8e2fb0f499abb4d162f2bedad68f5ef91a1682b5a03596ddb67efd37768d100"
 
 [[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -3716,55 +4925,49 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 dependencies = [
  "lock_api",
 ]
 
 [[package]]
 name = "spin"
-version = "0.10.0"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
+checksum = "0134f9043ed38b087ac4f7d4af44c79e2c9e5094421fe3164f435ce585953b10"
 dependencies = [
  "lock_api",
 ]
 
 [[package]]
 name = "spki"
-version = "0.7.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+checksum = "1d9efca8738c78ee9484207732f728b1ef517bbb1833d6fc0879ca898a522f6f"
 dependencies = [
  "base64ct",
  "der",
 ]
 
 [[package]]
+name = "sponge-cursor"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a0219bd7d979d58245a4f41f695e1ac9f8befdffadd7f61f1bae9e39abc6620"
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
-name = "strength_reduce"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
-
-[[package]]
-name = "string_cache"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
-dependencies = [
- "new_debug_unreachable",
- "parking_lot",
- "phf_shared",
- "precomputed-hash",
-]
 
 [[package]]
 name = "strip-ansi-escapes"
@@ -3821,9 +5024,20 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3832,14 +5046,14 @@ dependencies = [
 
 [[package]]
 name = "syn-solidity"
-version = "1.5.7"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53f425ae0b12e2f5ae65542e00898d500d4d318b4baf09f40fd0d410454e9947"
+checksum = "083be3061e64d362cbe6ef12cfe1307ba3884326d8856448fe8a120fa2c44ebf"
 dependencies = [
  "paste",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3847,12 +5061,32 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "target-triple"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "591ef38edfb78ca4771ee32cf494cb8771944bee237a9b91fc9c1424ac4b777b"
+checksum = "c3a6bfce3d99adfa72d24750a61f782f3036a81e7f86d8841ee1326deaebd171"
 
 [[package]]
 name = "tempfile"
@@ -3861,18 +5095,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "term"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8c27177b12a6399ffc08b98f76f7c9a1f4fe9fc967c784c5a071fa8d93cf7e1"
-dependencies = [
  "windows-sys 0.61.2",
 ]
 
@@ -3908,31 +5133,61 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "thread_local"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "time"
+version = "0.3.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
+
+[[package]]
+name = "time-macros"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]
@@ -3945,10 +5200,35 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio"
-version = "1.52.1"
+name = "tinystr"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
+checksum = "b1e27c91459209c2986af3dcf603a5a74a4368754ce37414f59acc971167f643"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tokio"
+version = "1.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",
@@ -3961,13 +5241,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.7.0"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -3982,9 +5262,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+checksum = "a3d06f0b082ba57c26b79407372e57cf2a1e28124f78e9479fe80322cf53420b"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -3994,24 +5274,25 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "libc",
  "pin-project-lite",
  "tokio",
 ]
 
 [[package]]
 name = "toml"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.4+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
 dependencies = [
- "indexmap",
+ "indexmap 2.14.0",
  "serde_core",
  "serde_spanned",
  "toml_datetime",
@@ -4030,25 +5311,37 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml_parser"
-version = "1.1.2+spec-1.1.0"
+name = "toml_edit"
+version = "0.25.13+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
+dependencies = [
+ "indexmap 2.14.0",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.3+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
  "winnow",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.1.1+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "tonic"
-version = "0.14.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
+checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
 dependencies = [
  "async-trait",
  "base64",
@@ -4076,21 +5369,21 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
-version = "0.14.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1882ac3bf5ef12877d7ed57aad87e75154c11931c2ba7e6cde5e22d63522c734"
+checksum = "c68f61875ac5293cf72e6c8cf0158086428c82c37229e98c840878f1706b0322"
 dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "tonic-health"
-version = "0.14.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4ff0636fef47afb3ec02818f5bceb4377b8abb9d6a386aeade18bd6212f8eb7"
+checksum = "fcfab99db777fba2802f0dfa861d1628d1ae916fb199d29819941f139ae85082"
 dependencies = [
  "prost",
  "tokio",
@@ -4101,9 +5394,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-prost"
-version = "0.14.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a55376a0bbaa4975a3f10d009ad763d8f4108f067c7c2e74f3001fb49778d309"
+checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
 dependencies = [
  "bytes",
  "prost",
@@ -4112,16 +5405,16 @@ dependencies = [
 
 [[package]]
 name = "tonic-prost-build"
-version = "0.14.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3144df636917574672e93d0f56d7edec49f90305749c668df5101751bb8f95a"
+checksum = "654e5643eff75d7f8c99197ce1440ed19a3474eada74c12bbac488b2cafdae27"
 dependencies = [
  "prettyplease",
  "proc-macro2",
  "prost-build",
  "prost-types",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
  "tempfile",
  "tonic-build",
 ]
@@ -4159,7 +5452,7 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap",
+ "indexmap 2.14.0",
  "pin-project-lite",
  "slab",
  "sync_wrapper",
@@ -4168,6 +5461,24 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
+dependencies = [
+ "bitflags 2.13.1",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "url",
 ]
 
 [[package]]
@@ -4201,7 +5512,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4244,16 +5555,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "transpose"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ad61aed86bc3faea4300c7aee358b4c6d0c8d6ccc36524c96e4c92ccf26e77e"
-dependencies = [
- "num-integer",
- "strength_reduce",
-]
-
-[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4261,9 +5562,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "trybuild"
-version = "1.0.116"
+version = "1.0.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47c635f0191bd3a2941013e5062667100969f8c4e9cd787c14f977265d73616e"
+checksum = "1e605bf6b39357663d8ba4e984f8be8da8df6bb32e81031d6889024ea8fd68e4"
 dependencies = [
  "dissimilar",
  "glob",
@@ -4283,15 +5584,33 @@ checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"
-version = "1.20.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "uint"
-version = "0.10.0"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "909988d098b2f738727b161a106cfc7cab00c539c2687a8836f8e565976fb53e"
+checksum = "76f64bba2c53b04fcab63c01a7d7427eadc821e3bc48c34dc9ba29c501164b52"
+dependencies = [
+ "byteorder",
+ "crunchy",
+ "hex",
+ "static_assertions",
+]
+
+[[package]]
+name = "uint"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f9227a75a5a540a464c832ad4a4195dbdbecd8787610a56262721fde6f04f90"
 dependencies = [
  "byteorder",
  "crunchy",
@@ -4325,9 +5644,9 @@ checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.13.2"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-width"
@@ -4349,12 +5668,12 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "universal-hash"
-version = "0.5.1"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+checksum = "f4987bdc12753382e0bec4a65c50738ffaabc998b9cdd1f952fb5f39b0048a96"
 dependencies = [
- "crypto-common",
- "subtle",
+ "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -4364,6 +5683,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4371,11 +5708,11 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.1"
+version = "1.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+checksum = "2cefc03fd367c0c6d4305de1b312cf00248c4114f4a0418ce6a6af769e3b0bd9"
 dependencies = [
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "js-sys",
  "serde_core",
  "wasm-bindgen",
@@ -4444,27 +5781,18 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.3+wasi-0.2.9"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
- "wit-bindgen 0.57.1",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen 0.51.0",
+ "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.118"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4475,9 +5803,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.68"
+version = "0.4.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
+checksum = "6b7777d5cc23d0e91404e53ce2d5e8ec7acae3026b16233dba62cd3246457950"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4485,9 +5813,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.118"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4495,46 +5823,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.118"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.118"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap",
- "wasm-encoder",
- "wasmparser",
 ]
 
 [[package]]
@@ -4551,25 +5857,32 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags",
- "hashbrown 0.15.5",
- "indexmap",
- "semver 1.0.28",
-]
-
-[[package]]
 name = "web-sys"
-version = "0.3.95"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+checksum = "c435338968042f4f59a557f690a253676d47ce13ceb55d70100e7facf6620a30"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -4579,6 +5892,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "wincode"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfc6339f1ba427bf7ad7c42403b28e524832ba2ddb5eef1bb2cc3b85db6b7b75"
+dependencies = [
+ "pastey",
+ "proc-macro2",
+ "quote",
+ "thiserror",
 ]
 
 [[package]]
@@ -4602,7 +5927,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4613,7 +5938,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4724,17 +6049,11 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "1.0.1"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
-
-[[package]]
-name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 dependencies = [
- "wit-bindgen-rust-macro",
+ "memchr",
 ]
 
 [[package]]
@@ -4744,122 +6063,160 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
+name = "wnaf"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+checksum = "ab12e7090f27e2ffd9322651492942d50c2926094af30601e1964337db39daf1"
 dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
+ "ff",
+ "group",
+ "hybrid-array",
 ]
 
 [[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
+name = "writeable"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap",
- "prettyplease",
- "syn 2.0.117",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
+checksum = "3ad82d2a33cdc9674dc7465672f271e096168fcdbe0f799d9e6db8c5892679dc"
 
 [[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
+name = "wyz"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver 1.0.28",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
+ "tap",
 ]
 
 [[package]]
 name = "x25519-dalek"
-version = "2.0.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
+checksum = "e7e8131a03190127fb2263afc72b322ecadae46b6ff8c6f399ff5d02f5559af6"
 dependencies = [
  "curve25519-dalek",
- "rand_core 0.6.4",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "yoke"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "synstructure",
 ]
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ea269c3bd32f0a32c321907a2ae912ba6f4649bb0fc764a15627e99a7095a3f"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0464e17806c1d976d5cba29399c7f08e516e279e2ba493f63123b5fca67dd8"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34df6fc39dbd26ddc9c10e6a2984476e13acce22e64e4487636ef494369225da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
 
 [[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/rust-client/Cargo.toml
+++ b/rust-client/Cargo.toml
@@ -4,8 +4,16 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-miden-client = { version = "0.15", features = ["testing", "tonic"] }
-miden-client-sqlite-store = { version = "0.15", package = "miden-client-sqlite-store" }
-miden-protocol = { version = "0.15" }
-rand = { version = "0.9" }
+hex = "0.4"
+miden-client = { version = "=0.16.0", features = ["testing", "tonic"] }
+miden-client-sqlite-store = { version = "=0.16.0", package = "miden-client-sqlite-store" }
+miden-protocol = { version = "=0.16.0" }
+rand = { version = "0.10" }
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+serde = { version = "1", features = ["derive"] }
+sha2 = "0.10"
 tokio = { version = "1.48", features = ["rt-multi-thread", "net", "macros", "fs"] }
+
+# Local proving in an unoptimized build can outlive the network's historical-state window.
+[profile.dev]
+opt-level = 2

--- a/rust-client/src/bin/counter_contract_deploy.rs
+++ b/rust-client/src/bin/counter_contract_deploy.rs
@@ -1,27 +1,31 @@
-use rand::RngCore;
+use rand::Rng;
+use rust_client::TutorialClientExt;
 use std::{path::PathBuf, sync::Arc};
 
 use miden_client::{
     account::{
-        component::AccountComponentMetadata, AccountBuilder, AccountComponent,
-        AccountType, StorageSlot, StorageSlotName,
+        component::{AccountComponentMetadata, BasicWallet},
+        AccountBuilder, AccountComponent, AccountType, StorageSlot, StorageSlotName,
     },
-    address::NetworkId,
     auth::NoAuth,
     builder::ClientBuilder,
     keystore::FilesystemKeyStore,
-    rpc::{Endpoint, GrpcClient},
+    rpc::{GrpcClient, VerifyingRpcClient},
     transaction::TransactionRequestBuilder,
     ClientError, Word,
 };
 use miden_client_sqlite_store::ClientBuilderSqliteExt;
+use rust_client::{fund_account_for_fees, FeeConfig, TutorialNetwork};
 
 #[tokio::main]
 async fn main() -> Result<(), ClientError> {
     // Initialize client
-    let endpoint = Endpoint::testnet();
+    let network = TutorialNetwork::from_env()?;
+    let endpoint = network.endpoint();
     let timeout_ms = 10_000;
-    let rpc_client = Arc::new(GrpcClient::new(&endpoint, timeout_ms));
+    let rpc_client = Arc::new(VerifyingRpcClient::new(GrpcClient::new(
+        &endpoint, timeout_ms,
+    )));
 
     // Initialize keystore
     let keystore_path = PathBuf::from("./keystore");
@@ -33,12 +37,12 @@ async fn main() -> Result<(), ClientError> {
         .rpc(rpc_client)
         .sqlite_store(store_path)
         .authenticator(keystore.clone())
-        .in_debug_mode(true.into())
         .build()
         .await?;
 
     let sync_summary = client.sync_state().await.unwrap();
     println!("Latest block: {}", sync_summary.block_num);
+    let fee_config = FeeConfig::from_client(&client, network).await?;
 
     // -------------------------------------------------------------------------
     // STEP 1: Create a basic counter contract
@@ -75,7 +79,8 @@ async fn main() -> Result<(), ClientError> {
     let counter_contract = AccountBuilder::new(seed)
         .account_type(AccountType::Public)
         .with_component(counter_component.clone())
-        .with_auth_component(NoAuth)
+        .with_component(BasicWallet)
+        .with_component(NoAuth)
         .build()
         .unwrap();
 
@@ -87,6 +92,7 @@ async fn main() -> Result<(), ClientError> {
     println!("counter_contract storage: {:?}", counter_contract.storage());
 
     client.add_account(&counter_contract, false).await.unwrap();
+    fund_account_for_fees(&mut client, counter_contract.id(), &fee_config).await?;
 
     // -------------------------------------------------------------------------
     // STEP 2: Call the Counter Contract with a script
@@ -113,18 +119,19 @@ async fn main() -> Result<(), ClientError> {
 
     // Execute and submit the transaction
     let tx_id = client
-        .submit_new_transaction(counter_contract.id(), tx_increment_request)
+        .submit_tutorial_transaction(counter_contract.id(), tx_increment_request)
         .await
         .unwrap();
 
     println!(
-        "View transaction on MidenScan: https://testnet.midenscan.com/tx/{:?}",
+        "View transaction on MidenScan: {}/tx/{:?}",
+        network.explorer_url(),
         tx_id
     );
 
     println!(
         "Counter contract id: {:?}",
-        counter_contract.id().to_bech32(NetworkId::Testnet)
+        counter_contract.id().to_bech32(network.network_id())
     );
 
     client.sync_state().await.unwrap();
@@ -138,6 +145,11 @@ async fn main() -> Result<(), ClientError> {
     println!(
         "counter contract storage: {:?}",
         account.storage().get_item(&counter_slot_name)
+    );
+    assert_eq!(
+        account.storage().get_item(&counter_slot_name).unwrap()[0].as_canonical_u64(),
+        1,
+        "the deployed counter must increment from zero to one",
     );
 
     Ok(())

--- a/rust-client/src/bin/counter_contract_fpi.rs
+++ b/rust-client/src/bin/counter_contract_fpi.rs
@@ -1,27 +1,32 @@
-use rand::RngCore;
+use rand::Rng;
+use rust_client::TutorialClientExt;
 use std::{path::PathBuf, sync::Arc, time::Duration};
 use tokio::time::sleep;
 
 use miden_client::{
     account::{
-        component::AccountComponentMetadata, AccountBuilder, AccountComponent, AccountId,
-        AccountType, StorageSlot, StorageSlotName,
+        component::{AccountComponentMetadata, BasicWallet},
+        AccountBuilder, AccountComponent, AccountId, AccountType, StorageSlot, StorageSlotName,
     },
     auth::NoAuth,
     builder::ClientBuilder,
     keystore::FilesystemKeyStore,
-    rpc::{domain::account::AccountStorageRequirements, Endpoint, GrpcClient},
+    rpc::{domain::account::AccountStorageRequirements, GrpcClient, VerifyingRpcClient},
     transaction::{ForeignAccount, TransactionRequestBuilder},
     ClientError, Word,
 };
 use miden_client_sqlite_store::ClientBuilderSqliteExt;
+use rust_client::{fund_account_for_fees, FeeConfig, TutorialNetwork};
 
 #[tokio::main]
 async fn main() -> Result<(), ClientError> {
     // Initialize client
-    let endpoint = Endpoint::testnet();
+    let network = TutorialNetwork::from_env()?;
+    let endpoint = network.endpoint();
     let timeout_ms = 10_000;
-    let rpc_client = Arc::new(GrpcClient::new(&endpoint, timeout_ms));
+    let rpc_client = Arc::new(VerifyingRpcClient::new(GrpcClient::new(
+        &endpoint, timeout_ms,
+    )));
 
     // Initialize keystore
     let keystore_path = PathBuf::from("./keystore");
@@ -33,12 +38,12 @@ async fn main() -> Result<(), ClientError> {
         .rpc(rpc_client)
         .sqlite_store(store_path)
         .authenticator(keystore.clone())
-        .in_debug_mode(true.into())
         .build()
         .await?;
 
     let sync_summary = client.sync_state().await.unwrap();
     println!("Latest block: {}", sync_summary.block_num);
+    let fee_config = FeeConfig::from_client(&client, network).await?;
 
     // -------------------------------------------------------------------------
     // STEP 1: Create the Count Reader Contract
@@ -74,7 +79,8 @@ async fn main() -> Result<(), ClientError> {
     let count_reader_contract = AccountBuilder::new(init_seed)
         .account_type(AccountType::Public)
         .with_component(count_reader_component.clone())
-        .with_auth_component(NoAuth)
+        .with_component(BasicWallet)
+        .with_component(NoAuth)
         .build()
         .unwrap();
 
@@ -88,15 +94,26 @@ async fn main() -> Result<(), ClientError> {
         .add_account(&count_reader_contract, false)
         .await
         .unwrap();
+    fund_account_for_fees(&mut client, count_reader_contract.id(), &fee_config).await?;
 
     // -------------------------------------------------------------------------
     // STEP 2: Build & Get State of the Counter Contract
     // -------------------------------------------------------------------------
     println!("\n[STEP 2] Building counter contract from public state");
 
-    // Define the Counter Contract account id from counter contract deploy
-    let (_, counter_contract_id) =
-        AccountId::from_bech32("mtst1apcqs7aj3a2cf5t6pnsfy0p4ns7wl7sp").unwrap();
+    // Pass the account ID printed by `counter_contract_deploy` as the first argument, or via
+    // `MIDEN_COUNTER_ACCOUNT_ID`.
+    let counter_contract_bech32 = std::env::args()
+        .nth(1)
+        .or_else(|| std::env::var("MIDEN_COUNTER_ACCOUNT_ID").ok())
+        .expect("pass the counter account ID from counter_contract_deploy");
+    let (account_network, counter_contract_id) =
+        AccountId::from_bech32(&counter_contract_bech32).expect("invalid counter account ID");
+    assert_eq!(
+        account_network,
+        network.network_id(),
+        "counter account must match the selected tutorial network"
+    );
 
     println!("counter contract id: {:?}", counter_contract_id);
 
@@ -137,7 +154,6 @@ async fn main() -> Result<(), ClientError> {
 
     let get_count_root = counter_component
         .component_code()
-        .as_library()
         .get_procedure_root_by_path("external_contract::counter_contract::get_count")
         .expect("get_count export not found");
     let get_count_hash = format!("{}", get_count_root);
@@ -161,14 +177,16 @@ async fn main() -> Result<(), ClientError> {
     // that compiles the script.
     let tx_script = client
         .code_builder()
-        .with_linked_module("external_contract::count_reader_contract", count_reader_code)
+        .with_linked_module(
+            "external_contract::count_reader_contract",
+            count_reader_code,
+        )
         .unwrap()
         .compile_tx_script(script_code.as_str())
         .unwrap();
 
     let foreign_account =
-        ForeignAccount::public(counter_contract_id, AccountStorageRequirements::default())
-            .unwrap();
+        ForeignAccount::public(counter_contract_id, AccountStorageRequirements::default()).unwrap();
 
     let tx_request = TransactionRequestBuilder::new()
         .foreign_accounts([foreign_account])
@@ -177,12 +195,13 @@ async fn main() -> Result<(), ClientError> {
         .unwrap();
 
     let tx_id = client
-        .submit_new_transaction(count_reader_contract.id(), tx_request)
+        .submit_tutorial_transaction(count_reader_contract.id(), tx_request)
         .await
         .unwrap();
 
     println!(
-        "View transaction on MidenScan: https://testnet.midenscan.com/tx/{:?}",
+        "View transaction on MidenScan: {}/tx/{:?}",
+        network.explorer_url(),
         tx_id
     );
 
@@ -211,6 +230,14 @@ async fn main() -> Result<(), ClientError> {
     println!(
         "count reader contract storage: {:?}",
         account_2.storage().get_item(&count_reader_slot_name)
+    );
+    assert_eq!(
+        account_2
+            .storage()
+            .get_item(&count_reader_slot_name)
+            .unwrap(),
+        account_1.storage().get_item(&counter_slot_name).unwrap(),
+        "FPI must copy the current counter value",
     );
 
     Ok(())

--- a/rust-client/src/bin/counter_contract_increment.rs
+++ b/rust-client/src/bin/counter_contract_increment.rs
@@ -1,21 +1,26 @@
+use rust_client::TutorialClientExt;
 use std::{path::PathBuf, sync::Arc};
 
 use miden_client::{
     account::{AccountId, StorageSlotName},
     builder::ClientBuilder,
     keystore::FilesystemKeyStore,
-    rpc::{Endpoint, GrpcClient},
+    rpc::{GrpcClient, VerifyingRpcClient},
     transaction::TransactionRequestBuilder,
     ClientError,
 };
 use miden_client_sqlite_store::ClientBuilderSqliteExt;
+use rust_client::TutorialNetwork;
 
 #[tokio::main]
 async fn main() -> Result<(), ClientError> {
     // Initialize client
-    let endpoint = Endpoint::testnet();
+    let network = TutorialNetwork::from_env()?;
+    let endpoint = network.endpoint();
     let timeout_ms = 10_000;
-    let rpc_client = Arc::new(GrpcClient::new(&endpoint, timeout_ms));
+    let rpc_client = Arc::new(VerifyingRpcClient::new(GrpcClient::new(
+        &endpoint, timeout_ms,
+    )));
 
     // Initialize keystore
     let keystore_path = PathBuf::from("./keystore");
@@ -27,7 +32,6 @@ async fn main() -> Result<(), ClientError> {
         .rpc(rpc_client)
         .sqlite_store(store_path)
         .authenticator(keystore.clone())
-        .in_debug_mode(true.into())
         .build()
         .await?;
 
@@ -39,9 +43,19 @@ async fn main() -> Result<(), ClientError> {
     // -------------------------------------------------------------------------
     println!("\n[STEP 1] Reading data from public state");
 
-    // Define the Counter Contract account id from counter contract deploy
-    let (_, counter_contract_id) =
-        AccountId::from_bech32("mtst1apcqs7aj3a2cf5t6pnsfy0p4ns7wl7sp").unwrap();
+    // Pass the account ID printed by `counter_contract_deploy` as the first argument, or via
+    // `MIDEN_COUNTER_ACCOUNT_ID`.
+    let counter_contract_bech32 = std::env::args()
+        .nth(1)
+        .or_else(|| std::env::var("MIDEN_COUNTER_ACCOUNT_ID").ok())
+        .expect("pass the counter account ID from counter_contract_deploy");
+    let (account_network, counter_contract_id) =
+        AccountId::from_bech32(&counter_contract_bech32).expect("invalid counter account ID");
+    assert_eq!(
+        account_network,
+        network.network_id(),
+        "counter account must match the selected tutorial network"
+    );
 
     client
         .import_account_by_id(counter_contract_id)
@@ -57,6 +71,12 @@ async fn main() -> Result<(), ClientError> {
         "Account details: {:?}",
         counter_contract.storage().slots().first().unwrap()
     );
+    let counter_slot_name =
+        StorageSlotName::new("miden::tutorials::counter").expect("valid slot name");
+    let count_before = counter_contract
+        .storage()
+        .get_item(&counter_slot_name)
+        .unwrap()[0];
 
     // -------------------------------------------------------------------------
     // STEP 2: Call the Counter Contract with a script
@@ -85,12 +105,13 @@ async fn main() -> Result<(), ClientError> {
 
     // Execute and submit the transaction
     let tx_id = client
-        .submit_new_transaction(counter_contract_id, tx_increment_request)
+        .submit_tutorial_transaction(counter_contract_id, tx_increment_request)
         .await
         .unwrap();
 
     println!(
-        "View transaction on MidenScan: https://testnet.midenscan.com/tx/{:?}",
+        "View transaction on MidenScan: {}/tx/{:?}",
+        network.explorer_url(),
         tx_id
     );
 
@@ -102,11 +123,14 @@ async fn main() -> Result<(), ClientError> {
         .await
         .unwrap()
         .expect("counter contract not found");
-    let counter_slot_name =
-        StorageSlotName::new("miden::tutorials::counter").expect("valid slot name");
     println!(
         "counter contract storage: {:?}",
         account.storage().get_item(&counter_slot_name)
+    );
+    assert_eq!(
+        account.storage().get_item(&counter_slot_name).unwrap()[0],
+        count_before + miden_client::ONE,
+        "the imported counter must increment exactly once",
     );
     Ok(())
 }

--- a/rust-client/src/bin/create_mint_consume_send.rs
+++ b/rust-client/src/bin/create_mint_consume_send.rs
@@ -1,34 +1,38 @@
-use rand::RngCore;
+use rand::Rng;
+use rust_client::TutorialClientExt;
 use std::{path::PathBuf, sync::Arc};
 use tokio::time::Duration;
 
 use miden_client::{
     account::{
         component::{
-            BasicWallet, BurnPolicyConfig, FungibleFaucet, MintPolicyConfig, PolicyRegistration,
-            TokenName, TokenPolicyManager,
+            create_singlesig_user_fungible_faucet, BasicWallet, BurnPolicy, FungibleFaucet,
+            MintPolicy, TokenName, TokenPolicyManager,
         },
         AccountBuilder, AccountId, AccountType,
     },
-    address::NetworkId,
-    asset::{AssetAmount, FungibleAsset, TokenSymbol},
-    auth::{AuthSchemeId, AuthSecretKey, AuthSingleSig},
+    asset::{AssetAmount, AssetCallbackFlag, AssetId, FungibleAsset, TokenSymbol},
+    auth::{AuthSecretKey, AuthSingleSig},
     builder::ClientBuilder,
     keystore::{FilesystemKeyStore, Keystore},
-    note::{NoteAttachments, NoteType, P2idNote},
-    rpc::{Endpoint, GrpcClient},
-    transaction::TransactionRequestBuilder,
+    note::{Note, NoteType, P2idNote},
+    rpc::{GrpcClient, VerifyingRpcClient},
+    transaction::{PaymentNoteDescription, TransactionRequestBuilder},
     ClientError,
 };
 use miden_client_sqlite_store::ClientBuilderSqliteExt;
 use miden_protocol::account::AccountIdVersion;
+use rust_client::{fund_account_for_fees, FeeConfig, TutorialNetwork};
 
 #[tokio::main]
 async fn main() -> Result<(), ClientError> {
     // Initialize client
-    let endpoint = Endpoint::testnet();
+    let network = TutorialNetwork::from_env()?;
+    let endpoint = network.endpoint();
     let timeout_ms = 10_000;
-    let rpc_client = Arc::new(GrpcClient::new(&endpoint, timeout_ms));
+    let rpc_client = Arc::new(VerifyingRpcClient::new(GrpcClient::new(
+        &endpoint, timeout_ms,
+    )));
 
     // Initialize keystore
     let keystore_path = PathBuf::from("./keystore");
@@ -40,12 +44,12 @@ async fn main() -> Result<(), ClientError> {
         .rpc(rpc_client)
         .sqlite_store(store_path)
         .authenticator(keystore.clone())
-        .in_debug_mode(true.into())
         .build()
         .await?;
 
     let sync_summary = client.sync_state().await.unwrap();
     println!("Latest block: {}", sync_summary.block_num);
+    let fee_config = FeeConfig::from_client(&client, network).await?;
 
     //------------------------------------------------------------
     // STEP 1: Create a basic wallet for Alice
@@ -61,7 +65,7 @@ async fn main() -> Result<(), ClientError> {
     // Build the account
     let alice_account = AccountBuilder::new(init_seed)
         .account_type(AccountType::Public)
-        .with_auth_component(AuthSingleSig::new(key_pair.public_key().to_commitment(), AuthSchemeId::Falcon512Poseidon2))
+        .with_component(AuthSingleSig::from_public_key(key_pair.public_key()))
         .with_component(BasicWallet)
         .build()
         .unwrap();
@@ -70,10 +74,15 @@ async fn main() -> Result<(), ClientError> {
     client.add_account(&alice_account, false).await?;
 
     // Add the key pair to the keystore
-    keystore.add_key(&key_pair, alice_account.id()).await.unwrap();
+    keystore
+        .add_key(&key_pair, alice_account.id())
+        .await
+        .unwrap();
 
-    let alice_account_id_bech32 = alice_account.id().to_bech32(NetworkId::Testnet);
+    let alice_account_id_bech32 = alice_account.id().to_bech32(network.network_id());
     println!("Alice's account ID: {:?}", alice_account_id_bech32);
+
+    fund_account_for_fees(&mut client, alice_account.id(), &fee_config).await?;
 
     //------------------------------------------------------------
     // STEP 2: Deploy a fungible faucet
@@ -93,39 +102,43 @@ async fn main() -> Result<(), ClientError> {
     let key_pair = AuthSecretKey::new_falcon512_poseidon2_with_rng(client.rng());
 
     // Build the faucet account.
-    // In v0.15 the faucet is a `FungibleFaucet` component plus a `TokenPolicyManager`
+    // The faucet is a `FungibleFaucet` component plus a `TokenPolicyManager`
     // that registers an "allow all" mint (and burn) policy; minting is rejected
     // unless an active mint policy is present.
-    let faucet_account = AccountBuilder::new(init_seed)
-        .account_type(AccountType::Public)
-        .with_auth_component(AuthSingleSig::new(key_pair.public_key().to_commitment(), AuthSchemeId::Falcon512Poseidon2))
-        .with_component(
-            FungibleFaucet::builder()
-                .name(TokenName::new("MID").unwrap())
-                .symbol(symbol)
-                .decimals(decimals)
-                .max_supply(max_supply)
-                .build()
-                .unwrap(),
-        )
-        .with_components(
-            TokenPolicyManager::new()
-                .with_mint_policy(MintPolicyConfig::AllowAll, PolicyRegistration::Active)
-                .unwrap()
-                .with_burn_policy(BurnPolicyConfig::AllowAll, PolicyRegistration::Active)
-                .unwrap(),
-        )
+    let faucet = FungibleFaucet::builder()
+        .name(TokenName::new("MID").unwrap())
+        .symbol(symbol)
+        .decimals(decimals)
+        .max_supply(max_supply)
         .build()
         .unwrap();
+    let policies = TokenPolicyManager::builder()
+        .active_mint_policy(MintPolicy::allow_all())
+        .active_burn_policy(BurnPolicy::allow_all())
+        .build();
+    // The SDK factory includes BasicWallet so the faucet can receive the native fee asset.
+    let faucet_account = create_singlesig_user_fungible_faucet(
+        init_seed,
+        faucet,
+        AuthSingleSig::from_public_key(key_pair.public_key()),
+        policies,
+        AccountType::Public,
+    )
+    .unwrap();
 
     // Add the faucet to the client
     client.add_account(&faucet_account, false).await?;
 
     // Add the key pair to the keystore
-    keystore.add_key(&key_pair, faucet_account.id()).await.unwrap();
+    keystore
+        .add_key(&key_pair, faucet_account.id())
+        .await
+        .unwrap();
 
-    let faucet_account_id_bech32 = faucet_account.id().to_bech32(NetworkId::Testnet);
+    let faucet_account_id_bech32 = faucet_account.id().to_bech32(network.network_id());
     println!("Faucet account ID: {:?}", faucet_account_id_bech32);
+
+    fund_account_for_fees(&mut client, faucet_account.id(), &fee_config).await?;
 
     // Resync to show newly deployed faucet
     client.sync_state().await?;
@@ -139,6 +152,7 @@ async fn main() -> Result<(), ClientError> {
     let amount: u64 = 100;
     let fungible_asset = FungibleAsset::new(faucet_account.id(), amount).unwrap();
 
+    let mut minted_note_ids = Vec::new();
     for i in 1..=5 {
         let transaction_request = TransactionRequestBuilder::new()
             .build_mint_fungible_asset(
@@ -149,10 +163,16 @@ async fn main() -> Result<(), ClientError> {
             )
             .unwrap();
 
+        minted_note_ids.extend(
+            transaction_request
+                .expected_output_own_notes()
+                .iter()
+                .map(Note::id),
+        );
         println!("tx request built");
 
         let tx_id = client
-            .submit_new_transaction(faucet_account.id(), transaction_request)
+            .submit_tutorial_transaction(faucet_account.id(), transaction_request)
             .await?;
         println!(
             "Minted note #{} of {} tokens for Alice. TX: {:?}",
@@ -169,40 +189,17 @@ async fn main() -> Result<(), ClientError> {
     //------------------------------------------------------------
     println!("\n[STEP 4] Alice will now consume all of her notes to consolidate them.");
 
-    // Consume all minted notes in a single transaction
-    loop {
-        // Resync to get the latest data
-        client.sync_state().await?;
-
-        let consumable_notes = client
-            .get_consumable_notes(Some(alice_account.id()))
-            .await?;
-        let notes = consumable_notes
-            .iter()
-            .map(|(note, _)| note.clone().try_into())
-            .collect::<Result<Vec<_>, _>>()?;
-
-        if notes.len() == 5 {
-            println!("Found 5 consumable notes for Alice. Consuming them now...");
-            let transaction_request =
-                TransactionRequestBuilder::new().build_consume_notes(notes)?;
-
-            let tx_id = client
-                .submit_new_transaction(alice_account.id(), transaction_request)
-                .await?;
-            println!(
-                "All of Alice's notes consumed successfully. TX: {:?}",
-                tx_id
-            );
-            break;
-        } else {
-            println!(
-                "Currently, Alice has {} consumable notes. Waiting...",
-                notes.len()
-            );
-            tokio::time::sleep(Duration::from_secs(3)).await;
-        }
-    }
+    // TX_FEE notes are also consumable. Select only the five P2ID notes we minted.
+    let notes = rust_client::wait_for_notes_by_id(&mut client, &minted_note_ids).await?;
+    assert_eq!(notes.len(), 5);
+    let transaction_request = TransactionRequestBuilder::new().build_consume_notes(notes)?;
+    let tx_id = client
+        .submit_tutorial_transaction(alice_account.id(), transaction_request)
+        .await?;
+    println!(
+        "All of Alice's notes consumed successfully. TX: {:?}",
+        tx_id
+    );
 
     //------------------------------------------------------------
     // STEP 5: Alice sends 5 notes of 50 tokens to 5 users
@@ -224,19 +221,20 @@ async fn main() -> Result<(), ClientError> {
             init_seed,
             AccountIdVersion::Version1,
             AccountType::Public,
+            AssetCallbackFlag::Disabled,
         );
 
         let send_amount = 50;
         let fungible_asset = FungibleAsset::new(faucet_account.id(), send_amount).unwrap();
 
-        let p2id_note = P2idNote::create(
-            alice_account.id(),
-            target_account_id,
-            vec![fungible_asset.into()],
-            NoteType::Public,
-            NoteAttachments::empty(),
-            client.rng(),
-        )?;
+        let p2id_note: Note = P2idNote::builder()
+            .sender(alice_account.id())
+            .target(target_account_id)
+            .asset(fungible_asset)
+            .note_type(NoteType::Public)
+            .generate_serial_number(client.rng())
+            .build()?
+            .into();
         p2id_notes.push(p2id_note);
     }
 
@@ -248,7 +246,7 @@ async fn main() -> Result<(), ClientError> {
         .unwrap();
 
     let tx_id = client
-        .submit_new_transaction(alice_account.id(), transaction_request)
+        .submit_tutorial_transaction(alice_account.id(), transaction_request)
         .await?;
 
     println!("Submitted a transaction with 4 P2ID notes. TX: {:?}", tx_id);
@@ -263,30 +261,36 @@ async fn main() -> Result<(), ClientError> {
         init_seed,
         AccountIdVersion::Version1,
         AccountType::Public,
+        AssetCallbackFlag::Disabled,
     );
 
     let send_amount = 50;
     let fungible_asset = FungibleAsset::new(faucet_account.id(), send_amount).unwrap();
 
-    let p2id_note = P2idNote::create(
+    let payment = PaymentNoteDescription::new(
+        vec![fungible_asset.into()],
         alice_account.id(),
         target_account_id,
-        vec![fungible_asset.into()],
+    );
+    let transaction_request = TransactionRequestBuilder::new().build_pay_to_id(
+        payment,
         NoteType::Public,
-        NoteAttachments::empty(),
         client.rng(),
     )?;
 
-    let transaction_request = TransactionRequestBuilder::new()
-        .own_output_notes(vec![p2id_note])
-        .build()
-        .unwrap();
-
     let tx_id = client
-        .submit_new_transaction(alice_account.id(), transaction_request)
+        .submit_tutorial_transaction(alice_account.id(), transaction_request)
         .await?;
 
     println!("Submitted final P2ID transaction. TX: {:?}", tx_id);
+    let alice = client
+        .get_account(alice_account.id())
+        .await?
+        .expect("Alice exists");
+    let balance = alice
+        .vault()
+        .get_balance(AssetId::new_fungible(faucet_account.id()))?;
+    assert_eq!(balance.as_u64(), 250, "Alice should retain 500 - 250 MID");
 
     println!("\nAll steps completed successfully!");
     println!("Alice created a wallet, a faucet was deployed,");

--- a/rust-client/src/bin/delegated_prover.rs
+++ b/rust-client/src/bin/delegated_prover.rs
@@ -1,23 +1,27 @@
-use rand::RngCore;
+use rand::Rng;
 use std::{path::PathBuf, sync::Arc};
 
 use miden_client::{
     account::{component::BasicWallet, AccountBuilder, AccountType},
-    auth::{AuthSchemeId, AuthSecretKey, AuthSingleSig},
+    auth::{AuthSecretKey, AuthSingleSig},
     builder::ClientBuilder,
     keystore::{FilesystemKeyStore, Keystore},
-    rpc::{Endpoint, GrpcClient},
+    rpc::{GrpcClient, VerifyingRpcClient},
     transaction::{TransactionProver, TransactionRequestBuilder},
     ClientError, RemoteTransactionProver,
 };
 use miden_client_sqlite_store::ClientBuilderSqliteExt;
+use rust_client::{fund_account_for_fees, FeeConfig, TutorialNetwork};
 
 #[tokio::main]
 async fn main() -> Result<(), ClientError> {
     // Initialize client
-    let endpoint = Endpoint::testnet();
+    let network = TutorialNetwork::from_env()?;
+    let endpoint = network.endpoint();
     let timeout_ms = 10_000;
-    let rpc_client = Arc::new(GrpcClient::new(&endpoint, timeout_ms));
+    let rpc_client = Arc::new(VerifyingRpcClient::new(GrpcClient::new(
+        &endpoint, timeout_ms,
+    )));
 
     // Initialize keystore
     let keystore_path = PathBuf::from("./keystore");
@@ -29,12 +33,12 @@ async fn main() -> Result<(), ClientError> {
         .rpc(rpc_client)
         .sqlite_store(store_path)
         .authenticator(keystore.clone())
-        .in_debug_mode(true.into())
         .build()
         .await?;
 
     let sync_summary = client.sync_state().await.unwrap();
     println!("Latest block: {}", sync_summary.block_num);
+    let fee_config = FeeConfig::from_client(&client, network).await?;
 
     // Create Alice's account
     let mut init_seed = [0_u8; 32];
@@ -44,29 +48,37 @@ async fn main() -> Result<(), ClientError> {
 
     let alice_account = AccountBuilder::new(init_seed)
         .account_type(AccountType::Private)
-        .with_auth_component(AuthSingleSig::new(key_pair.public_key().to_commitment(), AuthSchemeId::Falcon512Poseidon2))
+        .with_component(AuthSingleSig::from_public_key(key_pair.public_key()))
         .with_component(BasicWallet)
         .build()
         .unwrap();
 
     client.add_account(&alice_account, false).await?;
-    keystore.add_key(&key_pair, alice_account.id()).await.unwrap();
+    keystore
+        .add_key(&key_pair, alice_account.id())
+        .await
+        .unwrap();
+    fund_account_for_fees(&mut client, alice_account.id(), &fee_config).await?;
 
     // -------------------------------------------------------------------------
     // Set up the delegated (remote) tx prover
     // -------------------------------------------------------------------------
     // Delegated proving outsources ZK proof generation to a remote service. This is
-    // the public Miden testnet prover; run your own
+    // the public prover for the selected network; run your own
     // (https://crates.io/crates/miden-remote-prover) and swap the URL to use it.
-    // The constant `miden_client::grpc_support::TESTNET_PROVER_ENDPOINT` holds this
-    // same URL.
-    let remote_tx_prover = RemoteTransactionProver::new("https://tx-prover.testnet.miden.io");
+    // The upstream constant keeps this URL synchronized with the selected network.
+    let remote_tx_prover = RemoteTransactionProver::new(network.remote_prover_url());
     let tx_prover: Arc<dyn TransactionProver> = Arc::new(remote_tx_prover);
 
     // We use a dummy transaction request to showcase delegated proving.
-    // The only effect of this tx should be increasing Alice's nonce.
-    println!("Alice nonce initial: {:?}", alice_account.nonce());
-    let script_code = "begin push.1 drop end";
+    // In addition to paying the network fee, this transaction increments Alice's nonce.
+    let initial_nonce = client
+        .get_account(alice_account.id())
+        .await?
+        .expect("Alice exists")
+        .nonce();
+    println!("Alice nonce initial: {:?}", initial_nonce);
+    let script_code = "@transaction_script pub proc main push.1 drop end";
     let tx_script = client
         .code_builder()
         .compile_tx_script(script_code)
@@ -79,6 +91,7 @@ async fn main() -> Result<(), ClientError> {
 
     // Step 1: Execute the transaction locally
     println!("Executing transaction...");
+    client.sync_state().await?;
     let tx_result = client
         .execute_transaction(alice_account.id(), transaction_request)
         .await?;
@@ -97,6 +110,7 @@ async fn main() -> Result<(), ClientError> {
     client
         .apply_transaction(&tx_result, submission_height)
         .await?;
+    rust_client::wait_for_transaction(&mut client, tx_result.id()).await?;
 
     println!("Transaction submitted successfully using the delegated prover!");
 
@@ -109,6 +123,7 @@ async fn main() -> Result<(), ClientError> {
         .expect("alice account not found");
 
     println!("Alice nonce has increased: {:?}", account.nonce());
+    assert_eq!(account.nonce(), initial_nonce + miden_client::Felt::ONE);
 
     Ok(())
 }

--- a/rust-client/src/bin/hash_preimage_note.rs
+++ b/rust-client/src/bin/hash_preimage_note.rs
@@ -1,29 +1,28 @@
-use rand::RngCore;
+use rand::Rng;
+use rust_client::TutorialClientExt;
 use std::{path::PathBuf, sync::Arc};
-use tokio::time::{sleep, Duration};
 
 use miden_client::{
     account::{
         component::{
-            BasicWallet, BurnPolicyConfig, FungibleFaucet, MintPolicyConfig, PolicyRegistration,
-            TokenName, TokenPolicyManager,
+            create_singlesig_user_fungible_faucet, BasicWallet, BurnPolicy, FungibleFaucet,
+            MintPolicy, TokenName, TokenPolicyManager,
         },
         Account, AccountBuilder, AccountType,
     },
-    address::NetworkId,
-    asset::{AssetAmount, FungibleAsset, TokenSymbol},
-    auth::{AuthSchemeId, AuthSecretKey, AuthSingleSig},
+    asset::{AssetAmount, AssetId, FungibleAsset, TokenSymbol},
+    auth::{AuthSecretKey, AuthSingleSig},
     builder::ClientBuilder,
     crypto::FeltRng,
     keystore::{FilesystemKeyStore, Keystore},
     note::{Note, NoteAssets, NoteRecipient, NoteStorage, NoteTag, NoteType, PartialNoteMetadata},
-    rpc::{Endpoint, GrpcClient},
-    store::TransactionFilter,
-    transaction::{TransactionId, TransactionRequestBuilder, TransactionStatus},
+    rpc::{GrpcClient, VerifyingRpcClient},
+    transaction::{TransactionId, TransactionRequestBuilder},
     Client, ClientError, Felt,
 };
 use miden_client_sqlite_store::ClientBuilderSqliteExt;
 use miden_protocol::Hasher;
+use rust_client::{fund_account_for_fees, FeeConfig, TutorialNetwork};
 
 // Helper to create a basic account
 async fn create_basic_account(
@@ -37,7 +36,7 @@ async fn create_basic_account(
 
     let account = AccountBuilder::new(init_seed)
         .account_type(AccountType::Public)
-        .with_auth_component(AuthSingleSig::new(key_pair.public_key().to_commitment(), AuthSchemeId::Falcon512Poseidon2))
+        .with_component(AuthSingleSig::from_public_key(key_pair.public_key()))
         .with_component(BasicWallet)
         .build()
         .unwrap();
@@ -60,27 +59,25 @@ async fn create_basic_faucet(
     let decimals = 8;
     let max_supply = AssetAmount::new(1_000_000).unwrap();
 
-    let account = AccountBuilder::new(init_seed)
-        .account_type(AccountType::Public)
-        .with_auth_component(AuthSingleSig::new(key_pair.public_key().to_commitment(), AuthSchemeId::Falcon512Poseidon2))
-        .with_component(
-            FungibleFaucet::builder()
-                .name(TokenName::new("MID").unwrap())
-                .symbol(symbol)
-                .decimals(decimals)
-                .max_supply(max_supply)
-                .build()
-                .unwrap(),
-        )
-        .with_components(
-            TokenPolicyManager::new()
-                .with_mint_policy(MintPolicyConfig::AllowAll, PolicyRegistration::Active)
-                .unwrap()
-                .with_burn_policy(BurnPolicyConfig::AllowAll, PolicyRegistration::Active)
-                .unwrap(),
-        )
+    let faucet = FungibleFaucet::builder()
+        .name(TokenName::new("MID").unwrap())
+        .symbol(symbol)
+        .decimals(decimals)
+        .max_supply(max_supply)
         .build()
         .unwrap();
+    let policies = TokenPolicyManager::builder()
+        .active_mint_policy(MintPolicy::allow_all())
+        .active_burn_policy(BurnPolicy::allow_all())
+        .build();
+    let account = create_singlesig_user_fungible_faucet(
+        init_seed,
+        faucet,
+        AuthSingleSig::from_public_key(key_pair.public_key()),
+        policies,
+        AccountType::Public,
+    )
+    .unwrap();
 
     client.add_account(&account, false).await?;
     keystore.add_key(&key_pair, account.id()).await.unwrap();
@@ -93,39 +90,18 @@ async fn wait_for_tx(
     client: &mut Client<FilesystemKeyStore>,
     tx_id: TransactionId,
 ) -> Result<(), ClientError> {
-    loop {
-        client.sync_state().await?;
-
-        // Check transaction status
-        let txs = client
-            .get_transactions(TransactionFilter::Ids(vec![tx_id]))
-            .await?;
-        let tx_committed = if !txs.is_empty() {
-            matches!(txs[0].status, TransactionStatus::Committed { .. })
-        } else {
-            false
-        };
-
-        if tx_committed {
-            println!("✅ transaction {} committed", tx_id.to_hex());
-            break;
-        }
-
-        println!(
-            "Transaction {} not yet committed. Waiting...",
-            tx_id.to_hex()
-        );
-        sleep(Duration::from_secs(2)).await;
-    }
-    Ok(())
+    rust_client::wait_for_transaction(client, tx_id).await
 }
 
 #[tokio::main]
 async fn main() -> Result<(), ClientError> {
     // Initialize client
-    let endpoint = Endpoint::testnet();
+    let network = TutorialNetwork::from_env()?;
+    let endpoint = network.endpoint();
     let timeout_ms = 10_000;
-    let rpc_client = Arc::new(GrpcClient::new(&endpoint, timeout_ms));
+    let rpc_client = Arc::new(VerifyingRpcClient::new(GrpcClient::new(
+        &endpoint, timeout_ms,
+    )));
 
     // Initialize keystore
     let keystore_path = PathBuf::from("./keystore");
@@ -137,12 +113,12 @@ async fn main() -> Result<(), ClientError> {
         .rpc(rpc_client)
         .sqlite_store(store_path)
         .authenticator(keystore.clone())
-        .in_debug_mode(true.into())
         .build()
         .await?;
 
     let sync_summary = client.sync_state().await.unwrap();
     println!("Latest block: {}", sync_summary.block_num);
+    let fee_config = FeeConfig::from_client(&client, network).await?;
 
     // -------------------------------------------------------------------------
     // STEP 1: Create accounts and deploy faucet
@@ -151,20 +127,23 @@ async fn main() -> Result<(), ClientError> {
     let alice_account = create_basic_account(&mut client, &keystore).await?;
     println!(
         "Alice's account ID: {:?}",
-        alice_account.id().to_bech32(NetworkId::Testnet)
+        alice_account.id().to_bech32(network.network_id())
     );
     let bob_account = create_basic_account(&mut client, &keystore).await?;
     println!(
         "Bob's account ID: {:?}",
-        bob_account.id().to_bech32(NetworkId::Testnet)
+        bob_account.id().to_bech32(network.network_id())
     );
 
     println!("\nDeploying a new fungible faucet.");
     let faucet = create_basic_faucet(&mut client, &keystore).await?;
     println!(
         "Faucet account ID: {:?}",
-        faucet.id().to_bech32(NetworkId::Testnet)
+        faucet.id().to_bech32(network.network_id())
     );
+    for account_id in [alice_account.id(), bob_account.id(), faucet.id()] {
+        fund_account_for_fees(&mut client, account_id, &fee_config).await?;
+    }
     client.sync_state().await?;
 
     // -------------------------------------------------------------------------
@@ -184,7 +163,7 @@ async fn main() -> Result<(), ClientError> {
         .unwrap();
 
     let tx_id = client
-        .submit_new_transaction(faucet.id(), tx_request)
+        .submit_tutorial_transaction(faucet.id(), tx_request)
         .await?;
     println!("Minted tokens. TX: {:?}", tx_id);
 
@@ -194,7 +173,7 @@ async fn main() -> Result<(), ClientError> {
 
     // Consume the minted note
     let consumable_notes = client
-        .get_consumable_notes(Some(alice_account.id()))
+        .get_consumable_tutorial_notes(Some(alice_account.id()))
         .await?;
 
     if let Some((note_record, _)) = consumable_notes.first() {
@@ -202,7 +181,7 @@ async fn main() -> Result<(), ClientError> {
         let consume_request = TransactionRequestBuilder::new().build_consume_notes(vec![note])?;
 
         let tx_id = client
-            .submit_new_transaction(alice_account.id(), consume_request)
+            .submit_tutorial_transaction(alice_account.id(), consume_request)
             .await?;
         println!("Consumed minted note. TX: {:?}", tx_id);
     }
@@ -213,7 +192,12 @@ async fn main() -> Result<(), ClientError> {
     // STEP 3: Create custom note
     // -------------------------------------------------------------------------
     println!("\n[STEP 3] Create custom note");
-    let secret_vals = vec![Felt::new_unchecked(1), Felt::new_unchecked(2), Felt::new_unchecked(3), Felt::new_unchecked(4)];
+    let secret_vals = vec![
+        Felt::new_unchecked(1),
+        Felt::new_unchecked(2),
+        Felt::new_unchecked(3),
+        Felt::new_unchecked(4),
+    ];
     let digest = Hasher::hash_elements(&secret_vals);
     println!("digest: {:?}", digest);
 
@@ -237,10 +221,11 @@ async fn main() -> Result<(), ClientError> {
         .unwrap();
 
     let tx_id = client
-        .submit_new_transaction(alice_account.id(), note_request)
+        .submit_tutorial_transaction(alice_account.id(), note_request)
         .await?;
     println!(
-        "View transaction on MidenScan: https://testnet.midenscan.com/tx/{:?}",
+        "View transaction on MidenScan: {}/tx/{:?}",
+        network.explorer_url(),
         tx_id
     );
 
@@ -251,21 +236,39 @@ async fn main() -> Result<(), ClientError> {
     // -------------------------------------------------------------------------
     println!("\n[STEP 4] Bob consumes the Custom Note with Correct Secret");
 
-    let secret = [Felt::new_unchecked(1), Felt::new_unchecked(2), Felt::new_unchecked(3), Felt::new_unchecked(4)];
+    let secret = [
+        Felt::new_unchecked(1),
+        Felt::new_unchecked(2),
+        Felt::new_unchecked(3),
+        Felt::new_unchecked(4),
+    ];
     let consume_custom_request = TransactionRequestBuilder::new()
         .input_notes([(custom_note, Some(secret.into()))])
         .build()
         .unwrap();
 
     let tx_id = client
-        .submit_new_transaction(bob_account.id(), consume_custom_request)
+        .submit_tutorial_transaction(bob_account.id(), consume_custom_request)
         .await?;
     println!(
-        "Consumed Note Tx on MidenScan: https://testnet.midenscan.com/tx/{:?} \n",
+        "Consumed Note Tx on MidenScan: {}/tx/{:?} \n",
+        network.explorer_url(),
         tx_id
     );
 
     wait_for_tx(&mut client, tx_id).await?;
+
+    let bob = client
+        .get_account(bob_account.id())
+        .await?
+        .expect("Bob's account must exist after consuming the note");
+    let balance = bob.vault().get_balance(AssetId::new_fungible(faucet_id))?;
+    assert_eq!(
+        balance.as_u64(),
+        amount,
+        "Bob must receive all assets from the hash-preimage note",
+    );
+    println!("Bob's custom-note token balance: {balance}");
 
     Ok(())
 }

--- a/rust-client/src/bin/mapping_example.rs
+++ b/rust-client/src/bin/mapping_example.rs
@@ -1,26 +1,32 @@
-use rand::RngCore;
+use rand::Rng;
+use rust_client::TutorialClientExt;
 use std::{path::PathBuf, sync::Arc};
 
 use miden_client::{
     account::{
-        component::AccountComponentMetadata, AccountBuilder, AccountComponent,
-        AccountType, StorageMap, StorageSlot, StorageSlotName,
+        component::{AccountComponentMetadata, BasicWallet},
+        AccountBuilder, AccountComponent, AccountType, StorageMap, StorageMapKey, StorageSlot,
+        StorageSlotName,
     },
     auth::NoAuth,
     builder::ClientBuilder,
     keystore::FilesystemKeyStore,
-    rpc::{Endpoint, GrpcClient},
+    rpc::{GrpcClient, VerifyingRpcClient},
     transaction::TransactionRequestBuilder,
-    ClientError, Felt, Word,
+    ClientError,
 };
 use miden_client_sqlite_store::ClientBuilderSqliteExt;
+use rust_client::{fund_account_for_fees, FeeConfig, TutorialNetwork};
 
 #[tokio::main]
 async fn main() -> Result<(), ClientError> {
     // Initialize client
-    let endpoint = Endpoint::testnet();
+    let network = TutorialNetwork::from_env()?;
+    let endpoint = network.endpoint();
     let timeout_ms = 10_000;
-    let rpc_client = Arc::new(GrpcClient::new(&endpoint, timeout_ms));
+    let rpc_client = Arc::new(VerifyingRpcClient::new(GrpcClient::new(
+        &endpoint, timeout_ms,
+    )));
 
     // Initialize keystore
     let keystore_path = PathBuf::from("./keystore");
@@ -32,29 +38,23 @@ async fn main() -> Result<(), ClientError> {
         .rpc(rpc_client)
         .sqlite_store(store_path)
         .authenticator(keystore.clone())
-        .in_debug_mode(true.into())
         .build()
         .await?;
 
     let sync_summary = client.sync_state().await.unwrap();
     println!("Latest block: {}", sync_summary.block_num);
+    let fee_config = FeeConfig::from_client(&client, network).await?;
 
     // -------------------------------------------------------------------------
     // STEP 1: Deploy a smart contract with a mapping
     // -------------------------------------------------------------------------
     println!("\n[STEP 1] Deploy a smart contract with a mapping");
 
-    // Load the MASM file for the counter contract. `include_str!` resolves at
+    // Load the MASM file for the mapping contract. `include_str!` resolves at
     // compile time relative to this source file.
     let account_code = include_str!("../../../masm/accounts/mapping_example_contract.masm");
 
-    // Using an empty storage value in slot 0 since this is usually reserved
-    // for the account pub_key and metadata
-    let empty_slot_name =
-        StorageSlotName::new("miden::tutorials::mapping::value").expect("valid slot name");
-    let empty_storage_slot = StorageSlot::with_value(empty_slot_name.clone(), Word::default());
-
-    // initialize storage map
+    // Storage slots are named in v0.16; the component only needs its mapping slot.
     let storage_map = StorageMap::new();
     let map_slot_name =
         StorageSlotName::new("miden::tutorials::mapping::map").expect("valid slot name");
@@ -67,7 +67,7 @@ async fn main() -> Result<(), ClientError> {
         .unwrap();
     let mapping_contract_component = AccountComponent::new(
         component_code,
-        vec![empty_storage_slot, storage_slot_map],
+        vec![storage_slot_map],
         AccountComponentMetadata::new("miden_by_example::mapping_example_contract"),
     )
     .unwrap();
@@ -80,7 +80,8 @@ async fn main() -> Result<(), ClientError> {
     let mapping_example_contract = AccountBuilder::new(init_seed)
         .account_type(AccountType::Public)
         .with_component(mapping_contract_component.clone())
-        .with_auth_component(NoAuth)
+        .with_component(BasicWallet)
+        .with_component(NoAuth)
         .build()
         .unwrap();
 
@@ -88,6 +89,7 @@ async fn main() -> Result<(), ClientError> {
         .add_account(&mapping_example_contract, false)
         .await
         .unwrap();
+    fund_account_for_fees(&mut client, mapping_example_contract.id(), &fee_config).await?;
 
     // -------------------------------------------------------------------------
     // STEP 2: Call the Mapping Contract with a Script
@@ -113,12 +115,13 @@ async fn main() -> Result<(), ClientError> {
 
     // Execute and submit the transaction
     let tx_id = client
-        .submit_new_transaction(mapping_example_contract.id(), tx_increment_request)
+        .submit_tutorial_transaction(mapping_example_contract.id(), tx_increment_request)
         .await
         .unwrap();
 
     println!(
-        "View transaction on MidenScan: https://testnet.midenscan.com/tx/{:?}",
+        "View transaction on MidenScan: {}/tx/{:?}",
+        network.explorer_url(),
         tx_id
     );
 
@@ -129,18 +132,21 @@ async fn main() -> Result<(), ClientError> {
         .await
         .unwrap()
         .expect("mapping contract not found");
-    let key = [
-        Felt::new_unchecked(0),
-        Felt::new_unchecked(0),
-        Felt::new_unchecked(0),
-        Felt::new_unchecked(0),
-    ]
-    .into();
+    let key = StorageMapKey::empty();
     println!(
         "Mapping state\n Index: {:?}\n Key: {:?}\n Value: {:?}",
         map_slot_name,
         key,
         account.storage().get_map_item(&map_slot_name, key)
+    );
+    let value = account.storage().get_map_item(&map_slot_name, key).unwrap();
+    assert_eq!(
+        value
+            .iter()
+            .map(|felt| felt.as_canonical_u64())
+            .collect::<Vec<_>>(),
+        vec![4, 3, 2, 1],
+        "the mapping must store the value written by the transaction script",
     );
 
     Ok(())

--- a/rust-client/src/bin/network_notes_counter_contract.rs
+++ b/rust-client/src/bin/network_notes_counter_contract.rs
@@ -1,28 +1,30 @@
+use rust_client::TutorialClientExt;
 use std::{collections::BTreeSet, path::PathBuf, sync::Arc};
 
 use miden_client::{
     account::{
-        component::{AccountComponentMetadata, AuthNetworkAccount, BasicWallet}, AccountBuilder, AccountComponent,
-        AccountType, StorageSlot, StorageSlotName,
+        component::{
+            AccountComponentMetadata, AuthNetworkAccount, BasicConstantFeePolicy, BasicWallet,
+            FeePolicy, FeePolicyManager,
+        },
+        AccountBuilder, AccountComponent, AccountType, StorageSlot, StorageSlotName,
     },
-    address::NetworkId,
-    auth::{AuthSchemeId, AuthSecretKey, AuthSingleSig},
+    asset::AssetAmount,
+    auth::{AuthSecretKey, AuthSingleSig},
     builder::ClientBuilder,
     crypto::FeltRng,
     keystore::{FilesystemKeyStore, Keystore},
     note::{
         NetworkAccountTarget, Note, NoteAssets, NoteAttachments, NoteError, NoteExecutionHint,
-        NoteRecipient, NoteStorage, NoteTag, NoteType, PartialNoteMetadata,
+        NoteRecipient, NoteStorage, NoteTag, NoteType, P2idNote, PartialNoteMetadata,
     },
-    rpc::{Endpoint, GrpcClient},
-    store::TransactionFilter,
-    transaction::{
-        TransactionId, TransactionRequestBuilder, TransactionStatus,
-    },
+    rpc::{GrpcClient, VerifyingRpcClient},
+    transaction::{ExpirationTransactionScript, TransactionId, TransactionRequestBuilder},
     Client, ClientError, Felt, Word,
 };
 use miden_client_sqlite_store::ClientBuilderSqliteExt;
-use rand::RngCore;
+use rand::Rng;
+use rust_client::{fund_account_for_fees, FeeConfig, TutorialNetwork};
 use tokio::time::{sleep, Duration};
 
 /// Waits for a specific transaction to be committed.
@@ -30,39 +32,18 @@ async fn wait_for_tx(
     client: &mut Client<FilesystemKeyStore>,
     tx_id: TransactionId,
 ) -> Result<(), ClientError> {
-    loop {
-        client.sync_state().await?;
-
-        // Check transaction status
-        let txs = client
-            .get_transactions(TransactionFilter::Ids(vec![tx_id]))
-            .await?;
-        let tx_committed = if !txs.is_empty() {
-            matches!(txs[0].status, TransactionStatus::Committed { .. })
-        } else {
-            false
-        };
-
-        if tx_committed {
-            println!("✅ transaction {} committed", tx_id.to_hex());
-            break;
-        }
-
-        println!(
-            "Transaction {} not yet committed. Waiting...",
-            tx_id.to_hex()
-        );
-        sleep(Duration::from_secs(2)).await;
-    }
-    Ok(())
+    rust_client::wait_for_transaction(client, tx_id).await
 }
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Initialize client
-    let endpoint = Endpoint::testnet();
+    let network = TutorialNetwork::from_env()?;
+    let endpoint = network.endpoint();
     let timeout_ms = 10_000;
-    let rpc_client = Arc::new(GrpcClient::new(&endpoint, timeout_ms));
+    let rpc_client = Arc::new(VerifyingRpcClient::new(GrpcClient::new(
+        &endpoint, timeout_ms,
+    )));
 
     // Initialize keystore
     let keystore_path = PathBuf::from("./keystore");
@@ -74,12 +55,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .rpc(rpc_client)
         .sqlite_store(store_path)
         .authenticator(keystore.clone())
-        .in_debug_mode(true.into())
         .build()
         .await?;
 
     let sync_summary = client.sync_state().await.unwrap();
     println!("Latest block: {}", sync_summary.block_num);
+    let fee_config = FeeConfig::from_client(&client, network).await?;
+    let fee_faucet_id = fee_config.native_fee_faucet_id();
 
     // -------------------------------------------------------------------------
     // STEP 1: Create Basic User Account
@@ -95,7 +77,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Build the account
     let alice_account = AccountBuilder::new(init_seed)
         .account_type(AccountType::Public)
-        .with_auth_component(AuthSingleSig::new(key_pair.public_key().to_commitment(), AuthSchemeId::Falcon512Poseidon2))
+        .with_component(AuthSingleSig::from_public_key(key_pair.public_key()))
         .with_component(BasicWallet)
         .build()
         .unwrap();
@@ -104,11 +86,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     client.add_account(&alice_account, false).await?;
 
     // Add the key pair to the keystore
-    keystore.add_key(&key_pair, alice_account.id()).await.unwrap();
+    keystore
+        .add_key(&key_pair, alice_account.id())
+        .await
+        .unwrap();
+    fund_account_for_fees(&mut client, alice_account.id(), &fee_config).await?;
 
     println!(
         "Alice's account ID: {:?}",
-        alice_account.id().to_bech32(NetworkId::Testnet)
+        alice_account.id().to_bech32(network.network_id())
     );
 
     // -------------------------------------------------------------------------
@@ -119,34 +105,18 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // `include_str!` resolves at compile time relative to this source file,
     // so the binary is independent of the working directory it is run from.
     let counter_code = include_str!("../../../masm/accounts/counter.masm");
-    let script_code = include_str!("../../../masm/scripts/counter_script.masm");
     let network_note_code = include_str!("../../../masm/notes/network_increment_note.masm");
 
-    // In protocol v0.15 an account is a *network account* (one the network
+    // An account is a *network account* (one the network
     // transaction builder executes on a user's behalf) if and only if it is
     // public AND carries the `AuthNetworkAccount` auth component. That component
-    // holds two allowlists, both fixed at account creation:
-    //   * the note-script allowlist: its presence is what marks the account as a
-    //     network account, and the builder only executes notes whose script root
-    //     is listed here;
-    //   * the tx-script allowlist: the network auth procedure rejects any custom
-    //     tx script whose root is not listed, so the STEP 3 deploy script must be
-    //     in it.
-    // We therefore compile the note script and the deploy tx script now and feed
-    // their MAST roots into the allowlists below. Both compiled scripts are reused
-    // as-is in STEP 3 (tx script) and STEP 4 (note script) — nothing is compiled
-    // twice.
+    // holds an allowlist of note scripts the network builder may execute.
+    // Compile the increment note first so its root can be included at creation.
     let note_script = client
         .code_builder()
         .with_linked_module("external_contract::counter_contract", counter_code)?
         .compile_note_script(network_note_code)?;
     let note_script_root = note_script.root();
-
-    let tx_script = client
-        .code_builder()
-        .with_linked_module("external_contract::counter_contract", counter_code)?
-        .compile_tx_script(script_code)?;
-    let tx_script_root = tx_script.root();
 
     // Compile the counter MASM into an account component
     let counter_slot_name =
@@ -167,49 +137,56 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut init_seed = [0_u8; 32];
     client.rng().fill_bytes(&mut init_seed);
 
-    // Build the network account: public + `AuthNetworkAccount` with the note-script
-    // root allowlisted (this is what makes it a network account) and the deploy
-    // tx-script root allowlisted (so the auth procedure accepts the STEP 3 deploy).
-    let network_auth = AuthNetworkAccount::with_allowed_notes(BTreeSet::from([note_script_root]))?
-        .with_allowed_tx_scripts(BTreeSet::from([tx_script_root]));
+    // Build the public network account with the increment and funding notes allowed.
+    let fee_policy: FeePolicy = BasicConstantFeePolicy::new()
+        .with_fees(
+            [note_script_root, P2idNote::script_root()].map(|root| (root, AssetAmount::ZERO)),
+        )
+        .into();
+    let fee_policy_manager = FeePolicyManager::builder()
+        .fee_faucet_id(fee_faucet_id)
+        .active_fee_policy(fee_policy)
+        .build();
+    // Match the protocol/node counter example: only permit the two note scripts
+    // this account implements. Config notes need Authority, which it does not have.
+    // The canonical expiration script is required by the network builder.
+    let network_auth = AuthNetworkAccount::custom(
+        BTreeSet::from([note_script_root, P2idNote::script_root()]),
+        fee_policy_manager,
+    )?
+    .with_allowed_tx_scripts([ExpirationTransactionScript::script_root()]);
     let counter_contract = AccountBuilder::new(init_seed)
         .account_type(AccountType::Public)
-        .with_auth_component(network_auth)
+        .with_components(network_auth)
         .with_component(counter_component)
+        .with_component(BasicWallet)
         .build()
         .unwrap();
 
     client.add_account(&counter_contract, false).await.unwrap();
+    fund_account_for_fees(&mut client, counter_contract.id(), &fee_config).await?;
 
     println!(
         "contract id: {:?}",
-        counter_contract.id().to_bech32(NetworkId::Testnet)
+        counter_contract.id().to_bech32(network.network_id())
     );
 
     // -------------------------------------------------------------------------
-    // STEP 3: Deploy Network Account with Transaction Script
+    // STEP 3: Publish the network account
     // -------------------------------------------------------------------------
     println!("\n[STEP 3] Deploy network counter smart contract");
 
-    // Reuse the `tx_script` compiled in STEP 2 (its root is allowlisted on the
-    // account, so the network auth procedure accepts this deploy transaction).
-    let tx_increment_request = TransactionRequestBuilder::new()
-        .custom_script(tx_script)
-        .build()
-        .unwrap();
-
-    let tx_id = client
-        .submit_new_transaction(counter_contract.id(), tx_increment_request)
-        .await
-        .unwrap();
-
-    println!(
-        "View transaction on MidenScan: https://testnet.midenscan.com/tx/{:?}",
-        tx_id
-    );
-
-    // Wait for the transaction to be committed
-    wait_for_tx(&mut client, tx_id).await.unwrap();
+    // On a fee-enabled network, consuming the funding note already published this
+    // account. RPC permits users to deploy new network accounts, but rejects
+    // user-submitted transactions for existing ones. Subsequent increments must
+    // be requested by notes and executed by the network transaction builder.
+    if !fee_config.fees_are_active() {
+        let deployment = TransactionRequestBuilder::new().build()?;
+        client
+            .submit_tutorial_transaction(counter_contract.id(), deployment)
+            .await?;
+    }
+    println!("Network counter deployed; initial count is 0");
 
     // -------------------------------------------------------------------------
     // STEP 4: Prepare & Create the Network Note
@@ -244,11 +221,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .build()?;
 
     let note_tx_id = client
-        .submit_new_transaction(alice_account.id(), note_req)
+        .submit_tutorial_transaction(alice_account.id(), note_req)
         .await?;
 
     println!(
-        "View transaction on MidenScan: https://testnet.midenscan.com/tx/{:?}",
+        "View transaction on MidenScan: {}/tx/{:?}",
+        network.explorer_url(),
         note_tx_id
     );
 
@@ -263,7 +241,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     sleep(Duration::from_secs(6)).await;
 
     let mut last_val = None;
-    for _ in 0..10 {
+    for _ in 0..24 {
         client.sync_state().await?;
 
         // Checking updated state
@@ -276,7 +254,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .unwrap()
                 .into();
             let val = count[0].as_canonical_u64();
-            if val >= 2 {
+            if val == 1 {
                 println!("🔢 Final counter value: {}", val);
                 return Ok(());
             }
@@ -288,12 +266,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     // The network note was submitted, but it is executed asynchronously by the
-    // network transaction builder. If the counter has not reached 2 within the
+    // network transaction builder. If the counter has not reached 1 within the
     // polling window, the tutorial's final state is unconfirmed, so fail rather
     // than claim success.
     if let Some(val) = last_val {
         Err(format!(
-            "Counter did not reach the expected value 2 within the timeout (last observed {}). \
+            "Counter did not reach the expected value 1 within the timeout (last observed {}). \
              The network note was submitted but its execution is still pending on the network \
              transaction builder; re-run or check Midenscan.",
             val

--- a/rust-client/src/bin/note_creation_in_masm.rs
+++ b/rust-client/src/bin/note_creation_in_masm.rs
@@ -1,18 +1,19 @@
-use rand::RngCore;
+use rand::Rng;
+use rust_client::TutorialClientExt;
 use std::{path::PathBuf, sync::Arc};
 use tokio::time::{sleep, Duration};
 
 use miden_client::{
     account::{
         component::{
-            BasicWallet, BurnPolicyConfig, FungibleFaucet, MintPolicyConfig, PolicyRegistration,
-            TokenName, TokenPolicyManager,
+            create_singlesig_user_fungible_faucet, BasicWallet, BurnPolicy, FungibleFaucet,
+            MintPolicy, TokenName, TokenPolicyManager,
         },
         Account, AccountBuilder, AccountType,
     },
     address::NetworkId,
-    asset::{AssetAmount, FungibleAsset, TokenSymbol},
-    auth::{AuthSchemeId, AuthSecretKey, AuthSingleSig},
+    asset::{AssetAmount, AssetId, FungibleAsset, TokenSymbol},
+    auth::{AuthSecretKey, AuthSingleSig},
     builder::ClientBuilder,
     crypto::FeltRng,
     keystore::{FilesystemKeyStore, Keystore},
@@ -20,12 +21,12 @@ use miden_client::{
         Note, NoteAssets, NoteDetails, NoteRecipient, NoteStorage, NoteTag, NoteType,
         PartialNoteMetadata,
     },
-    rpc::{Endpoint, GrpcClient},
-    store::TransactionFilter,
-    transaction::{TransactionId, TransactionRequestBuilder, TransactionStatus},
+    rpc::{GrpcClient, VerifyingRpcClient},
+    transaction::{TransactionId, TransactionRequestBuilder},
     Client, ClientError, Felt,
 };
 use miden_client_sqlite_store::ClientBuilderSqliteExt;
+use rust_client::{fund_account_for_fees, FeeConfig, TutorialNetwork};
 
 // Helper to create a basic account
 async fn create_basic_account(
@@ -39,7 +40,7 @@ async fn create_basic_account(
 
     let account = AccountBuilder::new(init_seed)
         .account_type(AccountType::Public)
-        .with_auth_component(AuthSingleSig::new(key_pair.public_key().to_commitment(), AuthSchemeId::Falcon512Poseidon2))
+        .with_component(AuthSingleSig::from_public_key(key_pair.public_key()))
         .with_component(BasicWallet)
         .build()
         .unwrap();
@@ -62,27 +63,25 @@ async fn create_basic_faucet(
     let decimals = 8;
     let max_supply = AssetAmount::new(1_000_000).unwrap();
 
-    let account = AccountBuilder::new(init_seed)
-        .account_type(AccountType::Public)
-        .with_auth_component(AuthSingleSig::new(key_pair.public_key().to_commitment(), AuthSchemeId::Falcon512Poseidon2))
-        .with_component(
-            FungibleFaucet::builder()
-                .name(TokenName::new("MID").unwrap())
-                .symbol(symbol)
-                .decimals(decimals)
-                .max_supply(max_supply)
-                .build()
-                .unwrap(),
-        )
-        .with_components(
-            TokenPolicyManager::new()
-                .with_mint_policy(MintPolicyConfig::AllowAll, PolicyRegistration::Active)
-                .unwrap()
-                .with_burn_policy(BurnPolicyConfig::AllowAll, PolicyRegistration::Active)
-                .unwrap(),
-        )
+    let faucet = FungibleFaucet::builder()
+        .name(TokenName::new("MID").unwrap())
+        .symbol(symbol)
+        .decimals(decimals)
+        .max_supply(max_supply)
         .build()
         .unwrap();
+    let policies = TokenPolicyManager::builder()
+        .active_mint_policy(MintPolicy::allow_all())
+        .active_burn_policy(BurnPolicy::allow_all())
+        .build();
+    let account = create_singlesig_user_fungible_faucet(
+        init_seed,
+        faucet,
+        AuthSingleSig::from_public_key(key_pair.public_key()),
+        policies,
+        AccountType::Public,
+    )
+    .unwrap();
 
     client.add_account(&account, false).await?;
     keystore.add_key(&key_pair, account.id()).await.unwrap();
@@ -95,21 +94,29 @@ async fn wait_for_notes(
     client: &mut Client<FilesystemKeyStore>,
     account_id: &Account,
     expected: usize,
+    network_id: NetworkId,
 ) -> Result<(), ClientError> {
-    loop {
+    for _ in 0..24 {
         client.sync_state().await?;
-        let notes = client.get_consumable_notes(Some(account_id.id())).await?;
+        let notes = client
+            .get_consumable_tutorial_notes(Some(account_id.id()))
+            .await?;
         if notes.len() >= expected {
-            break;
+            return Ok(());
         }
         println!(
             "{} consumable notes found for account {}. Waiting...",
             notes.len(),
-            account_id.id().to_bech32(NetworkId::Testnet)
+            account_id.id().to_bech32(network_id.clone())
         );
         sleep(Duration::from_secs(3)).await;
     }
-    Ok(())
+    Err(ClientError::Observer(Box::new(std::io::Error::other(
+        format!(
+            "timed out waiting for {expected} tutorial notes for {}",
+            account_id.id()
+        ),
+    ))))
 }
 
 /// Waits for a specific transaction to be committed.
@@ -117,39 +124,18 @@ async fn wait_for_tx(
     client: &mut Client<FilesystemKeyStore>,
     tx_id: TransactionId,
 ) -> Result<(), ClientError> {
-    loop {
-        client.sync_state().await?;
-
-        // Check transaction status
-        let txs = client
-            .get_transactions(TransactionFilter::Ids(vec![tx_id]))
-            .await?;
-        let tx_committed = if !txs.is_empty() {
-            matches!(txs[0].status, TransactionStatus::Committed { .. })
-        } else {
-            false
-        };
-
-        if tx_committed {
-            println!("✅ transaction {} committed", tx_id.to_hex());
-            break;
-        }
-
-        println!(
-            "Transaction {} not yet committed. Waiting...",
-            tx_id.to_hex()
-        );
-        sleep(Duration::from_secs(2)).await;
-    }
-    Ok(())
+    rust_client::wait_for_transaction(client, tx_id).await
 }
 
 #[tokio::main]
 async fn main() -> Result<(), ClientError> {
     // Initialize client
-    let endpoint = Endpoint::testnet();
+    let network = TutorialNetwork::from_env()?;
+    let endpoint = network.endpoint();
     let timeout_ms = 10_000;
-    let rpc_client = Arc::new(GrpcClient::new(&endpoint, timeout_ms));
+    let rpc_client = Arc::new(VerifyingRpcClient::new(GrpcClient::new(
+        &endpoint, timeout_ms,
+    )));
 
     // Initialize keystore
     let keystore_path = PathBuf::from("./keystore");
@@ -161,12 +147,12 @@ async fn main() -> Result<(), ClientError> {
         .rpc(rpc_client)
         .sqlite_store(store_path)
         .authenticator(keystore.clone())
-        .in_debug_mode(true.into())
         .build()
         .await?;
 
     let sync_summary = client.sync_state().await.unwrap();
     println!("Latest block: {}", sync_summary.block_num);
+    let fee_config = FeeConfig::from_client(&client, network).await?;
 
     // -------------------------------------------------------------------------
     // STEP 1: Create accounts and deploy faucet
@@ -175,20 +161,23 @@ async fn main() -> Result<(), ClientError> {
     let alice_account = create_basic_account(&mut client, &keystore).await?;
     println!(
         "Alice's account ID: {:?}",
-        alice_account.id().to_bech32(NetworkId::Testnet)
+        alice_account.id().to_bech32(network.network_id())
     );
     let bob_account = create_basic_account(&mut client, &keystore).await?;
     println!(
         "Bob's account ID: {:?}",
-        bob_account.id().to_bech32(NetworkId::Testnet)
+        bob_account.id().to_bech32(network.network_id())
     );
 
     println!("\nDeploying a new fungible faucet.");
     let faucet = create_basic_faucet(&mut client, &keystore).await?;
     println!(
         "Faucet account ID: {:?}",
-        faucet.id().to_bech32(NetworkId::Testnet)
+        faucet.id().to_bech32(network.network_id())
     );
+    for account_id in [alice_account.id(), bob_account.id(), faucet.id()] {
+        fund_account_for_fees(&mut client, account_id, &fee_config).await?;
+    }
     client.sync_state().await?;
 
     // -------------------------------------------------------------------------
@@ -208,14 +197,16 @@ async fn main() -> Result<(), ClientError> {
         )
         .unwrap();
 
-    let tx_id = client.submit_new_transaction(faucet.id(), tx_req).await?;
+    let tx_id = client
+        .submit_tutorial_transaction(faucet.id(), tx_req)
+        .await?;
     println!("Minted tokens. TX: {:?}", tx_id);
 
-    wait_for_notes(&mut client, &alice_account, 1).await?;
+    wait_for_notes(&mut client, &alice_account, 1, network.network_id()).await?;
 
     // Consume the minted note
     let consumable_notes = client
-        .get_consumable_notes(Some(alice_account.id()))
+        .get_consumable_tutorial_notes(Some(alice_account.id()))
         .await?;
 
     if let Some((note_record, _)) = consumable_notes.first() {
@@ -223,7 +214,7 @@ async fn main() -> Result<(), ClientError> {
         let consume_req = TransactionRequestBuilder::new().build_consume_notes(vec![note])?;
 
         let tx_id = client
-            .submit_new_transaction(alice_account.id(), consume_req)
+            .submit_tutorial_transaction(alice_account.id(), consume_req)
             .await?;
         println!("Consumed minted note. TX: {:?}", tx_id);
     }
@@ -262,10 +253,11 @@ async fn main() -> Result<(), ClientError> {
         .unwrap();
 
     let tx_id = client
-        .submit_new_transaction(alice_account.id(), note_req)
+        .submit_tutorial_transaction(alice_account.id(), note_req)
         .await?;
     println!(
-        "View transaction on MidenScan: https://testnet.midenscan.com/tx/{:?}",
+        "View transaction on MidenScan: {}/tx/{:?}",
+        network.explorer_url(),
         tx_id
     );
 
@@ -307,14 +299,40 @@ async fn main() -> Result<(), ClientError> {
         .unwrap();
 
     let tx_id = client
-        .submit_new_transaction(bob_account.id(), consume_custom_req)
+        .submit_tutorial_transaction(bob_account.id(), consume_custom_req)
         .await?;
     println!(
-        "Consumed Note Tx on MidenScan: https://testnet.midenscan.com/tx/{:?}",
+        "Consumed Note Tx on MidenScan: {}/tx/{:?}",
+        network.explorer_url(),
         tx_id
     );
 
     wait_for_tx(&mut client, tx_id).await?;
+
+    // The SDK verifies expected recipients; also check the actual successor's assets and metadata.
+    let successor = client
+        .get_output_note(output_note.id())
+        .await?
+        .expect("the transaction must create the expected successor note");
+    assert!(successor.is_committed(), "the successor must be committed");
+    assert_eq!(successor.assets(), output_note.assets());
+    assert_eq!(successor.metadata(), output_note.metadata());
+    println!(
+        "Successor note committed with 50 tokens: {}",
+        successor.id()
+    );
+
+    let bob = client
+        .get_account(bob_account.id())
+        .await?
+        .expect("Bob's account must exist after consuming the note");
+    let balance = bob.vault().get_balance(AssetId::new_fungible(faucet_id))?;
+    assert_eq!(
+        balance.as_u64(),
+        50,
+        "Bob must retain the other half of the note's tokens",
+    );
+    println!("Bob's retained token balance: {balance}");
 
     Ok(())
 }

--- a/rust-client/src/bin/oracle_data_query.rs
+++ b/rust-client/src/bin/oracle_data_query.rs
@@ -1,24 +1,22 @@
 use miden_client::{
     account::{
-        component::AccountComponentMetadata, AccountBuilder, AccountComponent, AccountId,
-        AccountType, StorageMapKey, StorageSlot, StorageSlotName,
+        component::{AccountComponentMetadata, BasicWallet},
+        AccountBuilder, AccountComponent, AccountId, AccountType, StorageMapKey, StorageSlot,
+        StorageSlotName,
     },
-    assembly::{
-        CodeBuilder, DefaultSourceManager, Module, ModuleKind, Path as AssemblyPath,
-    },
+    assembly::CodeBuilder,
     auth::NoAuth,
     builder::ClientBuilder,
     keystore::FilesystemKeyStore,
-    rpc::{
-        domain::account::AccountStorageRequirements,
-        Endpoint, GrpcClient,
-    },
-    transaction::{ForeignAccount, TransactionKernel, TransactionRequestBuilder},
+    rpc::{domain::account::AccountStorageRequirements, GrpcClient, VerifyingRpcClient},
+    transaction::{ForeignAccount, TransactionRequestBuilder},
     Client, ClientError, Felt, Word, ZERO,
 };
 use miden_client_sqlite_store::ClientBuilderSqliteExt;
-use rand::RngCore;
-use std::{fs, path::Path, sync::Arc};
+use rand::Rng;
+use rust_client::TutorialClientExt;
+use rust_client::{fund_account_for_fees, FeeConfig, TutorialNetwork};
+use std::sync::Arc;
 
 /// Import the oracle + its publishers and return the ForeignAccount list
 /// Due to Pragma's decentralized oracle architecture, we need to get the
@@ -53,7 +51,7 @@ pub async fn get_oracle_foreign_accounts(
         StorageSlotName::new("pragma::oracle::publishers").expect("valid slot name");
     let publisher_ids: Vec<AccountId> = (2..next_publisher_index)
         .map(|index| {
-            let key: Word = [Felt::new_unchecked(index), ZERO, ZERO, ZERO].into();
+            let key = StorageMapKey::new([Felt::new_unchecked(index), ZERO, ZERO, ZERO].into());
             let publisher_word = storage
                 .get_map_item(&publishers_slot, key)
                 .expect("publisher entry missing from oracle storage");
@@ -64,8 +62,7 @@ pub async fn get_oracle_foreign_accounts(
 
     // Each publisher exposes its price entries in the `entries` map, keyed by
     // the faucet ID word of the trading pair.
-    let entries_slot =
-        StorageSlotName::new("pragma::publisher::entries").expect("valid slot name");
+    let entries_slot = StorageSlotName::new("pragma::publisher::entries").expect("valid slot name");
     let mut foreign_accounts = Vec::with_capacity(publisher_ids.len() + 1);
 
     for publisher_id in publisher_ids {
@@ -95,29 +92,17 @@ pub async fn get_oracle_foreign_accounts(
     Ok(foreign_accounts)
 }
 
-fn create_library(
-    library_path: &str,
-    source_code: &str,
-) -> Result<Arc<miden_client::assembly::Library>, Box<dyn std::error::Error>> {
-    let source_manager = Arc::new(DefaultSourceManager::default());
-    let assembler = TransactionKernel::assembler_with_source_manager(source_manager.clone());
-    let module = Module::parser(ModuleKind::Library).parse_str(
-        AssemblyPath::new(library_path),
-        source_code,
-        source_manager,
-    )?;
-    let library = assembler.assemble_library([module])?;
-    Ok(library)
-}
-
 #[tokio::main]
 async fn main() -> Result<(), ClientError> {
     // -------------------------------------------------------------------------
     // Initialize Client
     // -------------------------------------------------------------------------
-    let endpoint = Endpoint::testnet();
+    let network = TutorialNetwork::from_env()?;
+    let endpoint = network.endpoint();
     let timeout_ms = 10_000;
-    let rpc_client = Arc::new(GrpcClient::new(&endpoint, timeout_ms));
+    let rpc_client = Arc::new(VerifyingRpcClient::new(GrpcClient::new(
+        &endpoint, timeout_ms,
+    )));
 
     let keystore_path = std::path::PathBuf::from("./keystore");
     let keystore = Arc::new(FilesystemKeyStore::new(keystore_path).unwrap());
@@ -128,30 +113,55 @@ async fn main() -> Result<(), ClientError> {
         .rpc(rpc_client)
         .sqlite_store(store_path)
         .authenticator(keystore.clone())
-        .in_debug_mode(true.into())
         .build()
         .await?;
 
     println!("Latest block: {}", client.sync_state().await?.block_num);
+    let fee_config = FeeConfig::from_client(&client, network).await?;
 
     // -------------------------------------------------------------------------
     // Get all foreign accounts for oracle data
     // -------------------------------------------------------------------------
-    // Defaults to Pragma's current Miden v0.15 testnet oracle; pass a different
-    // bech32 id as the first CLI argument to point at another deployment. Pragma's
-    // addresses change between testnet iterations, so check their README
-    // (https://github.com/astraly-labs/pragma-miden) if this feed stops resolving.
+    // Pass a compatible oracle account ID and its `get_median` procedure root as CLI
+    // arguments (or through the matching environment variables). This tutorial remains skipped
+    // by the runner until Pragma publishes a deployment for the current protocol release.
     let oracle_bech32 = std::env::args()
         .nth(1)
-        .unwrap_or_else(|| "mtst1apadf2szkxqkcyt7x2znuggv9qkhccam".to_string());
-    let (_, oracle_account_id) = AccountId::from_bech32(&oracle_bech32).unwrap();
+        .or_else(|| std::env::var("MIDEN_ORACLE_ACCOUNT_ID").ok())
+        .ok_or_else(|| ClientError::Observer(Box::new(std::io::Error::other(
+            "Oracle deployment is required: set MIDEN_ORACLE_ACCOUNT_ID and MIDEN_ORACLE_GET_MEDIAN_ROOT for the selected network. Use a compatible v0.16 deployment on the selected network.",
+        ))))?;
+    let get_median_proc_root = std::env::args()
+        .nth(2)
+        .or_else(|| std::env::var("MIDEN_ORACLE_GET_MEDIAN_ROOT").ok())
+        .ok_or_else(|| {
+            ClientError::Observer(Box::new(std::io::Error::other(
+            "Set MIDEN_ORACLE_GET_MEDIAN_ROOT to the deployed oracle's get_median procedure root",
+        )))
+        })?;
+    let (account_network, oracle_account_id) = AccountId::from_bech32(&oracle_bech32).unwrap();
+    assert_eq!(
+        account_network,
+        network.network_id(),
+        "oracle account must match the selected tutorial network"
+    );
 
-    // BTC/USD is identified by the faucet ID pair `1:0` (prefix 1, suffix 0).
+    // BTC/USD was identified by the faucet ID pair `1:0` in the previous deployment. Override
+    // either value with the optional third and fourth CLI arguments for the selected deployment.
     // The faucet ID word is laid out as [0, 0, suffix, prefix].
-    let pair_prefix: u64 = 1;
-    let pair_suffix: u64 = 0;
-    let btc_usd_pair: Word =
-        [ZERO, ZERO, Felt::new_unchecked(pair_suffix), Felt::new_unchecked(pair_prefix)].into();
+    let pair_prefix: u64 = std::env::args()
+        .nth(3)
+        .map_or(1, |value| value.parse().expect("pair prefix must be a u64"));
+    let pair_suffix: u64 = std::env::args()
+        .nth(4)
+        .map_or(0, |value| value.parse().expect("pair suffix must be a u64"));
+    let btc_usd_pair: Word = [
+        ZERO,
+        ZERO,
+        Felt::new_unchecked(pair_suffix),
+        Felt::new_unchecked(pair_prefix),
+    ]
+    .into();
     let foreign_accounts: Vec<ForeignAccount> =
         get_oracle_foreign_accounts(&mut client, oracle_account_id, btc_usd_pair).await?;
 
@@ -164,8 +174,18 @@ async fn main() -> Result<(), ClientError> {
     // -------------------------------------------------------------------------
     // Create Oracle Reader contract
     // -------------------------------------------------------------------------
-    let contract_code =
-        fs::read_to_string(Path::new("../masm/accounts/oracle_reader.masm")).unwrap();
+    let contract_code = include_str!("../../../masm/accounts/oracle_reader.masm")
+        .replace("{get_median_proc_root}", &get_median_proc_root)
+        .replace(
+            "{oracle_id_prefix}",
+            &oracle_account_id.prefix().to_string(),
+        )
+        .replace(
+            "{oracle_id_suffix}",
+            &oracle_account_id.suffix().to_string(),
+        )
+        .replace("{pair_prefix}", &pair_prefix.to_string())
+        .replace("{pair_suffix}", &pair_suffix.to_string());
 
     let contract_slot_name =
         StorageSlotName::new("miden::tutorials::oracle_reader").expect("valid slot name");
@@ -188,7 +208,8 @@ async fn main() -> Result<(), ClientError> {
     let oracle_reader_contract = AccountBuilder::new(seed)
         .account_type(AccountType::Public)
         .with_component(contract_component.clone())
-        .with_auth_component(NoAuth)
+        .with_component(BasicWallet)
+        .with_component(NoAuth)
         .build()
         .unwrap();
 
@@ -196,22 +217,18 @@ async fn main() -> Result<(), ClientError> {
         .add_account(&oracle_reader_contract, false)
         .await
         .unwrap();
+    fund_account_for_fees(&mut client, oracle_reader_contract.id(), &fee_config).await?;
 
     // -------------------------------------------------------------------------
     // Build the script that calls our `get_price` procedure
     // -------------------------------------------------------------------------
-    let script_path = Path::new("../masm/scripts/oracle_reader_script.masm");
-    let script_code = fs::read_to_string(script_path).unwrap();
-
-    let library_path = "external_contract::oracle_reader";
-    let account_component_lib =
-        create_library(library_path, &contract_code).unwrap();
+    let script_code = include_str!("../../../masm/scripts/oracle_reader_script.masm");
 
     let tx_script = client
         .code_builder()
-        .with_dynamically_linked_library(&account_component_lib)
+        .with_linked_module("external_contract::oracle_reader", &contract_code)
         .unwrap()
-        .compile_tx_script(&script_code)
+        .compile_tx_script(script_code)
         .unwrap();
 
     let tx_increment_request = TransactionRequestBuilder::new()
@@ -221,12 +238,13 @@ async fn main() -> Result<(), ClientError> {
         .unwrap();
 
     let tx_id = client
-        .submit_new_transaction(oracle_reader_contract.id(), tx_increment_request)
+        .submit_tutorial_transaction(oracle_reader_contract.id(), tx_increment_request)
         .await
         .unwrap();
 
     println!(
-        "View transaction on MidenScan: https://testnet.midenscan.com/tx/{:?}",
+        "View transaction on MidenScan: {}/tx/{:?}",
+        network.explorer_url(),
         tx_id
     );
 

--- a/rust-client/src/bin/unauthenticated_note_transfer.rs
+++ b/rust-client/src/bin/unauthenticated_note_transfer.rs
@@ -1,67 +1,46 @@
-use rand::RngCore;
+use rand::Rng;
+use rust_client::TutorialClientExt;
 use std::{path::PathBuf, sync::Arc};
-use tokio::time::{sleep, Duration, Instant};
+use tokio::time::{Duration, Instant};
 
 use miden_client::{
     account::{
         component::{
-            BasicWallet, BurnPolicyConfig, FungibleFaucet, MintPolicyConfig, PolicyRegistration,
-            TokenName, TokenPolicyManager,
+            create_singlesig_user_fungible_faucet, BasicWallet, BurnPolicy, FungibleFaucet,
+            MintPolicy, TokenName, TokenPolicyManager,
         },
         AccountBuilder, AccountType,
     },
-    address::NetworkId,
-    asset::{AssetAmount, AssetCallbackFlag, AssetVaultKey, FungibleAsset, TokenSymbol},
-    auth::{AuthSchemeId, AuthSecretKey, AuthSingleSig},
+    asset::{AssetAmount, AssetId, FungibleAsset, TokenSymbol},
+    auth::{AuthSecretKey, AuthSingleSig},
     builder::ClientBuilder,
     keystore::{FilesystemKeyStore, Keystore},
-    note::{Note, NoteAttachments, NoteType, P2idNote},
-    rpc::{Endpoint, GrpcClient},
-    store::TransactionFilter,
-    transaction::{TransactionId, TransactionRequestBuilder, TransactionStatus},
+    note::{Note, NoteType, P2idNote},
+    rpc::{GrpcClient, VerifyingRpcClient},
+    transaction::{TransactionId, TransactionRequestBuilder},
     utils::{Deserializable, Serializable},
     Client, ClientError,
 };
 use miden_client_sqlite_store::ClientBuilderSqliteExt;
+use rust_client::{fund_account_for_fees, FeeConfig, TutorialNetwork};
 
 /// Waits for a specific transaction to be committed.
 async fn wait_for_tx(
     client: &mut Client<FilesystemKeyStore>,
     tx_id: TransactionId,
 ) -> Result<(), ClientError> {
-    loop {
-        client.sync_state().await?;
-
-        // Check transaction status
-        let txs = client
-            .get_transactions(TransactionFilter::Ids(vec![tx_id]))
-            .await?;
-        let tx_committed = if !txs.is_empty() {
-            matches!(txs[0].status, TransactionStatus::Committed { .. })
-        } else {
-            false
-        };
-
-        if tx_committed {
-            println!("✅ transaction {} committed", tx_id.to_hex());
-            break;
-        }
-
-        println!(
-            "Transaction {} not yet committed. Waiting...",
-            tx_id.to_hex()
-        );
-        sleep(Duration::from_secs(2)).await;
-    }
-    Ok(())
+    rust_client::wait_for_transaction(client, tx_id).await
 }
 
 #[tokio::main]
 async fn main() -> Result<(), ClientError> {
     // Initialize client
-    let endpoint = Endpoint::testnet();
+    let network = TutorialNetwork::from_env()?;
+    let endpoint = network.endpoint();
     let timeout_ms = 10_000;
-    let rpc_client = Arc::new(GrpcClient::new(&endpoint, timeout_ms));
+    let rpc_client = Arc::new(VerifyingRpcClient::new(GrpcClient::new(
+        &endpoint, timeout_ms,
+    )));
 
     // Initialize keystore
     let keystore_path = PathBuf::from("./keystore");
@@ -73,12 +52,12 @@ async fn main() -> Result<(), ClientError> {
         .rpc(rpc_client)
         .sqlite_store(store_path)
         .authenticator(keystore.clone())
-        .in_debug_mode(true.into())
         .build()
         .await?;
 
     let sync_summary = client.sync_state().await.unwrap();
     println!("Latest block: {}", sync_summary.block_num);
+    let fee_config = FeeConfig::from_client(&client, network).await?;
 
     //------------------------------------------------------------
     // STEP 1: Deploy a fungible faucet
@@ -98,38 +77,40 @@ async fn main() -> Result<(), ClientError> {
     let max_supply = AssetAmount::new(1_000_000).unwrap();
 
     // Build the account
-    let faucet_account = AccountBuilder::new(init_seed)
-        .account_type(AccountType::Public)
-        .with_auth_component(AuthSingleSig::new(key_pair.public_key().to_commitment(), AuthSchemeId::Falcon512Poseidon2))
-        .with_component(
-            FungibleFaucet::builder()
-                .name(TokenName::new("MID").unwrap())
-                .symbol(symbol)
-                .decimals(decimals)
-                .max_supply(max_supply)
-                .build()
-                .unwrap(),
-        )
-        .with_components(
-            TokenPolicyManager::new()
-                .with_mint_policy(MintPolicyConfig::AllowAll, PolicyRegistration::Active)
-                .unwrap()
-                .with_burn_policy(BurnPolicyConfig::AllowAll, PolicyRegistration::Active)
-                .unwrap(),
-        )
+    let faucet = FungibleFaucet::builder()
+        .name(TokenName::new("MID").unwrap())
+        .symbol(symbol)
+        .decimals(decimals)
+        .max_supply(max_supply)
         .build()
         .unwrap();
+    let policies = TokenPolicyManager::builder()
+        .active_mint_policy(MintPolicy::allow_all())
+        .active_burn_policy(BurnPolicy::allow_all())
+        .build();
+    let faucet_account = create_singlesig_user_fungible_faucet(
+        init_seed,
+        faucet,
+        AuthSingleSig::from_public_key(key_pair.public_key()),
+        policies,
+        AccountType::Public,
+    )
+    .unwrap();
 
     // Add the faucet to the client
     client.add_account(&faucet_account, false).await?;
 
     println!(
         "Faucet account ID: {}",
-        faucet_account.id().to_bech32(NetworkId::Testnet)
+        faucet_account.id().to_bech32(network.network_id())
     );
 
     // Add the key pair to the keystore
-    keystore.add_key(&key_pair, faucet_account.id()).await.unwrap();
+    keystore
+        .add_key(&key_pair, faucet_account.id())
+        .await
+        .unwrap();
+    fund_account_for_fees(&mut client, faucet_account.id(), &fee_config).await?;
 
     // Resync to show newly deployed faucet
     tokio::time::sleep(Duration::from_secs(2)).await;
@@ -151,7 +132,7 @@ async fn main() -> Result<(), ClientError> {
 
         let account = AccountBuilder::new(init_seed)
             .account_type(AccountType::Public)
-            .with_auth_component(AuthSingleSig::new(key_pair.public_key().to_commitment(), AuthSchemeId::Falcon512Poseidon2))
+            .with_component(AuthSingleSig::from_public_key(key_pair.public_key()))
             .with_component(BasicWallet)
             .build()
             .unwrap();
@@ -160,12 +141,13 @@ async fn main() -> Result<(), ClientError> {
         println!(
             "account id {:?}: {}",
             i,
-            account.id().to_bech32(NetworkId::Testnet)
+            account.id().to_bech32(network.network_id())
         );
         client.add_account(&account, true).await?;
 
         // Add the key pair to the keystore
         keystore.add_key(&key_pair, account.id()).await.unwrap();
+        fund_account_for_fees(&mut client, account.id(), &fee_config).await?;
     }
 
     // For demo purposes, Alice is the first account.
@@ -188,7 +170,7 @@ async fn main() -> Result<(), ClientError> {
         .unwrap();
 
     let tx_id = client
-        .submit_new_transaction(faucet_account.id(), transaction_request)
+        .submit_tutorial_transaction(faucet_account.id(), transaction_request)
         .await?;
     println!("Minted tokens. TX: {:?}", tx_id);
 
@@ -196,7 +178,9 @@ async fn main() -> Result<(), ClientError> {
     wait_for_tx(&mut client, tx_id).await?;
 
     // Get the minted note and consume it
-    let consumable_notes = client.get_consumable_notes(Some(alice.id())).await?;
+    let consumable_notes = client
+        .get_consumable_tutorial_notes(Some(alice.id()))
+        .await?;
 
     if let Some((note_record, _)) = consumable_notes.first() {
         let note: Note = note_record.clone().try_into()?;
@@ -204,7 +188,7 @@ async fn main() -> Result<(), ClientError> {
             TransactionRequestBuilder::new().build_consume_notes(vec![note])?;
 
         let consume_tx_id = client
-            .submit_new_transaction(alice.id(), transaction_request)
+            .submit_tutorial_transaction(alice.id(), transaction_request)
             .await?;
         println!("Consumed minted note. TX: {:?}", consume_tx_id);
 
@@ -221,10 +205,13 @@ async fn main() -> Result<(), ClientError> {
     for i in 0..number_of_accounts - 1 {
         let loop_start = Instant::now();
         println!("\nunauthenticated tx {:?}", i + 1);
-        println!("sender: {}", accounts[i].id().to_bech32(NetworkId::Testnet));
+        println!(
+            "sender: {}",
+            accounts[i].id().to_bech32(network.network_id())
+        );
         println!(
             "target: {}",
-            accounts[i + 1].id().to_bech32(NetworkId::Testnet)
+            accounts[i + 1].id().to_bech32(network.network_id())
         );
 
         // Time the creation of the p2id note
@@ -239,15 +226,15 @@ async fn main() -> Result<(), ClientError> {
             NoteType::Public
         };
 
-        let p2id_note = P2idNote::create(
-            accounts[i].id(),
-            accounts[i + 1].id(),
-            vec![fungible_asset_send_amount.into()],
-            note_type,
-            NoteAttachments::empty(),
-            client.rng(),
-        )
-        .unwrap();
+        let p2id_note: Note = P2idNote::builder()
+            .sender(accounts[i].id())
+            .target(accounts[i + 1].id())
+            .asset(fungible_asset_send_amount)
+            .note_type(note_type)
+            .generate_serial_number(client.rng())
+            .build()
+            .unwrap()
+            .into();
 
         let output_note = p2id_note.clone();
 
@@ -257,10 +244,12 @@ async fn main() -> Result<(), ClientError> {
             .build()
             .unwrap();
 
-        let tx_id = client
+        // Do not wait for inclusion: the receiver is given the complete note below.
+        client.sync_state().await?;
+        let send_tx_id = client
             .submit_new_transaction(accounts[i].id(), transaction_request)
             .await?;
-        println!("Created note. TX: {:?}", tx_id);
+        println!("Created note. TX: {:?}", send_tx_id);
 
         // Note serialization/deserialization
         // This demonstrates how you could send the serialized note to another client instance
@@ -268,17 +257,17 @@ async fn main() -> Result<(), ClientError> {
         let deserialized_p2id_note = Note::read_from_bytes(&serialized).unwrap();
 
         // Time consume note request building
-        let consume_note_request = TransactionRequestBuilder::new()
-            .input_notes([(deserialized_p2id_note, None)])
-            .build()
-            .unwrap();
+        let consume_note_request =
+            TransactionRequestBuilder::new().build_consume_notes(vec![deserialized_p2id_note])?;
 
         let tx_id = client
-            .submit_new_transaction(accounts[i + 1].id(), consume_note_request)
+            .submit_tutorial_transaction(accounts[i + 1].id(), consume_note_request)
             .await?;
+        rust_client::wait_for_transaction(&mut client, send_tx_id).await?;
 
         println!(
-            "Consumed Note Tx on MidenScan: https://testnet.midenscan.com/tx/{:?}",
+            "Consumed Note Tx on MidenScan: {}/tx/{:?}",
+            network.explorer_url(),
             tx_id
         );
         println!(
@@ -296,19 +285,28 @@ async fn main() -> Result<(), ClientError> {
     // Final resync and display account balances
     tokio::time::sleep(Duration::from_secs(3)).await;
     client.sync_state().await?;
-    for account in accounts.clone() {
+    for (index, account) in accounts.iter().enumerate() {
         let new_account = client.get_account(account.id()).await.unwrap().unwrap();
         let balance = new_account
             .vault()
-            .get_balance(AssetVaultKey::new_fungible(
-                faucet_account.id(),
-                AssetCallbackFlag::Disabled,
-            ))
+            .get_balance(AssetId::new_fungible(faucet_account.id()))
             .unwrap();
         println!(
             "Account: {} balance: {}",
-            account.id().to_bech32(NetworkId::Testnet),
+            account.id().to_bech32(network.network_id()),
             balance
+        );
+        let expected = if index == 0 {
+            80
+        } else if index == accounts.len() - 1 {
+            20
+        } else {
+            0
+        };
+        assert_eq!(
+            balance.as_u64(),
+            expected,
+            "unexpected transfer-chain balance"
         );
     }
 

--- a/rust-client/src/lib.rs
+++ b/rust-client/src/lib.rs
@@ -1,0 +1,547 @@
+//! Shared network and transaction-fee setup used by the executable tutorials.
+
+use std::{env, fmt::Display, time::Duration};
+
+use miden_client::{
+    account::{AccountId, Address},
+    address::{AddressId, NetworkId},
+    note::{Note, NoteConsumability, NoteId, TxFeeNote},
+    rpc::Endpoint,
+    store::{InputNoteRecord, TransactionFilter},
+    transaction::{
+        TransactionAuthenticator, TransactionId, TransactionRequest, TransactionRequestBuilder,
+        TransactionStatus,
+    },
+    Client, ClientError,
+};
+use serde::Deserialize;
+use sha2::{Digest, Sha256};
+
+// Allow for asynchronous network-note execution, but never poll indefinitely.
+const DEFAULT_SYNC_RETRIES: u32 = 24;
+const SYNC_RETRY_DELAY: Duration = Duration::from_secs(5);
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Fee-aware execution safeguards shared by the runnable examples.
+#[allow(async_fn_in_trait)]
+pub trait TutorialClientExt {
+    /// Refreshes the reference block, submits the transaction and verifies commitment.
+    async fn submit_tutorial_transaction(
+        &mut self,
+        account_id: AccountId,
+        request: TransactionRequest,
+    ) -> Result<TransactionId, ClientError>;
+    /// Excludes TX_FEE notes, which are consumable but are not tutorial transfers.
+    async fn get_consumable_tutorial_notes(
+        &self,
+        account_id: Option<AccountId>,
+    ) -> Result<Vec<(InputNoteRecord, Vec<NoteConsumability>)>, ClientError>;
+}
+
+impl<AUTH: TransactionAuthenticator + Sync + 'static> TutorialClientExt for Client<AUTH> {
+    async fn submit_tutorial_transaction(
+        &mut self,
+        account_id: AccountId,
+        request: TransactionRequest,
+    ) -> Result<TransactionId, ClientError> {
+        self.sync_state().await?;
+        let tx_id = self.submit_new_transaction(account_id, request).await?;
+        wait_for_transaction(self, tx_id).await?;
+        Ok(tx_id)
+    }
+
+    async fn get_consumable_tutorial_notes(
+        &self,
+        account_id: Option<AccountId>,
+    ) -> Result<Vec<(InputNoteRecord, Vec<NoteConsumability>)>, ClientError> {
+        let mut notes = self.get_consumable_notes(account_id).await?;
+        notes.retain(|(note, _)| is_tutorial_note_script(note.details().script().root()));
+        Ok(notes)
+    }
+}
+
+fn is_tutorial_note_script(root: miden_client::note::NoteScriptRoot) -> bool {
+    root != TxFeeNote::script_root()
+}
+
+/// Waits for actual on-chain commitment, failing with the transaction ID on timeout.
+pub async fn wait_for_transaction<AUTH: TransactionAuthenticator + Sync + 'static>(
+    client: &mut Client<AUTH>,
+    tx_id: TransactionId,
+) -> Result<(), ClientError> {
+    let retries = env_u32("MIDEN_TX_SYNC_RETRIES", DEFAULT_SYNC_RETRIES)?;
+    for attempt in 0..retries {
+        client.sync_state().await?;
+        let records = client
+            .get_transactions(TransactionFilter::Ids(vec![tx_id]))
+            .await?;
+        if let Some(record) = records.first() {
+            if matches!(record.status, TransactionStatus::Committed { .. }) {
+                println!("Transaction committed: {tx_id}");
+                return Ok(());
+            }
+            if let TransactionStatus::Discarded(cause) = &record.status {
+                return Err(tutorial_error(format!(
+                    "transaction {tx_id} was discarded: {cause}"
+                )));
+            }
+        }
+        if attempt + 1 < retries {
+            tokio::time::sleep(SYNC_RETRY_DELAY).await;
+        }
+    }
+    Err(tutorial_error(format!(
+        "transaction {tx_id} was not committed after {retries} sync attempts"
+    )))
+}
+
+/// Fetches exactly the notes created by the example, not unrelated or TX_FEE notes.
+pub async fn wait_for_notes_by_id<AUTH: TransactionAuthenticator + Sync + 'static>(
+    client: &mut Client<AUTH>,
+    ids: &[NoteId],
+) -> Result<Vec<Note>, ClientError> {
+    for attempt in 0..DEFAULT_SYNC_RETRIES {
+        client.sync_state().await?;
+        let mut notes = Vec::new();
+        for id in ids {
+            if let Some(record) = client.get_input_note(*id).await? {
+                if record.is_committed() {
+                    notes.push(record.try_into()?);
+                }
+            }
+        }
+        if notes.len() == ids.len() {
+            return Ok(notes);
+        }
+        if attempt + 1 < DEFAULT_SYNC_RETRIES {
+            tokio::time::sleep(SYNC_RETRY_DELAY).await;
+        }
+    }
+    Err(tutorial_error(format!(
+        "expected notes were not committed within the timeout: {ids:?}"
+    )))
+}
+
+/// Network selected for a tutorial run.
+///
+/// `TUTORIAL_NETWORK` takes precedence over `MIDEN_NETWORK`; both accept `testnet` or `devnet`.
+/// When neither is set, tutorials use testnet.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TutorialNetwork {
+    Testnet,
+    Devnet,
+}
+
+impl TutorialNetwork {
+    pub fn from_env() -> Result<Self, ClientError> {
+        let value = env::var("TUTORIAL_NETWORK")
+            .or_else(|_| env::var("MIDEN_NETWORK"))
+            .unwrap_or_else(|_| "testnet".to_owned());
+
+        match value.to_ascii_lowercase().as_str() {
+            "testnet" => Ok(Self::Testnet),
+            "devnet" => Ok(Self::Devnet),
+            other => Err(tutorial_error(format!(
+                "unsupported tutorial network `{other}`; use `testnet` or `devnet`"
+            ))),
+        }
+    }
+
+    pub fn endpoint(self) -> Endpoint {
+        match self {
+            Self::Testnet => Endpoint::testnet(),
+            Self::Devnet => Endpoint::devnet(),
+        }
+    }
+
+    pub fn network_id(self) -> NetworkId {
+        match self {
+            Self::Testnet => NetworkId::Testnet,
+            Self::Devnet => NetworkId::Devnet,
+        }
+    }
+
+    pub fn explorer_url(self) -> &'static str {
+        match self {
+            Self::Testnet => "https://testnet.midenscan.com",
+            Self::Devnet => "https://devnet.midenscan.com",
+        }
+    }
+
+    pub fn remote_prover_url(self) -> &'static str {
+        match self {
+            Self::Testnet => "https://tx-prover.testnet.miden.io",
+            Self::Devnet => "https://tx-prover.devnet.miden.io",
+        }
+    }
+
+    fn faucet_url(self) -> &'static str {
+        match self {
+            Self::Testnet => "https://faucet-api.testnet.miden.io",
+            Self::Devnet => "https://faucet-api.devnet.miden.io",
+        }
+    }
+}
+
+/// Fee parameters read from the client's current reference block.
+#[derive(Debug, Clone, Copy)]
+pub struct FeeConfig {
+    network: TutorialNetwork,
+    fee_faucet_id: AccountId,
+    verification_base_fee: u32,
+}
+
+impl FeeConfig {
+    pub async fn from_client<AUTH>(
+        client: &Client<AUTH>,
+        network: TutorialNetwork,
+    ) -> Result<Self, ClientError> {
+        let header = client.get_latest_block_header().await?;
+        let parameters = header.fee_parameters();
+
+        Ok(Self {
+            network,
+            fee_faucet_id: parameters.fee_faucet_id(),
+            verification_base_fee: parameters.verification_base_fee(),
+        })
+    }
+
+    pub fn fees_are_active(&self) -> bool {
+        self.verification_base_fee != 0
+    }
+
+    pub fn native_fee_faucet_id(&self) -> AccountId {
+        self.fee_faucet_id
+    }
+}
+
+/// Funds a newly-created account with the native fee asset when the selected network charges fees.
+///
+/// The faucet creates a public P2ID note. This function waits until the note is committed, then
+/// consumes it as the account's first transaction. Accounts using this helper must expose
+/// `BasicWallet`, since P2ID moves its assets through `BasicWallet::receive_asset`.
+///
+/// Environment overrides:
+/// - `MIDEN_FAUCET_URL`: faucet REST API base URL.
+/// - `MIDEN_FAUCET_API_KEY`: optional faucet API key.
+/// - `MIDEN_FEE_AMOUNT`: native base units requested per account (defaults to the faucet's
+///   advertised base amount).
+/// - `MIDEN_FEE_SYNC_RETRIES`: number of five-second sync attempts (default 24).
+pub async fn fund_account_for_fees<AUTH>(
+    client: &mut Client<AUTH>,
+    account_id: AccountId,
+    fee_config: &FeeConfig,
+) -> Result<(), ClientError>
+where
+    AUTH: TransactionAuthenticator + Sync + 'static,
+{
+    if !fee_config.fees_are_active() {
+        return Ok(());
+    }
+
+    let requested_amount = env::var("MIDEN_FEE_AMOUNT")
+        .ok()
+        .map(|value| {
+            value.parse::<u64>().map_err(|error| {
+                tutorial_error(format!("invalid MIDEN_FEE_AMOUNT value `{value}`: {error}"))
+            })
+        })
+        .transpose()?;
+
+    let api_url =
+        env::var("MIDEN_FAUCET_URL").unwrap_or_else(|_| fee_config.network.faucet_url().to_owned());
+    let api_key = env::var("MIDEN_FAUCET_API_KEY").ok();
+
+    println!(
+        "Requesting native fee funding for {} from {api_url}",
+        account_id.to_hex()
+    );
+
+    let (note_id, faucet_transaction_id, amount) = request_fee_note(
+        &api_url,
+        api_key.as_deref(),
+        account_id,
+        requested_amount,
+        fee_config.fee_faucet_id,
+        fee_config.network.network_id(),
+    )
+    .await?;
+    println!(
+        "Faucet transaction {faucet_transaction_id} accepted; waiting for public note {} with {amount} native fee units",
+        note_id.to_hex()
+    );
+    let retries = env_u32("MIDEN_FEE_SYNC_RETRIES", DEFAULT_SYNC_RETRIES)?;
+    let note_id_hex = note_id.to_hex();
+
+    let mut note_record = None;
+    for attempt in 1..=retries {
+        client.sync_state().await?;
+        if let Some(record) = client.get_input_note(note_id).await? {
+            if record.is_committed() {
+                note_record = Some(record);
+                break;
+            }
+        }
+
+        if attempt < retries {
+            tokio::time::sleep(SYNC_RETRY_DELAY).await;
+        }
+    }
+
+    let note_record = note_record.ok_or_else(|| {
+        tutorial_error(format!(
+            "native fee note {note_id_hex} from faucet transaction {faucet_transaction_id} was not committed after {retries} sync attempts"
+        ))
+    })?;
+    let input_note = note_record.try_into()?;
+
+    let request = TransactionRequestBuilder::new().build_consume_notes(vec![input_note])?;
+    client.sync_state().await?;
+    let transaction_id = client.submit_new_transaction(account_id, request).await?;
+    println!("Native fee funding transaction submitted: {transaction_id:?}");
+
+    for attempt in 1..=retries {
+        client.sync_state().await?;
+        let transactions = client
+            .get_transactions(TransactionFilter::Ids(vec![transaction_id]))
+            .await?;
+        if let Some(transaction) = transactions.first() {
+            match &transaction.status {
+                TransactionStatus::Committed { .. } => {
+                    println!("Native fee funding transaction committed: {transaction_id:?}");
+                    return Ok(());
+                }
+                TransactionStatus::Discarded(cause) => {
+                    return Err(tutorial_error(format!(
+                        "native fee funding transaction {transaction_id:?} was discarded: {cause}"
+                    )));
+                }
+                TransactionStatus::Pending => {}
+            }
+        }
+
+        if attempt < retries {
+            tokio::time::sleep(SYNC_RETRY_DELAY).await;
+        }
+    }
+
+    return Err(tutorial_error(format!(
+        "native fee funding transaction {transaction_id:?} was not committed after {retries} sync attempts"
+    )));
+}
+
+#[derive(Debug, Deserialize)]
+struct PowResponse {
+    challenge: String,
+    target: u64,
+}
+
+#[derive(Debug, Deserialize)]
+struct MintResponse {
+    note_id: String,
+    tx_id: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct MetadataResponse {
+    id: String,
+    base_amount: u64,
+}
+
+async fn request_fee_note(
+    api_url: &str,
+    api_key: Option<&str>,
+    account_id: AccountId,
+    requested_amount: Option<u64>,
+    expected_faucet_id: AccountId,
+    expected_network_id: NetworkId,
+) -> Result<(NoteId, String, u64), ClientError> {
+    let http = reqwest::Client::builder()
+        .timeout(REQUEST_TIMEOUT)
+        .build()
+        .map_err(|error| tutorial_error(format!("failed to build faucet HTTP client: {error}")))?;
+    let base_url = reqwest::Url::parse(api_url)
+        .map_err(|error| tutorial_error(format!("invalid MIDEN_FAUCET_URL: {error}")))?;
+
+    let metadata_url = base_url
+        .join("get_metadata")
+        .map_err(|error| tutorial_error(format!("invalid faucet metadata URL: {error}")))?;
+    let response = http
+        .get(metadata_url)
+        .send()
+        .await
+        .map_err(|error| tutorial_error(format!("faucet metadata request failed: {error}")))?;
+    let response = checked_response(response, "metadata", api_url).await?;
+    let metadata: MetadataResponse = response.json().await.map_err(|error| {
+        tutorial_error(format!(
+            "failed to decode faucet metadata response: {error}"
+        ))
+    })?;
+    let (actual_network_id, address) = Address::decode(&metadata.id).map_err(|error| {
+        tutorial_error(format!(
+            "faucet metadata returned an invalid address `{}`: {error}",
+            metadata.id
+        ))
+    })?;
+    if actual_network_id != expected_network_id {
+        return Err(tutorial_error(format!(
+            "faucet {api_url} is for {actual_network_id:?}, but the tutorial is using {expected_network_id:?}"
+        )));
+    }
+    let actual_faucet_id = match address.id() {
+        AddressId::AccountId(account_id) => account_id,
+        _ => {
+            return Err(tutorial_error(format!(
+                "faucet metadata address `{}` is not account-based",
+                metadata.id
+            )));
+        }
+    };
+    if actual_faucet_id != expected_faucet_id {
+        return Err(tutorial_error(format!(
+            "faucet {api_url} issues asset {}, but the selected chain requires native fee asset {}",
+            actual_faucet_id.to_hex(),
+            expected_faucet_id.to_hex()
+        )));
+    }
+    let amount = requested_amount.unwrap_or(metadata.base_amount);
+    if amount == 0 {
+        return Err(tutorial_error(
+            "MIDEN_FEE_AMOUNT or the faucet's advertised base amount must be greater than zero",
+        ));
+    }
+
+    let mut pow_params = vec![
+        ("account_id", account_id.to_hex()),
+        ("amount", amount.to_string()),
+    ];
+    if let Some(api_key) = api_key {
+        pow_params.push(("api_key", api_key.to_owned()));
+    }
+
+    let pow_url = base_url
+        .join("pow")
+        .map_err(|error| tutorial_error(format!("invalid faucet PoW URL: {error}")))?;
+    let response = http
+        .get(pow_url)
+        .query(&pow_params)
+        .send()
+        .await
+        .map_err(|error| tutorial_error(format!("faucet PoW request failed: {error}")))?;
+    let response = checked_response(response, "PoW", api_url).await?;
+    let pow: PowResponse = response.json().await.map_err(|error| {
+        tutorial_error(format!("failed to decode faucet PoW response: {error}"))
+    })?;
+    let nonce = solve_pow(pow.challenge.clone(), pow.target).await?;
+
+    let mut mint_params = vec![
+        ("account_id", account_id.to_hex()),
+        ("is_private_note", "false".to_owned()),
+        ("asset_amount", amount.to_string()),
+        ("challenge", pow.challenge),
+        ("nonce", nonce.to_string()),
+    ];
+    if let Some(api_key) = api_key {
+        mint_params.push(("api_key", api_key.to_owned()));
+    }
+
+    let mint_url = base_url
+        .join("get_tokens")
+        .map_err(|error| tutorial_error(format!("invalid faucet mint URL: {error}")))?;
+    let response = http
+        .get(mint_url)
+        .query(&mint_params)
+        .send()
+        .await
+        .map_err(|error| tutorial_error(format!("faucet mint request failed: {error}")))?;
+    let response = checked_response(response, "mint", api_url).await?;
+    let mint: MintResponse = response.json().await.map_err(|error| {
+        tutorial_error(format!("failed to decode faucet mint response: {error}"))
+    })?;
+
+    let note_id = NoteId::try_from_hex(&mint.note_id)
+        .map_err(|error| tutorial_error(format!("faucet returned an invalid note ID: {error}")))?;
+    Ok((note_id, mint.tx_id, amount))
+}
+
+async fn checked_response(
+    response: reqwest::Response,
+    operation: &str,
+    api_url: &str,
+) -> Result<reqwest::Response, ClientError> {
+    if response.status().is_success() {
+        return Ok(response);
+    }
+
+    let status = response.status();
+    let body = response.text().await.unwrap_or_default();
+    Err(tutorial_error(format!(
+        "faucet {operation} request to {api_url} failed with {status}: {body}. Set \
+         MIDEN_FAUCET_URL to a fee-faucet API compatible with the selected network"
+    )))
+}
+
+async fn solve_pow(challenge_hex: String, target: u64) -> Result<u64, ClientError> {
+    if target == 0 {
+        return Err(tutorial_error("faucet returned a zero PoW target"));
+    }
+    let challenge = hex::decode(&challenge_hex).map_err(|error| {
+        tutorial_error(format!("faucet returned invalid challenge hex: {error}"))
+    })?;
+
+    tokio::task::spawn_blocking(move || {
+        for nonce in 0..=u64::MAX {
+            let mut hasher = Sha256::new();
+            hasher.update(&challenge);
+            hasher.update(nonce.to_be_bytes());
+            let digest = hasher.finalize();
+            let prefix = u64::from_be_bytes(digest[..8].try_into().expect("SHA-256 prefix"));
+            if prefix < target {
+                return nonce;
+            }
+        }
+        unreachable!("a valid u64 PoW nonce should exist")
+    })
+    .await
+    .map_err(|error| tutorial_error(format!("faucet PoW task failed: {error}")))
+}
+
+fn env_u32(name: &str, default: u32) -> Result<u32, ClientError> {
+    env::var(name).map_or(Ok(default), |value| {
+        value
+            .parse()
+            .map_err(|error| tutorial_error(format!("invalid {name} value `{value}`: {error}")))
+    })
+}
+
+fn tutorial_error(message: impl Display) -> ClientError {
+    ClientError::Observer(Box::new(std::io::Error::other(message.to_string())))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use miden_client::note::P2idNote;
+
+    #[test]
+    fn fee_notes_do_not_count_as_tutorial_transfers() {
+        assert!(!is_tutorial_note_script(TxFeeNote::script_root()));
+        assert!(is_tutorial_note_script(P2idNote::script_root()));
+    }
+
+    #[tokio::test]
+    async fn invalid_pow_challenges_fail_instead_of_looping() {
+        assert!(solve_pow("00".into(), 0).await.is_err());
+        assert!(solve_pow("not hex".into(), u64::MAX).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn pow_nonce_satisfies_faucet_target() {
+        let nonce = solve_pow("abcd".into(), u64::MAX).await.unwrap();
+        let mut hasher = Sha256::new();
+        hasher.update([0xab, 0xcd]);
+        hasher.update(nonce.to_be_bytes());
+        let digest = hasher.finalize();
+        assert!(u64::from_be_bytes(digest[..8].try_into().unwrap()) < u64::MAX);
+    }
+}

--- a/rust-client/tests/masm_compilation.rs
+++ b/rust-client/tests/masm_compilation.rs
@@ -1,0 +1,36 @@
+//! Compile the standalone MASM artifacts that do not have a self-contained network run.
+
+use miden_client::assembly::CodeBuilder;
+
+#[test]
+fn standalone_fee_auth_component_compiles() {
+    CodeBuilder::new()
+        .compile_component_code(
+            "tutorials::auth",
+            include_str!("../../masm/accounts/auth/no_auth.masm"),
+        )
+        .expect("the standalone no-auth component must support the v0.16 fee API");
+}
+
+#[test]
+fn oracle_component_and_transaction_script_compile_without_a_deployment() {
+    // These are assembly operands, not an oracle deployment or runtime price proof.
+    let component_code = include_str!("../../masm/accounts/oracle_reader.masm")
+        .replace("{pair_suffix}", "0")
+        .replace("{pair_prefix}", "1")
+        .replace(
+            "{get_median_proc_root}",
+            "0x0000000000000000000000000000000000000000000000000000000000000000",
+        )
+        .replace("{oracle_id_prefix}", "1")
+        .replace("{oracle_id_suffix}", "0");
+
+    CodeBuilder::new()
+        .compile_component_code("external_contract::oracle_reader", &component_code)
+        .expect("the oracle reader component must assemble before a deployment is configured");
+    CodeBuilder::new()
+        .with_linked_module("external_contract::oracle_reader", &component_code)
+        .unwrap()
+        .compile_tx_script(include_str!("../../masm/scripts/oracle_reader_script.masm"))
+        .expect("the oracle transaction must link its account procedure");
+}

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.98.1"
+profile = "minimal"
+components = ["rustfmt", "clippy"]

--- a/scripts/run_tutorials.sh
+++ b/scripts/run_tutorials.sh
@@ -12,6 +12,9 @@ WEB_EXAMPLES=(
   incrementCounterContract
   unauthenticatedNoteTransfer
   foreignProcedureInvocation
+  react:createMintConsume
+  react:multiSendWithDelegatedProver
+  react:unauthenticatedNoteTransfer
 )
 
 WEB_SKIPPED=()
@@ -31,11 +34,7 @@ RUST_EXAMPLES=(
   unauthenticated_note_transfer
 )
 
-RUST_SKIPPED=(
-  counter_contract_fpi
-  counter_contract_increment
-  oracle_data_query
-)
+RUST_SKIPPED=(oracle_data_query)
 
 usage() {
   cat <<'EOF'
@@ -49,6 +48,10 @@ Examples:
   yarn tutorials --rust
   yarn tutorials --web=createMintConsume
   yarn tutorials --rust=counter_contract_deploy
+
+The default network is testnet. Set TUTORIAL_NETWORK=devnet for devnet tests.
+Counter FPI/increment use a counter deployed by this run unless
+MIDEN_COUNTER_ACCOUNT_ID is set.
 EOF
 }
 
@@ -92,6 +95,12 @@ saw_selector=0
 web_names=()
 rust_names=()
 failures=()
+tutorial_network="${TUTORIAL_NETWORK:-testnet}"
+
+if [[ "$tutorial_network" != "testnet" && "$tutorial_network" != "devnet" ]]; then
+  echo "TUTORIAL_NETWORK must be either testnet or devnet, got: $tutorial_network" >&2
+  exit 1
+fi
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -187,8 +196,11 @@ if [[ "$run_web" -eq 1 ]]; then
   done
 
   web_pattern="$(IFS='|'; echo "${web_names[*]}")"
-  echo "Running web tutorials: ${web_names[*]}"
-  if ! yarn --cwd "$WEB_DIR" playwright test --grep "$web_pattern"; then
+  echo "Running web tutorials on $tutorial_network: ${web_names[*]}"
+  if ! NEXT_PUBLIC_MIDEN_NETWORK="$tutorial_network" \
+    NEXT_PUBLIC_MIDEN_FAUCET_URL="${MIDEN_FAUCET_URL:-}" \
+    NEXT_PUBLIC_MIDEN_FEE_AMOUNT="${MIDEN_FEE_AMOUNT:-}" \
+    yarn --cwd "$WEB_DIR" playwright test --grep "(^| )($web_pattern)$"; then
     failures+=("web")
   fi
 fi
@@ -214,7 +226,18 @@ if [[ "$run_rust" -eq 1 ]]; then
     fi
   done
 
-  echo "Cleaning rust build artifacts before running tutorials..."
+  # Dependent tutorials must never reuse an account from an older network genesis.
+  if contains counter_contract_fpi "${rust_names[@]}" || contains counter_contract_increment "${rust_names[@]}"; then
+    if [[ -z "${MIDEN_COUNTER_ACCOUNT_ID:-}" ]]; then
+      ordered_names=(counter_contract_deploy)
+      for name in "${rust_names[@]}"; do
+        [[ "$name" == counter_contract_deploy ]] || ordered_names+=("$name")
+      done
+      rust_names=("${ordered_names[@]}")
+    fi
+  fi
+
+  echo "Cleaning rust build artifacts before running tutorials on $tutorial_network..."
   cargo clean --manifest-path "$RUST_DIR/Cargo.toml"
 
   mkdir -p "$RUNS_DIR"
@@ -239,13 +262,18 @@ if [[ "$run_rust" -eq 1 ]]; then
       set +e
       (
         cd "$run_dir"
-        RUST_BACKTRACE=1 cargo run --manifest-path "$RUST_DIR/Cargo.toml" --bin "$name"
+        MIDEN_NETWORK="$tutorial_network" RUST_BACKTRACE=1 \
+          cargo run --locked --manifest-path "$RUST_DIR/Cargo.toml" --bin "$name"
       ) 2>&1 | tee "$run_dir/output.log"
       status=${PIPESTATUS[0]}
       set -e
       echo "Output log: $run_dir/output.log"
 
       if [[ "$status" -eq 0 ]]; then
+        if [[ "$name" == counter_contract_deploy ]]; then
+          MIDEN_COUNTER_ACCOUNT_ID="$(sed -n 's/^Counter contract id: "\([^"]*\)"$/\1/p' "$run_dir/output.log" | tail -n 1)"
+          export MIDEN_COUNTER_ACCOUNT_ID
+        fi
         break
       fi
 

--- a/web-client/README.md
+++ b/web-client/README.md
@@ -16,6 +16,9 @@ bun dev
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 
+The tutorials use v0.16 on testnet. Run `yarn playwright test` to execute them.
+See the [setup guide](../docs/src/web-client/setup_guide.md) for fee funding.
+
 You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
 
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.

--- a/web-client/app/react-tutorials/page.tsx
+++ b/web-client/app/react-tutorials/page.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import dynamic from 'next/dynamic';
+import { useEffect, useState } from 'react';
+
+const tutorials = {
+  createMintConsume: dynamic(
+    () => import('../../lib/react/createMintConsume'),
+    { ssr: false },
+  ),
+  multiSendWithDelegatedProver: dynamic(
+    () => import('../../lib/react/multiSendWithDelegatedProver'),
+    { ssr: false },
+  ),
+  unauthenticatedNoteTransfer: dynamic(
+    () => import('../../lib/react/unauthenticatedNoteTransfer'),
+    { ssr: false },
+  ),
+};
+
+export default function ReactTutorials() {
+  const [selected, setSelected] = useState<keyof typeof tutorials | null>(null);
+  useEffect(() => {
+    const requested = new URLSearchParams(window.location.search).get(
+      'tutorial',
+    );
+    if (requested && requested in tutorials)
+      setSelected(requested as keyof typeof tutorials);
+  }, []);
+  const Tutorial = selected ? tutorials[selected] : null;
+  return (
+    <main>
+      <h1>React SDK tutorials</h1>
+      <nav>
+        {Object.keys(tutorials).map((name) => (
+          <p key={name}>
+            <a href={`?tutorial=${name}`}>{name}</a>
+          </p>
+        ))}
+      </nav>
+      {Tutorial && <Tutorial />}
+    </main>
+  );
+}

--- a/web-client/lib/createMintConsume.ts
+++ b/web-client/lib/createMintConsume.ts
@@ -1,5 +1,10 @@
 // lib/createMintConsume.ts
-import { MidenClient, NoteVisibility, StorageMode } from '@miden-sdk/miden-sdk/lazy';
+import { NoteVisibility, StorageMode } from '@miden-sdk/miden-sdk/lazy';
+import {
+  consumeAllFeeAware,
+  createTutorialClient,
+  fundAccountForFees,
+} from './feeSupport';
 
 export async function createMintConsume(): Promise<void> {
   if (typeof window === 'undefined') {
@@ -7,10 +12,8 @@ export async function createMintConsume(): Promise<void> {
     return;
   }
 
-  await MidenClient.ready();
-
-  const client = await MidenClient.create({
-    rpcUrl: 'https://rpc.testnet.miden.io',
+  const client = await createTutorialClient({
+    proverUrl: 'local',
   });
 
   // 1. Sync with the latest blockchain state
@@ -24,7 +27,8 @@ export async function createMintConsume(): Promise<void> {
   });
   console.log('Alice ID:', alice.id().toString());
 
-  // 3. Deploy a fungible faucet
+  // 3. Create our own fungible faucet. SDK v0.16 includes BasicWallet,
+  // allowing both accounts to consume native fee funding before minting MID.
   console.log('Creating faucet…');
   const faucet = await client.accounts.create({
     type: 0, // 0 = FungibleFaucet
@@ -34,36 +38,46 @@ export async function createMintConsume(): Promise<void> {
     storage: StorageMode.Public,
   });
   console.log('Faucet ID:', faucet.id().toString());
+  await fundAccountForFees(client, alice);
+  await fundAccountForFees(client, faucet);
 
-  // 4. Mint tokens to Alice
+  // 4. Mint tokens to Alice.
   console.log('Minting tokens to Alice...');
+  await client.sync();
   const { txId: mintTxId } = await client.transactions.mint({
     account: faucet,
     to: alice,
     amount: BigInt(1000),
     type: NoteVisibility.Public,
   });
-
   console.log('Waiting for transaction confirmation...');
-  await client.transactions.waitFor(mintTxId);
+  await client.transactions.waitFor(mintTxId, { timeout: 120_000 });
 
-  // 5-6. Consume all available notes for Alice
+  // 5-6. Consume all available notes for Alice.
   console.log('Consuming minted notes...');
-  await client.transactions.consumeAll({
-    account: alice,
-  });
+  await consumeAllFeeAware(client, alice);
 
   console.log('Notes consumed.');
 
   // 7. Send tokens to Bob
-  const bobAddress = 'mtst1arpsz3jlmjxl7u2jjzfsc0wyqyaas6a9';
+  const bob = await client.accounts.create({
+    storage: StorageMode.Public,
+  });
   console.log("Sending tokens to Bob's account...");
-  await client.transactions.send({
+  await client.sync();
+  const { txId: sendTxId } = await client.transactions.send({
     account: alice,
-    to: bobAddress,
+    to: bob,
     token: faucet,
     amount: BigInt(100),
     type: NoteVisibility.Public,
+    waitForConfirmation: true,
+    timeout: 120_000,
   });
+  console.log(`Transaction committed: ${sendTxId.toHex()}`);
+  const updatedAlice = await client.accounts.get(alice);
+  const balance = updatedAlice?.vault().getBalance(faucet.id());
+  if (balance !== BigInt(900))
+    throw new Error(`Expected Alice to retain 900 MID, got ${balance}`);
   console.log('Tokens sent successfully!');
 }

--- a/web-client/lib/feeSupport.ts
+++ b/web-client/lib/feeSupport.ts
@@ -1,0 +1,288 @@
+import {
+  Account,
+  AccountBuilder,
+  AccountComponent,
+  AccountId,
+  AccountStorageMode,
+  AuthSecretKey,
+  Endpoint,
+  MidenClient,
+  RpcClient,
+  type ClientOptions,
+  type InputNoteRecord,
+} from '@miden-sdk/miden-sdk/lazy';
+
+type TutorialNetwork = 'testnet' | 'devnet';
+type ExecutingAccount = Account | AccountId;
+
+type FaucetPowResponse = {
+  challenge: string;
+  target: string | number;
+};
+
+type FaucetMintResponse = {
+  note_id: string;
+  tx_id: string;
+};
+
+type FaucetMetadata = {
+  base_amount: number;
+  id: string;
+};
+
+const DEFAULT_DEVNET_FAUCET_URL = 'https://faucet-api.devnet.miden.io';
+const DEFAULT_TESTNET_FAUCET_URL = 'https://faucet-api.testnet.miden.io';
+// Network notes settle asynchronously; keep a bounded two-minute polling window.
+const FUNDING_NOTE_POLL_ATTEMPTS = 24;
+const FUNDING_NOTE_POLL_INTERVAL_MS = 5_000;
+
+export function tutorialNetwork(): TutorialNetwork {
+  const configured = process.env.NEXT_PUBLIC_MIDEN_NETWORK?.toLowerCase();
+
+  if (!configured || configured === 'testnet') return 'testnet';
+  if (configured === 'devnet') return 'devnet';
+
+  throw new Error(
+    `Unsupported NEXT_PUBLIC_MIDEN_NETWORK=${configured}; expected testnet or devnet`,
+  );
+}
+
+export function tutorialExplorerUrl(): string {
+  return tutorialNetwork() === 'devnet'
+    ? 'https://devnet.midenscan.com'
+    : 'https://testnet.midenscan.com';
+}
+
+export async function createTutorialClient(
+  options: ClientOptions = {},
+): Promise<MidenClient> {
+  await MidenClient.ready();
+  return tutorialNetwork() === 'devnet'
+    ? MidenClient.createDevnet(options)
+    : MidenClient.createTestnet(options);
+}
+
+/**
+ * The high-level contract helper installs auth plus the custom component. A
+ * fee-enabled contract also needs BasicWallet so its bootstrap P2ID note can
+ * deposit the native fee asset into the vault.
+ */
+export async function createFundableContractAccount(
+  client: MidenClient,
+  seed: Uint8Array,
+  auth: AuthSecretKey,
+  components: AccountComponent[],
+): Promise<Account> {
+  let builder = new AccountBuilder(seed)
+    .storageMode(AccountStorageMode.public())
+    .withAuthComponent(AccountComponent.createAuthComponentFromSecretKey(auth))
+    .withBasicWalletComponent();
+
+  for (const component of components) {
+    builder = builder.withComponent(component);
+  }
+
+  const account = builder.build().account;
+  await client.accounts.insert({ account });
+  await client.keystore.insert(account.id(), auth);
+  return account;
+}
+
+function accountId(account: ExecutingAccount): AccountId {
+  return account instanceof Account ? account.id() : account;
+}
+
+/** Read the native fee asset and activation from the selected chain. */
+export async function tutorialFeeConfig() {
+  const endpoint =
+    tutorialNetwork() === 'devnet' ? Endpoint.devnet() : Endpoint.testnet();
+  const header = await new RpcClient(endpoint).getBlockHeaderByNumber();
+  return {
+    faucetId: header.feeFaucetId(),
+    baseFee: header.verificationBaseFee(),
+  };
+}
+
+export async function consumeAllFeeAware(
+  client: MidenClient,
+  account: ExecutingAccount,
+) {
+  await client.sync();
+  const available = await client.notes.listAvailable({
+    account: accountId(account),
+  });
+  // TX_FEE notes (tag 0xFEE) are consumable by any account; they are not P2ID transfers.
+  const notes = available.filter(
+    (note) => note.metadata()?.tag().asU32() !== 0xfee,
+  );
+  if (notes.length === 0) {
+    throw new Error(`No consumable notes found for ${accountId(account)}`);
+  }
+  return client.transactions.consume({
+    account,
+    notes,
+    waitForConfirmation: true,
+    timeout: 120_000,
+  });
+}
+
+function faucetUrl(): string {
+  const configured = process.env.NEXT_PUBLIC_MIDEN_FAUCET_URL?.trim();
+  if (configured) return configured.replace(/\/$/, '');
+
+  return tutorialNetwork() === 'devnet'
+    ? DEFAULT_DEVNET_FAUCET_URL
+    : DEFAULT_TESTNET_FAUCET_URL;
+}
+
+function hexBytes(value: string): Uint8Array {
+  const hex = value.replace(/^0x/, '');
+  if (hex.length % 2 !== 0 || !/^[0-9a-f]+$/i.test(hex)) {
+    throw new Error('The faucet returned an invalid PoW challenge');
+  }
+
+  return Uint8Array.from(hex.match(/.{2}/g)!, (byte) =>
+    Number.parseInt(byte, 16),
+  );
+}
+
+async function solvePow(challenge: string, target: bigint): Promise<bigint> {
+  const challengeBytes = hexBytes(challenge);
+  const nonceBytes = new Uint8Array(8);
+  const nonceView = new DataView(nonceBytes.buffer);
+  const input = new Uint8Array(challengeBytes.length + nonceBytes.length);
+  input.set(challengeBytes);
+
+  for (let attempt = 0; ; attempt += 1) {
+    const high = BigInt(crypto.getRandomValues(new Uint32Array(1))[0]);
+    const low = BigInt(crypto.getRandomValues(new Uint32Array(1))[0]);
+    const nonce = (high << BigInt(32)) | low;
+    nonceView.setBigUint64(0, nonce, false);
+    input.set(nonceBytes, challengeBytes.length);
+
+    const hash = await crypto.subtle.digest('SHA-256', input);
+    const digest = new DataView(hash).getBigUint64(0, false);
+    if (digest < target) return nonce;
+
+    if (attempt % 1_000 === 0) {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+  }
+}
+
+async function fetchJson<T>(url: URL | string, operation: string): Promise<T> {
+  const response = await fetch(url, { signal: AbortSignal.timeout(30_000) });
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(
+      `${operation} failed (${response.status}): ${body.trim()}`,
+    );
+  }
+  return response.json() as Promise<T>;
+}
+
+export async function requestFundingNote(
+  recipient: AccountId,
+  expectedFaucet: AccountId,
+  requestedAmount?: number,
+): Promise<FaucetMintResponse> {
+  const baseUrl = faucetUrl();
+  const metadata = await fetchJson<FaucetMetadata>(
+    `${baseUrl}/get_metadata`,
+    'Reading faucet metadata',
+  );
+  const actualFaucet = metadata.id.startsWith('0x')
+    ? AccountId.fromHex(metadata.id)
+    : AccountId.fromBech32(metadata.id);
+  if (actualFaucet.toString() !== expectedFaucet.toString()) {
+    throw new Error(
+      `Configured faucet ${actualFaucet} does not issue ${tutorialNetwork()}'s native fee asset ${expectedFaucet}`,
+    );
+  }
+
+  const configuredAmount = process.env.NEXT_PUBLIC_MIDEN_FEE_AMOUNT?.trim();
+  const amount =
+    requestedAmount ??
+    (configuredAmount ? Number(configuredAmount) : metadata.base_amount);
+  if (!Number.isSafeInteger(amount) || amount <= 0) {
+    throw new Error(
+      `Invalid fee-funding amount ${String(amount)}; expected a positive safe integer`,
+    );
+  }
+
+  const powUrl = new URL(`${baseUrl}/pow`);
+  powUrl.searchParams.set('account_id', recipient.toString());
+  powUrl.searchParams.set('amount', amount.toString());
+  const pow = await fetchJson<FaucetPowResponse>(
+    powUrl,
+    'Requesting faucet PoW',
+  );
+  const nonce = await solvePow(pow.challenge, BigInt(pow.target));
+
+  const mintUrl = new URL(`${baseUrl}/get_tokens`);
+  mintUrl.searchParams.set('account_id', recipient.toString());
+  mintUrl.searchParams.set('is_private_note', 'false');
+  mintUrl.searchParams.set('asset_amount', amount.toString());
+  mintUrl.searchParams.set('challenge', pow.challenge);
+  mintUrl.searchParams.set('nonce', nonce.toString());
+  return fetchJson<FaucetMintResponse>(mintUrl, 'Requesting fee tokens');
+}
+
+async function waitForFundingNote(
+  client: MidenClient,
+  noteId: string,
+  faucetTxId: string,
+): Promise<InputNoteRecord> {
+  for (let attempt = 0; attempt < FUNDING_NOTE_POLL_ATTEMPTS; attempt += 1) {
+    await client.sync();
+    const note = await client.notes.get(noteId);
+    if (note?.inclusionProof()) return note;
+    if (attempt < FUNDING_NOTE_POLL_ATTEMPTS - 1) {
+      await new Promise((resolve) =>
+        setTimeout(resolve, FUNDING_NOTE_POLL_INTERVAL_MS),
+      );
+    }
+  }
+
+  throw new Error(
+    `Fee-funding note ${noteId} from faucet transaction ${faucetTxId} was not found after ${FUNDING_NOTE_POLL_ATTEMPTS} sync attempts`,
+  );
+}
+
+/**
+ * Funds a newly-created account with the chain's native fee asset. The first
+ * consume transaction can pay from the asset added by the input P2ID note, so
+ * this also bootstraps accounts whose vault starts empty.
+ */
+export async function fundAccountForFees(
+  client: MidenClient,
+  account: ExecutingAccount,
+  amount?: number,
+): Promise<void> {
+  const { faucetId: feeFaucet, baseFee } = await tutorialFeeConfig();
+  if (baseFee === 0) return;
+
+  const id = accountId(account);
+  await client.sync();
+  // Read the native fee balance from the synchronized account vault.
+  const updated = await client.accounts.get(id);
+  if (!updated) throw new Error(`Account ${id} is not in the local store`);
+  const balance = updated.vault().getBalance(feeFaucet);
+  if (balance > BigInt(0)) return;
+
+  console.log(`Funding ${id} with ${tutorialNetwork()} fee tokens…`);
+  const mint = await requestFundingNote(id, feeFaucet, amount);
+  console.log(
+    `Faucet transaction ${mint.tx_id} accepted; waiting for note ${mint.note_id}…`,
+  );
+  const note = await waitForFundingNote(client, mint.note_id, mint.tx_id);
+  await client.sync();
+  const { txId } = await client.transactions.consume({
+    account,
+    notes: [note],
+    waitForConfirmation: true,
+    timeout: 120_000,
+  });
+  await client.sync();
+  console.log(`Fee funding submitted: ${txId.toHex()}`);
+}

--- a/web-client/lib/foreignProcedureInvocation.ts
+++ b/web-client/lib/foreignProcedureInvocation.ts
@@ -1,7 +1,16 @@
 // lib/foreignProcedureInvocation.ts
 import counterContractCode from './masm/counter_contract.masm';
 import countReaderCode from './masm/count_reader.masm';
-import { AuthSecretKey, StorageMode, StorageSlot, StorageResult, MidenClient } from '@miden-sdk/miden-sdk/lazy';
+import {
+  AuthSecretKey,
+  StorageSlot,
+  StorageResult,
+} from '@miden-sdk/miden-sdk/lazy';
+import {
+  createFundableContractAccount,
+  createTutorialClient,
+  fundAccountForFees,
+} from './feeSupport';
 
 export async function foreignProcedureInvocation(): Promise<void> {
   if (typeof window === 'undefined') {
@@ -9,10 +18,7 @@ export async function foreignProcedureInvocation(): Promise<void> {
     return;
   }
 
-  await MidenClient.ready();
-
-  const nodeEndpoint = 'https://rpc.testnet.miden.io';
-  const client = await MidenClient.create({ rpcUrl: nodeEndpoint });
+  const client = await createTutorialClient({ proverUrl: 'local' });
   console.log('Current block number: ', (await client.sync()).blockNum());
 
   const counterSlotName = 'miden::tutorials::counter';
@@ -32,30 +38,54 @@ export async function foreignProcedureInvocation(): Promise<void> {
   crypto.getRandomValues(counterSeed);
   const counterAuth = AuthSecretKey.rpoFalconWithRNG(counterSeed);
 
-  const counterAccount = await client.accounts.create({
-    storage: StorageMode.Public,
-    seed: counterSeed,
-    auth: counterAuth,
-    components: [counterComponent],
-  });
+  const counterAccount = await createFundableContractAccount(
+    client,
+    counterSeed,
+    counterAuth,
+    [counterComponent],
+  );
+
+  await fundAccountForFees(client, counterAccount);
 
   // Deploy the counter to the node by executing a transaction on it
   const deployScript = await client.compile.txScript({
     code: `
-      use external_contract::counter_contract
-      begin
-        call.counter_contract::increment_count
-      end
-    `,
-    libraries: [{ namespace: 'external_contract::counter_contract', code: counterContractCode }],
+use external_contract::counter_contract
+
+#! Increments the counter.
+#!
+#! Inputs:  [ARGS, pad(12)]
+#! Outputs: [pad(16)]
+#!
+#! Where:
+#! - ARGS contains unused transaction script arguments.
+#!
+#! Invocation: dyncall
+@transaction_script
+pub proc main(args: word)
+    dropw
+    # => [pad(16)]
+
+    call.counter_contract::increment_count
+    # => [pad(16)]
+end
+`,
+    libraries: [
+      {
+        namespace: 'external_contract::counter_contract',
+        code: counterContractCode,
+      },
+    ],
   });
 
   // Wait for the deploy transaction to be committed to a block
   // before using it as a foreign account in FPI
+  await client.sync();
   await client.transactions.execute({
     account: counterAccount,
     script: deployScript,
     waitForConfirmation: true,
+    timeout: 120_000,
   });
   console.log('Counter contract ID:', counterAccount.id().toString());
 
@@ -73,12 +103,14 @@ export async function foreignProcedureInvocation(): Promise<void> {
   crypto.getRandomValues(readerSeed);
   const readerAuth = AuthSecretKey.rpoFalconWithRNG(readerSeed);
 
-  let countReaderAccount = await client.accounts.create({
-    storage: StorageMode.Public,
-    seed: readerSeed,
-    auth: readerAuth,
-    components: [countReaderComponent],
-  });
+  const countReaderAccount = await createFundableContractAccount(
+    client,
+    readerSeed,
+    readerAuth,
+    [countReaderComponent],
+  );
+
+  await fundAccountForFees(client, countReaderAccount);
 
   console.log('Count reader contract ID:', countReaderAccount.id().toString());
 
@@ -92,11 +124,21 @@ export async function foreignProcedureInvocation(): Promise<void> {
   const getCountProcHash = counterComponent.getProcedureHash('get_count');
 
   const fpiScriptCode = `
-    use external_contract::count_reader_contract
-    use miden::core::sys
+use external_contract::count_reader_contract
+use miden::core::sys
 
-    begin
-    padw padw padw padw
+#! Copies a public counter through the reader account.
+#!
+#! Inputs:  [ARGS, pad(12)]
+#! Outputs: [pad(16)]
+#!
+#! Where:
+#! - ARGS contains unused transaction script arguments.
+#!
+#! Invocation: dyncall
+@transaction_script
+pub proc main(args: word)
+    dropw
     # => [pad(16)]
 
     push.${getCountProcHash}
@@ -109,24 +151,32 @@ export async function foreignProcedureInvocation(): Promise<void> {
     # => [account_id_suffix, account_id_prefix, GET_COUNT_HASH, pad(16)]
 
     call.count_reader_contract::copy_count
-    # => []
+    # => [pad(16)]
 
     exec.sys::truncate_stack
-    # => []
-
-    end
+    # => [pad(16)]
+end
 `;
 
   const script = await client.compile.txScript({
     code: fpiScriptCode,
-    libraries: [{ namespace: 'external_contract::count_reader_contract', code: countReaderCode }],
+    libraries: [
+      {
+        namespace: 'external_contract::count_reader_contract',
+        code: countReaderCode,
+      },
+    ],
   });
 
-  await client.transactions.execute({
+  await client.sync();
+  const { txId } = await client.transactions.execute({
     account: countReaderAccount,
     script,
     foreignAccounts: [counterAccount],
+    waitForConfirmation: true,
+    timeout: 120_000,
   });
+  console.log(`Transaction committed: ${txId.toHex()}`);
 
   const updatedCountReader = await client.accounts.get(countReaderAccount);
   // `getItem()` is typed to return a low-level `Word`, but at runtime the SDK
@@ -138,7 +188,11 @@ export async function foreignProcedureInvocation(): Promise<void> {
 
   if (countReaderStorage) {
     const countValue = Number(countReaderStorage.toBigInt());
+    if (countValue !== 1)
+      throw new Error(`Expected copied counter 1, got ${countValue}`);
     console.log('Count copied via Foreign Procedure Invocation:', countValue);
+  } else {
+    throw new Error('Count reader storage was not available after commitment');
   }
 
   console.log('\nForeign Procedure Invocation Transaction completed!');

--- a/web-client/lib/incrementCounterContract.ts
+++ b/web-client/lib/incrementCounterContract.ts
@@ -1,6 +1,15 @@
 // lib/incrementCounterContract.ts
 import counterContractCode from './masm/counter_contract.masm';
-import { AuthSecretKey, StorageMode, StorageSlot, StorageResult, MidenClient } from '@miden-sdk/miden-sdk/lazy';
+import {
+  AuthSecretKey,
+  StorageSlot,
+  StorageResult,
+} from '@miden-sdk/miden-sdk/lazy';
+import {
+  createFundableContractAccount,
+  createTutorialClient,
+  fundAccountForFees,
+} from './feeSupport';
 
 export async function incrementCounterContract(): Promise<void> {
   if (typeof window === 'undefined') {
@@ -8,10 +17,7 @@ export async function incrementCounterContract(): Promise<void> {
     return;
   }
 
-  await MidenClient.ready();
-
-  const nodeEndpoint = 'https://rpc.testnet.miden.io';
-  const client = await MidenClient.create({ rpcUrl: nodeEndpoint });
+  const client = await createTutorialClient({ proverUrl: 'local' });
   console.log('Current block number: ', (await client.sync()).blockNum());
 
   const counterSlotName = 'miden::tutorials::counter';
@@ -25,29 +31,55 @@ export async function incrementCounterContract(): Promise<void> {
   crypto.getRandomValues(walletSeed);
   const auth = AuthSecretKey.rpoFalconWithRNG(walletSeed);
 
-  const account = await client.accounts.create({
-    storage: StorageMode.Public,
-    seed: walletSeed,
+  const account = await createFundableContractAccount(
+    client,
+    walletSeed,
     auth,
-    components: [counterAccountComponent],
-  });
+    [counterAccountComponent],
+  );
+
+  await fundAccountForFees(client, account);
 
   const txScriptCode = `
-    use external_contract::counter_contract
-    begin
+use external_contract::counter_contract
+
+#! Increments the counter.
+#!
+#! Inputs:  [ARGS, pad(12)]
+#! Outputs: [pad(16)]
+#!
+#! Where:
+#! - ARGS contains unused transaction script arguments.
+#!
+#! Invocation: dyncall
+@transaction_script
+pub proc main(args: word)
+    dropw
+    # => [pad(16)]
+
     call.counter_contract::increment_count
-    end
+    # => [pad(16)]
+end
 `;
 
   const script = await client.compile.txScript({
     code: txScriptCode,
-    libraries: [{ namespace: 'external_contract::counter_contract', code: counterContractCode }],
+    libraries: [
+      {
+        namespace: 'external_contract::counter_contract',
+        code: counterContractCode,
+      },
+    ],
   });
 
-  await client.transactions.execute({
+  await client.sync();
+  const { txId } = await client.transactions.execute({
     account,
     script,
+    waitForConfirmation: true,
+    timeout: 120_000,
   });
+  console.log(`Transaction committed: ${txId.toHex()}`);
 
   console.log('Counter contract ID:', account.id().toString());
 
@@ -56,8 +88,9 @@ export async function incrementCounterContract(): Promise<void> {
   // wraps the slot in a `StorageResult` whose `toBigInt()` reads the first
   // felt — the count. The cast reflects that runtime type.
   const count = counter?.storage().getItem(counterSlotName) as unknown as
-    | StorageResult
-    | undefined;
+    StorageResult | undefined;
   const counterValue = Number(count!.toBigInt());
+  if (counterValue !== 1)
+    throw new Error(`Expected counter 1, got ${counterValue}`);
   console.log('Count: ', counterValue);
 }

--- a/web-client/lib/masm/count_reader.masm
+++ b/web-client/lib/masm/count_reader.masm
@@ -1,26 +1,51 @@
-use miden::protocol::active_account
 use miden::protocol::native_account
 use miden::protocol::tx
-use miden::core::word
 use miden::core::sys
+use {AccountId, AccountProcedureRoot} from miden::protocol::types
 
-# The storage slot where the copied count is stored.
+# CONSTANTS
+# =================================================================================================
+
 const COUNT_READER_SLOT = word("miden::tutorials::count_reader")
 
-# => [account_id_suffix, account_id_prefix, PROC_HASH(4), foreign_procedure_inputs(16)]
-pub proc copy_count
+# PUBLIC INTERFACE
+# =================================================================================================
+
+#! Copies the count returned by the foreign counter into this account's storage.
+#!
+#! Inputs:  [foreign_account_id_{suffix,prefix}, FOREIGN_PROC_ROOT, pad(10)]
+#! Outputs: [pad(16)]
+#!
+#! Where:
+#! - foreign_account_id_{suffix,prefix} identifies the public counter account.
+#! - FOREIGN_PROC_ROOT is the root of its get_count procedure.
+#!
+#! Invocation: call
+@account_procedure
+@locals(6)
+pub proc copy_count(foreign_account_id: AccountId, foreign_proc_root: AccountProcedureRoot)
+    # save the foreign target while preparing its sixteen zero inputs
+    loc_store.4 loc_store.5 loc_storew_le.0 dropw
+    # => [pad(16)]
+
+    padw padw padw padw
+    # => [foreign_procedure_inputs(16), pad(16)]
+
+    padw loc_loadw_le.0 loc_load.5 loc_load.4
+    # => [foreign_account_id_suffix, foreign_account_id_prefix, FOREIGN_PROC_ROOT, foreign_procedure_inputs(16), pad(16)]
+
     exec.tx::execute_foreign_procedure
-    # => [count, pad(12)]
+    # => [[count, 0, 0, 0], pad(28)]
 
     push.COUNT_READER_SLOT[0..2]
-    # [slot_id_prefix, slot_id_suffix, count, pad(12)]
+    # => [slot_id_suffix, slot_id_prefix, [count, 0, 0, 0], pad(28)]
 
     exec.native_account::set_item
-    # => [OLD_VALUE, pad(12)]
+    # => [OLD_VALUE, pad(28)]
 
-    dropw dropw dropw dropw
-    # => []
+    dropw
+    # => [pad(28)]
 
     exec.sys::truncate_stack
-    # => []
+    # => [pad(16)]
 end

--- a/web-client/lib/masm/counter_contract.masm
+++ b/web-client/lib/masm/counter_contract.masm
@@ -1,32 +1,50 @@
 use miden::protocol::active_account
 use miden::protocol::native_account
-use miden::core::word
 use miden::core::sys
+
+# CONSTANTS
+# =================================================================================================
 
 const COUNTER_SLOT = word("miden::tutorials::counter")
 
-#! Inputs:  []
-#! Outputs: [count]
-pub proc get_count
+# PUBLIC INTERFACE
+# =================================================================================================
+
+#! Returns the current count.
+#!
+#! Inputs:  [pad(16)]
+#! Outputs: [count, pad(15)]
+#!
+#! Invocation: call
+@account_procedure
+pub proc get_count() -> felt
     push.COUNTER_SLOT[0..2] exec.active_account::get_item
-    # => [count]
+    # => [[count, 0, 0, 0], pad(16)]
 
     exec.sys::truncate_stack
-    # => [count]
+    # => [count, pad(15)]
 end
 
-#! Inputs:  []
-#! Outputs: []
-pub proc increment_count
+#! Increments the current count by one.
+#!
+#! Inputs:  [pad(16)]
+#! Outputs: [pad(16)]
+#!
+#! Invocation: call
+@account_procedure
+pub proc increment_count()
     push.COUNTER_SLOT[0..2] exec.active_account::get_item
-    # => [count]
+    # => [[count, 0, 0, 0], pad(16)]
 
     add.1
-    # => [count+1]
+    # => [[count + 1, 0, 0, 0], pad(16)]
 
     push.COUNTER_SLOT[0..2] exec.native_account::set_item
-    # => []
+    # => [OLD_VALUE, pad(16)]
+
+    dropw
+    # => [pad(16)]
 
     exec.sys::truncate_stack
-    # => []
+    # => [pad(16)]
 end

--- a/web-client/lib/mintTestnetToAddress.ts
+++ b/web-client/lib/mintTestnetToAddress.ts
@@ -1,7 +1,12 @@
 /**
- * Mint 100 MIDEN tokens on testnet to a fixed recipient.
+ * Mint 100 MID base units on the configured network to a newly created recipient.
+ * Uses testnet unless another network is configured explicitly.
  */
-import { MidenClient, NoteVisibility, StorageMode } from '@miden-sdk/miden-sdk/lazy';
+import { NoteVisibility, StorageMode } from '@miden-sdk/miden-sdk/lazy';
+import {
+  createTutorialClient,
+  fundAccountForFees,
+} from './feeSupport';
 
 export async function mintTestnetToAddress(): Promise<void> {
   if (typeof window === 'undefined') {
@@ -9,10 +14,8 @@ export async function mintTestnetToAddress(): Promise<void> {
     return;
   }
 
-  await MidenClient.ready();
-
-  const client = await MidenClient.create({
-    rpcUrl: 'https://rpc.testnet.miden.io',
+  const client = await createTutorialClient({
+    proverUrl: 'local',
   });
 
   console.log('Latest block:', (await client.sync()).blockNum());
@@ -27,22 +30,25 @@ export async function mintTestnetToAddress(): Promise<void> {
     storage: StorageMode.Public,
   });
   console.log('Faucet ID:', faucet.id().toString());
+  await fundAccountForFees(client, faucet);
 
   // ── Mint to recipient ───────────────────────────────────────────────────────
-  const recipientAddress = 'mtst1arpsz3jlmjxl7u2jjzfsc0wyqyaas6a9';
+  const recipient = await client.accounts.create({
+    storage: StorageMode.Public,
+  });
+  const recipientAddress = recipient.id().toString();
   console.log('Recipient address:', recipientAddress);
 
-  console.log('Minting 100 MIDEN tokens...');
+  console.log('Minting 100 MID base units...');
+  await client.sync();
   const { txId: mintTxId } = await client.transactions.mint({
     account: faucet,
-    to: recipientAddress,
+    to: recipient,
     amount: BigInt(100),
     type: NoteVisibility.Public,
   });
 
-  console.log('Waiting for settlement...');
-  await client.transactions.waitFor(mintTxId);
-
+  await client.transactions.waitFor(mintTxId, { timeout: 120_000 });
   console.log('Mint tx id:', mintTxId.toHex());
   console.log('Mint complete.');
 }

--- a/web-client/lib/multiSendWithDelegatedProver.ts
+++ b/web-client/lib/multiSendWithDelegatedProver.ts
@@ -5,23 +5,22 @@
  * @throws {Error} If the function cannot be executed in a browser environment
  */
 import {
-  MidenClient,
+  NoteArray,
   NoteVisibility,
   StorageMode,
   createP2IDNote,
-  NoteArray,
-  TransactionRequestBuilder,
 } from '@miden-sdk/miden-sdk/lazy';
+import {
+  consumeAllFeeAware,
+  createTutorialClient,
+  fundAccountForFees,
+} from './feeSupport';
 
 export async function multiSendWithDelegatedProver(): Promise<void> {
   // Ensure this runs only in a browser context
   if (typeof window === 'undefined') return console.warn('Run in browser');
 
-  await MidenClient.ready();
-
-  const client = await MidenClient.create({
-    rpcUrl: 'https://rpc.testnet.miden.io',
-  });
+  const client = await createTutorialClient();
 
   console.log('Latest block:', (await client.sync()).blockNum());
 
@@ -32,7 +31,7 @@ export async function multiSendWithDelegatedProver(): Promise<void> {
   });
   console.log('Alice account ID:', alice.id().toString());
 
-  // ── Creating new faucet ──────────────────────────────────────────────────────
+  // ── Creating new faucet ────────────────────────────────────────────────────
   const faucet = await client.accounts.create({
     type: 0, // 0 = FungibleFaucet
     symbol: 'MID',
@@ -41,29 +40,30 @@ export async function multiSendWithDelegatedProver(): Promise<void> {
     storage: StorageMode.Public,
   });
   console.log('Faucet ID:', faucet.id().toString());
+  await fundAccountForFees(client, alice);
+  await fundAccountForFees(client, faucet);
 
-  // ── mint 10 000 MID to Alice ──────────────────────────────────────────────────────
+  // ── mint 10 000 MID to Alice ───────────────────────────────────────────────
+  await client.sync();
   const { txId: mintTxId } = await client.transactions.mint({
     account: faucet,
     to: alice,
     amount: BigInt(10_000),
     type: NoteVisibility.Public,
   });
-
   console.log('waiting for settlement');
-  await client.transactions.waitFor(mintTxId);
-
-  // ── consume the freshly minted notes ──────────────────────────────────────────────
-  await client.transactions.consumeAll({
-    account: alice,
-  });
+  await client.transactions.waitFor(mintTxId, { timeout: 120_000 });
+  await consumeAllFeeAware(client, alice);
 
   // ── build 3 P2ID notes (100 MID each) ─────────────────────────────────────────────
-  const recipientAddresses = [
-    'mtst1arqeemdpnzu4k52wlpd3xekl5uklfjl5',
-    'mtst1arqk5qt3kms0cut9rdtqdaz8y5xmj245',
-    'mtst1aq6kyfrh23n9gvt6jkg0z7fyts99hdqr',
-  ];
+  const recipients = await Promise.all(
+    Array.from({ length: 3 }, () =>
+      client.accounts.create({ storage: StorageMode.Public }),
+    ),
+  );
+  const recipientAddresses = recipients.map((account) =>
+    account.id().toString(),
+  );
 
   const p2idNotes = recipientAddresses.map((addr) =>
     createP2IDNote({
@@ -75,9 +75,18 @@ export async function multiSendWithDelegatedProver(): Promise<void> {
   );
 
   // ── create all P2ID notes ───────────────────────────────────────────────────────────────
-  const builder = new TransactionRequestBuilder();
-  const txRequest = builder.withOwnOutputNotes(new NoteArray(p2idNotes)).build();
-  await client.transactions.submit(alice, txRequest);
+  await client.sync();
+  const builder = await client.feeAwareTransactionRequestBuilder(alice);
+  const outputs = new NoteArray();
+  for (const note of p2idNotes) outputs.push(note);
+  const request = builder.withOwnOutputNotes(outputs).build();
+  const { txId } = await client.transactions.submit(alice, request);
+  await client.transactions.waitFor(txId, { timeout: 120_000 });
+  console.log(`Transaction committed: ${txId.toHex()}`);
+  const updatedAlice = await client.accounts.get(alice);
+  const balance = updatedAlice?.vault().getBalance(faucet.id());
+  if (balance !== BigInt(9_700))
+    throw new Error(`Expected Alice to retain 9700 MID, got ${balance}`);
 
   console.log('All notes created ✅');
 }

--- a/web-client/lib/react/createMintConsume.tsx
+++ b/web-client/lib/react/createMintConsume.tsx
@@ -1,85 +1,111 @@
-// Documentation-only example for the "Mint, Consume, and Create Notes" tutorial.
-// This component is embedded in docs via CodeSdkTabs and is not wired into the
-// test harness (app/page.tsx). The TypeScript equivalent in lib/createMintConsume.ts
-// is used for Playwright tests instead.
 'use client';
 
-import { MidenProvider, useMiden, useCreateWallet, useCreateFaucet, useMint, useConsume, useSend, useWaitForCommit, useWaitForNotes } from '@miden-sdk/react/lazy';
+import {
+  MidenProvider,
+  useMiden,
+  useCreateWallet,
+  useCreateFaucet,
+  useMint,
+  useConsume,
+  useSend,
+} from '@miden-sdk/react/lazy';
 import { NoteVisibility, StorageMode } from '@miden-sdk/miden-sdk/lazy';
+import { tutorialNetwork } from '../feeSupport';
+import {
+  TutorialButton,
+  tutorialAuthScheme,
+  useTutorialSupport,
+} from './tutorialSupport';
 
 function CreateMintConsumeInner() {
-  const { isReady } = useMiden();
+  const { sync } = useMiden();
   const { createWallet } = useCreateWallet();
   const { createFaucet } = useCreateFaucet();
   const { mint } = useMint();
   const { consume } = useConsume();
   const { send } = useSend();
-  const { waitForCommit } = useWaitForCommit();
-  const { waitForConsumableNotes } = useWaitForNotes();
+  const {
+    fundAccount,
+    committed,
+    waitForTokenNotes,
+    waitForNote,
+    assertBalance,
+  } = useTutorialSupport();
 
   const run = async () => {
-    // 1. Create Alice's wallet (public, mutable)
-    console.log('Creating account for Alice…');
-    const alice = await createWallet({ storageMode: StorageMode.Public });
+    console.log('Synchronizing before creating accounts…');
+    await sync();
+    console.log('Creating Alice with useCreateWallet…');
+    const authScheme = await tutorialAuthScheme();
+    // Native fee tokens and the tutorial's MID token are separate assets.
+    const alice = await createWallet({
+      storageMode: StorageMode.Public,
+      authScheme,
+    });
     console.log('Alice ID:', alice.id().toString());
+    await fundAccount(alice);
 
-    // 2. Deploy a fungible faucet
-    console.log('Creating faucet…');
+    // v0.16 faucets include BasicWallet, so they can receive fee funding.
     const faucet = await createFaucet({
       tokenSymbol: 'MID',
       decimals: 8,
       maxSupply: BigInt(1_000_000),
       storageMode: StorageMode.Public,
+      authScheme,
     });
     console.log('Faucet ID:', faucet.id().toString());
+    await fundAccount(faucet);
 
-    // 3. Mint 1000 tokens to Alice
-    console.log('Minting tokens to Alice...');
-    const mintResult = await mint({
+    await sync();
+    const minted = await mint({
       faucetId: faucet,
       targetAccountId: alice,
       amount: BigInt(1000),
       noteType: NoteVisibility.Public,
     });
-    console.log('Mint tx:', mintResult.transactionId);
+    await committed(minted.transactionId);
+    const notes = await waitForTokenNotes(alice, faucet);
+    const consumed = await consume({ accountId: alice.id().toString(), notes });
+    await committed(consumed.transactionId);
+    await assertBalance(alice, faucet, BigInt(1000));
 
-    // 4. Wait for the mint transaction to be committed
-    await waitForCommit(mintResult.transactionId);
-
-    // 5. Wait for consumable notes to appear
-    const notes = await waitForConsumableNotes({ accountId: alice });
-    console.log('Consumable notes:', notes.length);
-
-    // 6. Consume minted notes
-    console.log('Consuming minted notes...');
-    await consume({ accountId: alice.id().toString(), notes });
-    console.log('Notes consumed.');
-
-    // 7. Send 100 tokens to Bob
-    const bobAddress = 'mtst1arpsz3jlmjxl7u2jjzfsc0wyqyaas6a9';
-    console.log("Sending tokens to Bob's account...");
-    await send({
+    const bob = await createWallet({
+      storageMode: StorageMode.Public,
+      authScheme,
+    });
+    const sent = await send({
       from: alice,
-      to: bobAddress,
+      to: bob,
       assetId: faucet,
       amount: BigInt(100),
       noteType: NoteVisibility.Public,
+      returnNote: true,
     });
+    await committed(sent.txId);
+    if (!sent.note) throw new Error('Send did not return its output note');
+    await waitForNote(sent.note.id().toString());
+    await assertBalance(alice, faucet, BigInt(900));
     console.log('Tokens sent successfully!');
   };
 
   return (
-    <div>
-      <button onClick={run} disabled={!isReady}>
-        {isReady ? 'Run: Create, Mint, Consume & Send' : 'Initializing…'}
-      </button>
-    </div>
+    <TutorialButton
+      name="createMintConsume"
+      label="Run: Create, Mint, Consume & Send"
+      run={run}
+    />
   );
 }
 
 export default function CreateMintConsume() {
   return (
-    <MidenProvider config={{ rpcUrl: 'testnet', prover: 'local' }}>
+    <MidenProvider
+      config={{
+        rpcUrl: tutorialNetwork(),
+        prover: 'local',
+        autoSyncInterval: 0,
+      }}
+    >
       <CreateMintConsumeInner />
     </MidenProvider>
   );

--- a/web-client/lib/react/multiSendWithDelegatedProver.tsx
+++ b/web-client/lib/react/multiSendWithDelegatedProver.tsx
@@ -1,79 +1,111 @@
-// Documentation-only example for the "Creating Multiple Notes" tutorial.
-// This component is embedded in docs via CodeSdkTabs and is not wired into the
-// test harness (app/page.tsx). The TypeScript equivalent in
-// lib/multiSendWithDelegatedProver.ts is used for Playwright tests instead.
 'use client';
 
-import { MidenProvider, useMiden, useCreateWallet, useCreateFaucet, useMint, useConsume, useMultiSend, useWaitForCommit, useWaitForNotes } from '@miden-sdk/react/lazy';
+import {
+  MidenProvider,
+  useMiden,
+  useCreateWallet,
+  useCreateFaucet,
+  useMint,
+  useConsume,
+  useMultiSend,
+} from '@miden-sdk/react/lazy';
 import { NoteVisibility, StorageMode } from '@miden-sdk/miden-sdk/lazy';
+import { tutorialNetwork } from '../feeSupport';
+import {
+  TutorialButton,
+  tutorialAuthScheme,
+  useTutorialSupport,
+} from './tutorialSupport';
 
 function MultiSendInner() {
-  const { isReady } = useMiden();
+  const { sync } = useMiden();
   const { createWallet } = useCreateWallet();
   const { createFaucet } = useCreateFaucet();
   const { mint } = useMint();
   const { consume } = useConsume();
   const { sendMany } = useMultiSend();
-  const { waitForCommit } = useWaitForCommit();
-  const { waitForConsumableNotes } = useWaitForNotes();
+  const { fundAccount, committed, waitForTokenNotes, assertBalance } =
+    useTutorialSupport();
 
   const run = async () => {
-    // 1. Create Alice's wallet
-    console.log('Creating account for Alice…');
-    const alice = await createWallet({ storageMode: StorageMode.Public });
-    console.log('Alice account ID:', alice.id().toString());
-
-    // 2. Deploy a fungible faucet
+    await sync();
+    const authScheme = await tutorialAuthScheme();
+    const alice = await createWallet({
+      storageMode: StorageMode.Public,
+      authScheme,
+    });
+    console.log('Alice ID:', alice.id().toString());
+    await fundAccount(alice);
     const faucet = await createFaucet({
       tokenSymbol: 'MID',
       decimals: 8,
       maxSupply: BigInt(1_000_000),
       storageMode: StorageMode.Public,
+      authScheme,
     });
     console.log('Faucet ID:', faucet.id().toString());
+    await fundAccount(faucet);
 
-    // 3. Mint 10,000 MID to Alice
-    const mintResult = await mint({
+    await sync();
+    const minted = await mint({
       faucetId: faucet,
       targetAccountId: alice,
       amount: BigInt(10_000),
       noteType: NoteVisibility.Public,
     });
+    await committed(minted.transactionId);
+    const notes = await waitForTokenNotes(alice, faucet);
+    const consumed = await consume({ accountId: alice.id().toString(), notes });
+    await committed(consumed.transactionId);
 
-    console.log('Waiting for settlement…');
-    await waitForCommit(mintResult.transactionId);
-
-    // 4. Consume the freshly minted notes
-    const notes = await waitForConsumableNotes({ accountId: alice });
-    await consume({ accountId: alice.id().toString(), notes });
-
-    // 5. Send 100 MID to three recipients in a single transaction
-    await sendMany({
+    const recipients = [];
+    for (let index = 0; index < 3; index += 1) {
+      recipients.push(
+        await createWallet({ storageMode: StorageMode.Public, authScheme }),
+      );
+    }
+    const sent = await sendMany({
       from: alice,
       assetId: faucet,
-      recipients: [
-        { to: 'mtst1arqeemdpnzu4k52wlpd3xekl5uklfjl5', amount: BigInt(100) },
-        { to: 'mtst1arqk5qt3kms0cut9rdtqdaz8y5xmj245', amount: BigInt(100) },
-        { to: 'mtst1aq6kyfrh23n9gvt6jkg0z7fyts99hdqr', amount: BigInt(100) },
-      ],
+      recipients: recipients.map((account) => ({
+        to: account,
+        amount: BigInt(100),
+      })),
       noteType: NoteVisibility.Public,
     });
-
+    await committed(sent.transactionId);
+    for (const recipient of recipients) {
+      const outputs = await waitForTokenNotes(recipient, faucet);
+      if (
+        outputs.length !== 1 ||
+        outputs[0].details().assets().fungibleAssets()[0]?.amount() !==
+          BigInt(100)
+      ) {
+        throw new Error(`Expected one 100 MID note for ${recipient.id()}`);
+      }
+    }
+    await assertBalance(alice, faucet, BigInt(9700));
     console.log('All notes created ✅');
   };
 
   return (
-    <div>
-      <button onClick={run} disabled={!isReady}>
-        {isReady ? 'Run: Multi-Send with Delegated Proving' : 'Initializing…'}
-      </button>
-    </div>
+    <TutorialButton
+      name="multiSendWithDelegatedProver"
+      label="Run: Multi-Send with Delegated Proving"
+      run={run}
+    />
   );
 }
 
 export default function MultiSendWithDelegatedProver() {
   return (
-    <MidenProvider config={{ rpcUrl: 'testnet', prover: 'testnet' }}>
+    <MidenProvider
+      config={{
+        rpcUrl: tutorialNetwork(),
+        prover: tutorialNetwork(),
+        autoSyncInterval: 0,
+      }}
+    >
       <MultiSendInner />
     </MidenProvider>
   );

--- a/web-client/lib/react/tutorialSupport.tsx
+++ b/web-client/lib/react/tutorialSupport.tsx
@@ -1,0 +1,175 @@
+'use client';
+
+import { useState } from 'react';
+import { useConsume, useMiden, useWaitForCommit } from '@miden-sdk/react/lazy';
+import {
+  Account,
+  AccountId,
+  getWasmOrThrow,
+  type InputNoteRecord,
+} from '@miden-sdk/miden-sdk/lazy';
+import {
+  requestFundingNote,
+  tutorialFeeConfig,
+  tutorialNetwork,
+} from '../feeSupport';
+
+const SETTLEMENT_TIMEOUT_MS = 120_000;
+const POLL_INTERVAL_MS = 5_000;
+
+/** React wallet hooks expect the low-level numeric authentication enum. */
+export async function tutorialAuthScheme() {
+  const wasm = await getWasmOrThrow();
+  return wasm.AuthScheme.AuthRpoFalcon512;
+}
+
+/** Uses the provider's actual client and hooks, not a second client. */
+export function useTutorialSupport() {
+  const { client, sync, runExclusive } = useMiden();
+  const { consume } = useConsume();
+  const { waitForCommit } = useWaitForCommit();
+
+  const committed = async (transactionId: string) => {
+    await waitForCommit(transactionId, {
+      timeoutMs: SETTLEMENT_TIMEOUT_MS,
+      intervalMs: POLL_INTERVAL_MS,
+    });
+    console.log(`Transaction committed: ${transactionId}`);
+  };
+
+  const waitForNote = async (noteId: string): Promise<InputNoteRecord> => {
+    if (!client) throw new Error('Miden client is not ready');
+    const deadline = Date.now() + SETTLEMENT_TIMEOUT_MS;
+    while (Date.now() < deadline) {
+      await sync();
+      const note = await runExclusive(() => client.getInputNote(noteId));
+      if (note?.inclusionProof()) return note;
+      await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+    }
+    throw new Error(`Timed out waiting for committed note ${noteId}`);
+  };
+
+  const fundAccount = async (account: Account) => {
+    if (!client) throw new Error('Miden client is not ready');
+    const { faucetId, baseFee } = await tutorialFeeConfig();
+    if (baseFee === 0) return;
+    await sync();
+    const updated = await runExclusive(() => client.getAccount(account.id()));
+    if (!updated) throw new Error(`Account ${account.id()} is not in the local store`);
+    if (updated.vault().getBalance(faucetId) > BigInt(0)) return;
+    console.log(`Funding ${account.id()} with native ${tutorialNetwork()} fee tokens`);
+    const minted = await requestFundingNote(account.id(), faucetId);
+    console.log(
+      `Funding note ${minted.note_id}; faucet transaction ${minted.tx_id}`,
+    );
+    const note = await waitForNote(minted.note_id);
+    // The first transaction pays its fee from the native asset in the input note.
+    await sync();
+    const result = await consume({
+      accountId: account.id().toString(),
+      notes: [note],
+    });
+    await committed(result.transactionId);
+  };
+
+  const waitForTokenNotes = async (
+    account: Account,
+    faucet: Account,
+  ): Promise<InputNoteRecord[]> => {
+    if (!client) throw new Error('Miden client is not ready');
+    const deadline = Date.now() + SETTLEMENT_TIMEOUT_MS;
+    while (Date.now() < deadline) {
+      await sync();
+      const records = await runExclusive(() =>
+        client.getConsumableNotes(account.id()),
+      );
+      const notes = records
+        .map((record) => record.inputNoteRecord())
+        .filter(
+          (record) =>
+            // Globally consumable TX_FEE notes are not tutorial transfers.
+            record.metadata()?.tag().asU32() !== 0xfee &&
+            record.inclusionProof() &&
+            record
+              .details()
+              .assets()
+              .fungibleAssets()
+              .some(
+                (asset) =>
+                  asset.faucetId().toString() === faucet.id().toString(),
+              ),
+        );
+      if (notes.length > 0) return notes;
+      await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+    }
+    throw new Error(
+      `No committed ${faucet.id()} token notes for ${account.id()}`,
+    );
+  };
+
+  const assertBalance = async (
+    account: Account,
+    token: Account | AccountId,
+    expected: bigint,
+  ) => {
+    if (!client) throw new Error('Miden client is not ready');
+    await sync();
+    const updated = await runExclusive(() => client.getAccount(account.id()));
+    const actual = updated
+      ?.vault()
+      .getBalance(token instanceof Account ? token.id() : token);
+    if (actual !== expected)
+      throw new Error(
+        `Balance mismatch for ${account.id()}: expected ${expected}, got ${actual}`,
+      );
+    console.log(`Verified balance ${account.id()}: ${actual}`);
+  };
+
+  return {
+    committed,
+    fundAccount,
+    waitForNote,
+    waitForTokenNotes,
+    assertBalance,
+  };
+}
+
+/** Surfaces actual hook errors to readers and to the browser test harness. */
+export function TutorialButton({
+  name,
+  label,
+  run,
+}: {
+  name: string;
+  label: string;
+  run: () => Promise<void>;
+}) {
+  const { isReady, error: initializationError } = useMiden();
+  const [state, setState] = useState('idle');
+  const [error, setError] = useState<string | null>(null);
+  const execute = async () => {
+    setState('running');
+    setError(null);
+    try {
+      await run();
+      setState('passed');
+      console.log(`React tutorial passed: ${name}`);
+    } catch (cause) {
+      const message = cause instanceof Error ? cause.message : String(cause);
+      setError(message);
+      setState('failed');
+      console.error(message);
+    }
+  };
+  return (
+    <section
+      data-testid={`react-${name}`}
+      data-state={initializationError ? 'failed' : state}
+    >
+      <button onClick={execute} disabled={!isReady || state === 'running'}>
+        {isReady ? label : 'Initializing…'}
+      </button>
+      <p role="status">{initializationError?.message ?? error ?? state}</p>
+    </section>
+  );
+}

--- a/web-client/lib/react/unauthenticatedNoteTransfer.tsx
+++ b/web-client/lib/react/unauthenticatedNoteTransfer.tsx
@@ -1,66 +1,79 @@
-// Documentation-only example for the "Unauthenticated Note Transfer" tutorial.
-// This component is embedded in docs via CodeSdkTabs and is not wired into the
-// test harness (app/page.tsx). The TypeScript equivalent in
-// lib/unauthenticatedNoteTransfer.ts is used for Playwright tests instead.
 'use client';
 
-import { MidenProvider, useMiden, useCreateWallet, useCreateFaucet, useMint, useConsume, useSend, useWaitForCommit, useWaitForNotes, type Account } from '@miden-sdk/react/lazy';
+import {
+  MidenProvider,
+  useMiden,
+  useCreateWallet,
+  useCreateFaucet,
+  useMint,
+  useConsume,
+  useSend,
+  type Account,
+} from '@miden-sdk/react/lazy';
 import { NoteVisibility, StorageMode } from '@miden-sdk/miden-sdk/lazy';
+import { tutorialExplorerUrl, tutorialNetwork } from '../feeSupport';
+import {
+  TutorialButton,
+  tutorialAuthScheme,
+  useTutorialSupport,
+} from './tutorialSupport';
 
 function UnauthenticatedNoteTransferInner() {
-  const { isReady } = useMiden();
+  const { sync } = useMiden();
   const { createWallet } = useCreateWallet();
   const { createFaucet } = useCreateFaucet();
   const { mint } = useMint();
   const { consume } = useConsume();
   const { send } = useSend();
-  const { waitForCommit } = useWaitForCommit();
-  const { waitForConsumableNotes } = useWaitForNotes();
+  const { fundAccount, committed, waitForTokenNotes, assertBalance } =
+    useTutorialSupport();
 
   const run = async () => {
-    // 1. Create Alice and 5 wallets for the transfer chain
-    console.log('Creating accounts…');
-    const alice = await createWallet({ storageMode: StorageMode.Public });
-    console.log('Alice account ID:', alice.id().toString());
-
+    await sync();
+    const authScheme = await tutorialAuthScheme();
+    const alice = await createWallet({
+      storageMode: StorageMode.Public,
+      authScheme,
+    });
+    console.log('Alice ID:', alice.id().toString());
+    await fundAccount(alice);
     const wallets: Account[] = [];
-    for (let i = 0; i < 5; i++) {
-      const wallet = await createWallet({ storageMode: StorageMode.Public });
+    for (let index = 0; index < 5; index += 1) {
+      const wallet = await createWallet({
+        storageMode: StorageMode.Public,
+        authScheme,
+      });
+      console.log(`Wallet ${index}:`, wallet.id().toString());
+      // Every recipient pays fees when consuming and forwarding the note.
+      await fundAccount(wallet);
       wallets.push(wallet);
-      console.log(`Wallet ${i}:`, wallet.id().toString());
     }
-
-    // 2. Deploy a fungible faucet
     const faucet = await createFaucet({
       tokenSymbol: 'MID',
       decimals: 8,
       maxSupply: BigInt(1_000_000),
       storageMode: StorageMode.Public,
+      authScheme,
     });
     console.log('Faucet ID:', faucet.id().toString());
-
-    // 3. Mint 10,000 MID to Alice
-    const mintResult = await mint({
+    await fundAccount(faucet);
+    await sync();
+    const minted = await mint({
       faucetId: faucet,
       targetAccountId: alice,
       amount: BigInt(10_000),
       noteType: NoteVisibility.Public,
     });
+    await committed(minted.transactionId);
+    const notes = await waitForTokenNotes(alice, faucet);
+    const consumed = await consume({ accountId: alice.id().toString(), notes });
+    await committed(consumed.transactionId);
 
-    console.log('Waiting for settlement…');
-    await waitForCommit(mintResult.transactionId);
-
-    // 4. Consume the freshly minted notes
-    const notes = await waitForConsumableNotes({ accountId: alice });
-    await consume({ accountId: alice.id().toString(), notes });
-
-    // 5. Create the unauthenticated note transfer chain:
-    //    Alice → Wallet 0 → Wallet 1 → Wallet 2 → Wallet 3 → Wallet 4
-    console.log('Starting unauthenticated transfer chain…');
-    let currentSender: Account = alice;
-    for (let i = 0; i < wallets.length; i++) {
-      const wallet = wallets[i];
-      const { note } = await send({
+    // Pass full Note objects directly, without fetching an inclusion proof.
+    let currentSender = alice;
+    for (let index = 0; index < wallets.length; index += 1) {
+      const wallet = wallets[index];
+      const sent = await send({
         from: currentSender,
         to: wallet,
         assetId: faucet,
@@ -68,30 +81,43 @@ function UnauthenticatedNoteTransferInner() {
         noteType: NoteVisibility.Public,
         returnNote: true,
       });
-
-      const result = await consume({ accountId: wallet.id().toString(), notes: [note!] });
+      if (!sent.note) throw new Error('Send did not return its output note');
+      const received = await consume({
+        accountId: wallet.id().toString(),
+        notes: [sent.note],
+      });
+      await committed(sent.txId);
+      await committed(received.transactionId);
+      await assertBalance(wallet, faucet, BigInt(50));
       console.log(
-        `Transfer ${i + 1}: https://testnet.midenscan.com/tx/${result.transactionId}`,
+        `Transfer ${index + 1}: ${tutorialExplorerUrl()}/tx/${received.transactionId}`,
       );
-
       currentSender = wallet;
     }
-
+    await assertBalance(alice, faucet, BigInt(9950));
+    for (const wallet of wallets.slice(0, -1))
+      await assertBalance(wallet, faucet, BigInt(0));
     console.log('Asset transfer chain completed ✅');
   };
 
   return (
-    <div>
-      <button onClick={run} disabled={!isReady}>
-        {isReady ? 'Run: Unauthenticated Note Transfer' : 'Initializing…'}
-      </button>
-    </div>
+    <TutorialButton
+      name="unauthenticatedNoteTransfer"
+      label="Run: Unauthenticated Note Transfer"
+      run={run}
+    />
   );
 }
 
 export default function UnauthenticatedNoteTransfer() {
   return (
-    <MidenProvider config={{ rpcUrl: 'testnet', prover: 'local' }}>
+    <MidenProvider
+      config={{
+        rpcUrl: tutorialNetwork(),
+        prover: 'local',
+        autoSyncInterval: 0,
+      }}
+    >
       <UnauthenticatedNoteTransferInner />
     </MidenProvider>
   );

--- a/web-client/lib/unauthenticatedNoteTransfer.ts
+++ b/web-client/lib/unauthenticatedNoteTransfer.ts
@@ -1,19 +1,23 @@
 /**
- * Demonstrates unauthenticated note transfer chain against Miden testnet
+ * Demonstrates unauthenticated note transfer chain against the configured Miden network
  * Creates a chain of P2ID (Pay to ID) notes: Alice → wallet 1 → wallet 2 → wallet 3 → wallet 4
  *
  * @throws {Error} If the function cannot be executed in a browser environment
  */
-import { MidenClient, NoteVisibility, StorageMode } from '@miden-sdk/miden-sdk/lazy';
+import { NoteVisibility, StorageMode } from '@miden-sdk/miden-sdk/lazy';
+import {
+  consumeAllFeeAware,
+  createTutorialClient,
+  fundAccountForFees,
+  tutorialExplorerUrl,
+} from './feeSupport';
 
 export async function unauthenticatedNoteTransfer(): Promise<void> {
   // Ensure this runs only in a browser context
   if (typeof window === 'undefined') return console.warn('Run in browser');
 
-  await MidenClient.ready();
-
-  const client = await MidenClient.create({
-    rpcUrl: 'https://rpc.testnet.miden.io',
+  const client = await createTutorialClient({
+    proverUrl: 'local',
   });
 
   console.log('Latest block:', (await client.sync()).blockNum());
@@ -36,7 +40,6 @@ export async function unauthenticatedNoteTransfer(): Promise<void> {
     console.log('wallet ', i.toString(), wallet.id().toString());
   }
 
-  // ── Creating new faucet ──────────────────────────────────────────────────────
   const faucet = await client.accounts.create({
     type: 0, // 0 = FungibleFaucet
     symbol: 'MID',
@@ -45,22 +48,23 @@ export async function unauthenticatedNoteTransfer(): Promise<void> {
     storage: StorageMode.Public,
   });
   console.log('Faucet ID:', faucet.id().toString());
+  await fundAccountForFees(client, alice);
+  await fundAccountForFees(client, faucet);
 
-  // ── mint 10 000 MID to Alice ──────────────────────────────────────────────────────
+  await client.sync();
   const { txId: mintTxId } = await client.transactions.mint({
     account: faucet,
     to: alice,
     amount: BigInt(10_000),
     type: NoteVisibility.Public,
   });
-
   console.log('Waiting for settlement');
-  await client.transactions.waitFor(mintTxId);
+  await client.transactions.waitFor(mintTxId, { timeout: 120_000 });
+  await consumeAllFeeAware(client, alice);
 
-  // ── Consume the freshly minted note ──────────────────────────────────────────────
-  await client.transactions.consumeAll({
-    account: alice,
-  });
+  for (const wallet of wallets) {
+    await fundAccountForFees(client, wallet);
+  }
 
   // ── Create unauthenticated note transfer chain ─────────────────────────────────────────────
   // Alice → wallet 1 → wallet 2 → wallet 3 → wallet 4
@@ -73,24 +77,36 @@ export async function unauthenticatedNoteTransfer(): Promise<void> {
     console.log('Sender:', sender.id().toString());
     console.log('Receiver:', receiver.id().toString());
 
-    const { note } = await client.transactions.send({
+    await client.sync();
+    const { note, txId: sendTxId } = await client.transactions.send({
       account: sender,
       to: receiver,
       token: faucet,
       amount: BigInt(50),
       type: NoteVisibility.Public,
       returnNote: true,
+      waitForConfirmation: false,
     });
 
+    // Pass the full note before waiting for the sender's transaction.
+    await client.sync();
     const { txId: consumeTxId } = await client.transactions.consume({
       account: receiver,
       notes: [note],
+      waitForConfirmation: true,
+      timeout: 120_000,
     });
+    await client.transactions.waitFor(sendTxId, { timeout: 120_000 });
+    console.log(`Transaction committed: ${consumeTxId.toHex()}`);
 
     console.log(
-      `Consumed Note Tx on MidenScan: https://testnet.midenscan.com/tx/${consumeTxId.toHex()}`,
+      `Consumed Note Tx on MidenScan: ${tutorialExplorerUrl()}/tx/${consumeTxId.toHex()}`,
     );
   }
 
+  const lastWallet = await client.accounts.get(wallets[wallets.length - 1]);
+  const balance = lastWallet?.vault().getBalance(faucet.id());
+  if (balance !== BigInt(50))
+    throw new Error(`Expected last wallet to hold 50 MID, got ${balance}`);
   console.log('Asset transfer chain completed ✅');
 }

--- a/web-client/package.json
+++ b/web-client/package.json
@@ -9,8 +9,8 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@miden-sdk/miden-sdk": "0.15.2",
-    "@miden-sdk/react": "0.15.2",
+    "@miden-sdk/miden-sdk": "0.16.0",
+    "@miden-sdk/react": "0.16.0",
     "next": "15.3.2",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"

--- a/web-client/playwright.config.ts
+++ b/web-client/playwright.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig } from "@playwright/test";
 
-const tutorialTimeoutMs = 10 * 60 * 1000;
+const tutorialTimeoutMs = 30 * 60 * 1000;
 
 export default defineConfig({
   testDir: "./tests",
@@ -12,14 +12,11 @@ export default defineConfig({
   use: {
     baseURL: "http://localhost:3000",
     headless: true,
-    launchOptions: {
-      args: ["--disable-web-security"],
-    },
   },
   webServer: {
     command: "yarn dev",
     url: "http://localhost:3000",
-    reuseExistingServer: !process.env.CI,
+    reuseExistingServer: false,
     timeout: 120 * 1000,
   },
 });

--- a/web-client/tests/react-tutorials.spec.ts
+++ b/web-client/tests/react-tutorials.spec.ts
@@ -1,0 +1,47 @@
+import { expect, test } from '@playwright/test';
+
+const tutorialTimeoutMs = 30 * 60 * 1000;
+
+const names = [
+  'createMintConsume',
+  'multiSendWithDelegatedProver',
+  'unauthenticatedNoteTransfer',
+] as const;
+
+for (const name of names) {
+  test(`react:${name}`, async ({ page }) => {
+    test.setTimeout(tutorialTimeoutMs);
+    const logs: string[] = [];
+    const errors: string[] = [];
+    page.on('console', (message) => {
+      logs.push(`[${message.type()}] ${message.text()}`);
+      if (message.type() === 'error') errors.push(message.text());
+    });
+    page.on('pageerror', (error) => {
+      errors.push(error.message);
+    });
+    await page.goto(`/react-tutorials?tutorial=${name}`);
+    const tutorial = page.getByTestId(`react-${name}`);
+    await expect(tutorial).toBeVisible({ timeout: 120_000 });
+    await expect
+      .poll(
+        async () => {
+          const state = await tutorial.getAttribute('data-state');
+          if (state === 'failed') throw new Error(await tutorial.innerText());
+          return tutorial.getByRole('button').isEnabled();
+        },
+        { timeout: 120_000 },
+      )
+      .toBe(true);
+    await tutorial.getByRole('button').click();
+    await expect(tutorial).toHaveAttribute('data-state', /passed|failed/, {
+      timeout: tutorialTimeoutMs,
+    });
+    expect(await tutorial.getByRole('status').innerText()).toBe('passed');
+    expect(errors).toEqual([]);
+    expect(logs.some((line) => line.includes('Transaction committed:'))).toBe(
+      true,
+    );
+    expect(logs.some((line) => line.includes('Verified balance'))).toBe(true);
+  });
+}

--- a/web-client/tests/tutorials.spec.ts
+++ b/web-client/tests/tutorials.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "@playwright/test";
 import type { Page } from "@playwright/test";
 
-const tutorialTimeoutMs = 10 * 60 * 1000;
+const tutorialTimeoutMs = 30 * 60 * 1000;
 
 type RequiredLog = string | RegExp;
 
@@ -97,6 +97,7 @@ const runTutorial = async (
     );
   }
   expect(status?.state).toBe("passed");
+  expect(consoleLogs.some((line) => line.includes("Transaction committed:"))).toBe(true);
 
   for (const required of requiredLogs) {
     const matched = consoleLogs.some((line) =>

--- a/web-client/yarn.lock
+++ b/web-client/yarn.lock
@@ -215,37 +215,37 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
-"@miden-sdk/miden-sdk@0.15.2":
-  version "0.15.2"
-  resolved "https://registry.yarnpkg.com/@miden-sdk/miden-sdk/-/miden-sdk-0.15.2.tgz#c143231769513cc4493711aaa23ff48a7e8c56b9"
-  integrity sha512-0ww0aKrTZlLOpn9TbPnYg5erqE+j5QOqqGBn1ki/ku6iJRvkHyZquQPIz2CWi76AOAnUt+OZLKoMNEZ0X2RFww==
+"@miden-sdk/miden-sdk@0.16.0":
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/@miden-sdk/miden-sdk/-/miden-sdk-0.16.0.tgz#a54e095b3fc2aa36ebf249b24eeb9f280b4fbc75"
+  integrity sha512-APdct6zmuoGRPQaZ3kf2ovpUQ1a9C8VxV2MrJcGS3DelupiV34WBNNvIXhGE+I6DnSV9t2NzAHvokPVYhUq+kQ==
   dependencies:
     dexie "^4.0.1"
     glob "^11.0.0"
   optionalDependencies:
-    "@miden-sdk/node-darwin-arm64" "0.15.2"
-    "@miden-sdk/node-darwin-x64" "0.15.2"
-    "@miden-sdk/node-linux-x64-gnu" "0.15.2"
+    "@miden-sdk/node-darwin-arm64" "0.16.0"
+    "@miden-sdk/node-darwin-x64" "0.16.0"
+    "@miden-sdk/node-linux-x64-gnu" "0.16.0"
 
-"@miden-sdk/node-darwin-arm64@0.15.2":
-  version "0.15.2"
-  resolved "https://registry.yarnpkg.com/@miden-sdk/node-darwin-arm64/-/node-darwin-arm64-0.15.2.tgz#c1724dbb204db0e638ff0d74d9f7ccfa9b71bdb8"
-  integrity sha512-Y4cZjjSImHC1AwAlk+xWp661+3LIIzlHB/1saDCSr4pAvufoMCou2vRRP+l4vwAT+9iDvLwi1iSw2qfybCORiA==
+"@miden-sdk/node-darwin-arm64@0.16.0":
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/@miden-sdk/node-darwin-arm64/-/node-darwin-arm64-0.16.0.tgz#0ce84fa029899820674557b8b92690d25fb21b0c"
+  integrity sha512-uxwzouQkVG91/pU9o0wajLqzq2yqdZSttzzHmQtpl2hlpyFZJ8lucMwMFKOLCzU04+87PutBiUQ18Xfir2et6w==
 
-"@miden-sdk/node-darwin-x64@0.15.2":
-  version "0.15.2"
-  resolved "https://registry.yarnpkg.com/@miden-sdk/node-darwin-x64/-/node-darwin-x64-0.15.2.tgz#176d6a47b854d227a5e4212b47d0f172e533ecca"
-  integrity sha512-pxUZpHWCNjClEcEVPDLF4HsFqAQMzoA2PjSjVHSUK8xdcD3F/fiRNIuW+3pYD9gDkvNPGRsJtPLO21R2Rmvskg==
+"@miden-sdk/node-darwin-x64@0.16.0":
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/@miden-sdk/node-darwin-x64/-/node-darwin-x64-0.16.0.tgz#1f2aa253398984cda42a1bfd6888a7ba512c1b11"
+  integrity sha512-vqKtB5xw8iE5OkmEE31KMVuTWxJ006EwrFFSBFEsZNuGGWHyZXlpSqCA3y3azstu2RX3FEYoViBFPwu0fLJVzg==
 
-"@miden-sdk/node-linux-x64-gnu@0.15.2":
-  version "0.15.2"
-  resolved "https://registry.yarnpkg.com/@miden-sdk/node-linux-x64-gnu/-/node-linux-x64-gnu-0.15.2.tgz#b5a0e9ea7750e9aed42913430e23e8eaf4509eec"
-  integrity sha512-7ndNrEg+xSmcGb8lDcD/MAYKwXAzjlB6tfL/8fsUvZVgJ5h6ijDIhNCt4JMA40SS736mU7JHlzbTy8uPBwxqFA==
+"@miden-sdk/node-linux-x64-gnu@0.16.0":
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/@miden-sdk/node-linux-x64-gnu/-/node-linux-x64-gnu-0.16.0.tgz#2618859bfc526a0ec67e79eaaa4d9290ad675aff"
+  integrity sha512-+gFdLiRcAcv77QX3n4/0BoAecho9lbMxQR87sKH8oIIwP70+1ux0DFCE2Uf1nR8RK/rsbSSk/57R+0QBRY1kgw==
 
-"@miden-sdk/react@0.15.2":
-  version "0.15.2"
-  resolved "https://registry.yarnpkg.com/@miden-sdk/react/-/react-0.15.2.tgz#c5aa6caeb0fb2bd0cd343de26cc10d2305f01332"
-  integrity sha512-L3vxV2QRE+qQ9YPo4VIsCfQ7u12oN0fGp8oRnUGAgSwT1oztHx/rOku02ggAdy1SWQnpe8AiUGiFfC9lNoXkqg==
+"@miden-sdk/react@0.16.0":
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/@miden-sdk/react/-/react-0.16.0.tgz#c2ecc5d68425acbb17d03c13b6f1e193a8470f57"
+  integrity sha512-p4Blni66CPcZnyt1GNGh2I+OfbmIBQPSOqahsEzjfaZcP6P6k3XhhNt/sqxsoTr08QvVoxpwhXyosKyJNLQBvA==
   dependencies:
     zustand "^5.0.0"
 


### PR DESCRIPTION
Updates the Rust and Web/React tutorials to Miden SDK v0.16, including their MASM code and documentation. Testnet remains the default, with devnet available for testing. Miden Bank is outside this migration.

The tutorial flows were validated on devnet. Dependencies now point to the official v0.16 packages, and local tests, doctests and builds pass.

Still pending:
- Epoch: verify a full bridge round trip with compatible allocator and faucet deployments.
- Pragma: verify the oracle tutorial against a compatible deployment.
